### PR TITLE
Initial setting "name" in the Settings Designer should be localized

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/Resources/Microsoft.VisualStudio.Editors.Designer.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/Resources/Microsoft.VisualStudio.Editors.Designer.Designer.vb
@@ -4220,7 +4220,16 @@ Namespace My.Resources
                 Return ResourceManager.GetString("SD_ComboBoxItem_WebUserScope", resourceCulture)
             End Get
         End Property
-        
+
+        '''<summary>
+        '''  Looks up a localized string similar to Setting.
+        '''</summary>
+        Friend Shared ReadOnly Property SD_DefaultSettingName() As String
+            Get
+                Return ResourceManager.GetString("SD_DefaultSettingName", resourceCulture)
+            End Get
+        End Property
+
         '''<summary>
         '''  Looks up a localized string similar to Description of the setting..
         '''</summary>

--- a/src/Microsoft.VisualStudio.Editors/Resources/Microsoft.VisualStudio.Editors.Designer.resx
+++ b/src/Microsoft.VisualStudio.Editors/Resources/Microsoft.VisualStudio.Editors.Designer.resx
@@ -112,10 +112,10 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CMN_AllFilesFilter" xml:space="preserve">
     <value>All Files</value>
@@ -1923,5 +1923,8 @@ Do you want to update the value in the .settings file?</value>
   </data>
   <data name="PPG_UnknownOutputType" xml:space="preserve">
     <value>Unknown output type: {0}</value>
+  </data>
+  <data name="SD_DefaultSettingName" xml:space="preserve">
+    <value>Setting</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DesignTimeSettings.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DesignTimeSettings.vb
@@ -180,10 +180,9 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             Return String.Equals(Id1, Id2, StringComparison.OrdinalIgnoreCase)
         End Function
 
-        Friend Function CreateUniqueName(Optional ByVal Base As String = "Setting") As String
-            If Base = "" Then
-                Debug.Fail("Must give a valid base name or not supply any parameter at all (can't create a unique name from a null or empty string!)")
-                Throw New ArgumentException()
+        Friend Function CreateUniqueName(Optional ByVal Base As String = Nothing) As String
+            If String.IsNullOrEmpty(Base) Then
+                Base = SR.SD_DefaultSettingName
             End If
 
             Dim ExistingNames As New System.Collections.Hashtable


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/10985.