### PR TITLE
Add code base binding redirects for the project system binaries

### DIFF
--- a/src/ProjectSystemSetup/AssemblyRedirects.cs
+++ b/src/ProjectSystemSetup/AssemblyRedirects.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio;
+
+[assembly: ProvideProjectSystemBindingRedirection("Microsoft.VisualStudio.Editors")]
+[assembly: ProvideProjectSystemBindingRedirection("Microsoft.VisualStudio.AppDesigner")]
+[assembly: ProvideProjectSystemBindingRedirection("Microsoft.VisualStudio.ProjectSystem.CSharp")]
+[assembly: ProvideProjectSystemBindingRedirection("Microsoft.VisualStudio.ProjectSystem.CSharp.VS")]
+[assembly: ProvideProjectSystemBindingRedirection("Microsoft.VisualStudio.ProjectSystem.Managed")]
+[assembly: ProvideProjectSystemBindingRedirection("Microsoft.VisualStudio.ProjectSystem.Managed.VS")]
+[assembly: ProvideProjectSystemBindingRedirection("Microsoft.VisualStudio.ProjectSystem.VisualBasic")]
+[assembly: ProvideProjectSystemBindingRedirection("Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS")]

--- a/src/ProjectSystemSetup/ProjectSystemSetup.csproj
+++ b/src/ProjectSystemSetup/ProjectSystemSetup.csproj
@@ -11,7 +11,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <AssemblyName>ProjectSystem</AssemblyName>
-    <GeneratePkgDefFile>false</GeneratePkgDefFile>
+    <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
@@ -19,11 +19,12 @@
     <ImportVSSDKTargets>true</ImportVSSDKTargets>
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-    <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
+    <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
     <NoDocumentationFile>true</NoDocumentationFile>
     <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
+    <ProjectSystemLayer>VisualStudio</ProjectSystemLayer>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>
@@ -95,7 +96,12 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="project.json" />
     <None Include="source.extension.vsixmanifest" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ProvideBindingRedirectionAttribute.cs" />
+    <Compile Include="AssemblyRedirects.cs" />
   </ItemGroup>
   <Import Project="..\..\build\Targets\VSL.Imports.targets" />
 </Project>

--- a/src/ProjectSystemSetup/ProvideBindingRedirectionAttribute.cs
+++ b/src/ProjectSystemSetup/ProvideBindingRedirectionAttribute.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio
+{
+    /// <summary>
+    ///     A <see cref="RegistrationAttribute"/> that provides binding redirects for the project system.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    internal sealed class ProvideProjectSystemBindingRedirectionAttribute : RegistrationAttribute
+    {
+        private readonly ProvideBindingRedirectionAttribute _redirectionAttribute;
+
+        public ProvideProjectSystemBindingRedirectionAttribute(string assemblyName)
+        {
+            // ProvideBindingRedirectionAttribute is sealed, so we can't inherit from it to provide defaults.
+            // Instead, we'll do more of an aggregation pattern here.
+            _redirectionAttribute = new ProvideBindingRedirectionAttribute
+            {
+                AssemblyName = assemblyName,
+                OldVersionLowerBound = "0.0.0.0",
+                CodeBase = assemblyName + ".dll",
+            };
+        }
+
+        public override void Register(RegistrationContext context)
+        {
+            _redirectionAttribute.Register(context);
+        }
+
+        public override void Unregister(RegistrationContext context)
+        {
+            _redirectionAttribute.Unregister(context);
+        }
+    }
+}

--- a/src/ProjectSystemSetup/project.json
+++ b/src/ProjectSystemSetup/project.json
@@ -1,0 +1,7 @@
+﻿{
+  "frameworks": {
+    "net46": {}
+  },
+  "dependencies": {
+  }
+}


### PR DESCRIPTION
This enables us to F5 and override binaries in VS install enabling us to test AppDesigner and Editors.