### PR TITLE
Tweaked the build property page layout

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AddImportDialogBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AddImportDialogBase.vb
@@ -4,8 +4,11 @@ Imports System.Drawing
 Imports System.Windows.Forms
 Imports VsShell = Microsoft.VisualStudio.Shell.Interop
 Imports VsErrorHandler = Microsoft.VisualStudio.ErrorHandler
+Imports System.ComponentModel
 
 Namespace Microsoft.VisualStudio.Editors.AddImports
+
+    <TypeDescriptionProvider(GetType(AbstractControlTypeDescriptionProvider(Of AddImportDialogBase, Form)))>
     Friend MustInherit Class AddImportDialogBase
         Inherits Form
 
@@ -29,7 +32,7 @@ Namespace Microsoft.VisualStudio.Editors.AddImports
                 Dim hostLocale As VsShell.IUIHostLocale2 = CType(_serviceProvider.GetService(GetType(VsShell.SUIHostLocale)), VsShell.IUIHostLocale2)
                 If hostLocale IsNot Nothing Then
                     Dim fonts(1) As VsShell.UIDLGLOGFONT
-                    If VSErrorHandler.Succeeded(hostLocale.GetDialogFont(fonts)) Then
+                    If VsErrorHandler.Succeeded(hostLocale.GetDialogFont(fonts)) Then
                         Return Font.FromLogFont(fonts(0))
                     End If
                 End If

--- a/src/Microsoft.VisualStudio.Editors/ComponentModel/AbstractControlTypeDescriptionProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/ComponentModel/AbstractControlTypeDescriptionProvider.vb
@@ -1,0 +1,45 @@
+﻿Namespace System.ComponentModel
+
+    ''' <summary>
+    '''     A <see cref="TypeDescriptionProvider"/> that allows you swap out an abstract class with a concrete 
+    '''     implementation, so that derived types can be opened And designed in the editor.
+    ''' </summary>
+    Friend Class AbstractControlTypeDescriptionProvider(Of TAbstract, TDerived)
+        Inherits TypeDescriptionProvider
+
+        ' Based on Brian Pepin's post: http://www.pocketsilicon.com/post/Using-Visual-Studio-Whidbey-to-Design-Abstract-Forms
+
+        Public Sub New()
+
+            MyBase.New(TypeDescriptor.GetProvider(GetType(TAbstract)))
+
+        End Sub
+
+        Public Overrides Function GetReflectionType(objectType As Type, instance As Object) As Type
+
+            ' If the designer Is asking for the abstract control,
+            ' return the "concrete" version of it instead
+            If (objectType = GetType(TAbstract)) Then
+                Return GetType(TDerived)
+            End If
+
+            Return MyBase.GetReflectionType(objectType, instance)
+
+        End Function
+
+        Public Overrides Function CreateInstance(provider As IServiceProvider, objectType As Type, argTypes As Type(), args As Object()) As Object
+
+            ' If the designer Is asking to create the abstract 
+            ' control, instantiate the "concrete" version of it instead
+            If (objectType = GetType(TAbstract)) Then
+                objectType = GetType(TDerived)
+            End If
+
+            Return MyBase.CreateInstance(provider, objectType, argTypes, args)
+
+        End Function
+
+    End Class
+
+End Namespace
+

--- a/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
+++ b/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
@@ -73,22 +73,27 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Package\EditorToolsOptionsPanel.resx">
+      <DependentUpon>EditorToolsOptionsPanel.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.Package.EditorToolsOptionsPanel.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\AdvancedServicesDialog.resx">
+      <DependentUpon>AdvancedServicesDialog.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.AdvancedServicesDialog.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\AdvBuildSettingsPropPage.resx">
+      <DependentUpon>AdvBuildSettingsPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.AdvBuildSettingsPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\AdvCompilerSettingsPropPage.resx">
+      <DependentUpon>AdvCompilerSettingsPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.AdvCompilerSettingsPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\ApplicationPropPage.resx">
+      <DependentUpon>ApplicationPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.ApplicationPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
@@ -97,54 +102,65 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\ApplicationPropPageVBBase.resx">
-      <SubType>Designer</SubType>
       <DependentUpon>ApplicationPropPageVBBase.vb</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\ApplicationPropPageVBWinForms.resx">
       <DependentUpon>ApplicationPropPageVBWinForms.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\AssemblyInfoPropPage.resx">
+      <DependentUpon>AssemblyInfoPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.AssemblyInfoPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\BuildEventCommandLineDialog.resx">
+      <DependentUpon>BuildEventCommandLineDialog.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.BuildEventCommandLineDialog.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\BuildEventsPropPage.resx">
+      <DependentUpon>BuildEventsPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.BuildEventsPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\BuildPropPage.resx">
+      <DependentUpon>BuildPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.BuildPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\CompilePropPage2.resx">
+      <DependentUpon>CompilePropPage2.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.CompilePropPage2.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\CSharpApplicationPropPage.resx">
+      <DependentUpon>CSharpApplicationPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.CSharpApplicationPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\DebugPropPage.resx">
+      <DependentUpon>DebugPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.DebugPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\ReferencePathsPropPage.resx">
+      <DependentUpon>ReferencePathsPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.ReferencePathsPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\ReferencePropPage.resx">
+      <DependentUpon>ReferencePropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.ReferencePropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\ServicesAuthenticationForm.resx">
+      <DependentUpon>ServicesAuthenticationForm.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.ServicesAuthenticationForm.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\ServicesPropPage.resx">
+      <DependentUpon>ServicesPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.ServicesPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
@@ -155,22 +171,25 @@
       <LastGenOutput>Strings.Designer.vb</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\UnusedReferencePropPage.resx">
+      <DependentUpon>UnusedReferencePropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.UnusedReferencePropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\WPF\AppDotXamlErrorControl.resx">
-      <SubType>Designer</SubType>
       <DependentUpon>AppDotXamlErrorControl.vb</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\WPF\ApplicationPropPageVBWPF.resx">
       <DependentUpon>ApplicationPropPageVBWPF.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="ResourceEditor\DialogQueryName.resx">
+      <DependentUpon>DialogQueryName.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.ResourceEditor.DialogQueryName.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="ResourceEditor\OpenFileWarningDialog.resx">
+      <DependentUpon>OpenFileWarningDialog.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.ResourceEditor.OpenFileWarningDialog.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
@@ -211,14 +230,17 @@
     <EmbeddedResource Include="Resources\SettingsDesigner\namespace.bmp" />
     <EmbeddedResource Include="Resources\SettingsDesigner\object.bmp" />
     <EmbeddedResource Include="SettingsDesigner\SettingsDesignerView.resx">
+      <DependentUpon>SettingsDesignerView.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsDesignerView.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="SettingsDesigner\TypeEditorHostControl.resx">
+      <DependentUpon>TypeEditorHostControl.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.SettingsDesigner.TypeEditorHostControl.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="SettingsDesigner\TypePickerDialog.resx">
+      <DependentUpon>TypePickerDialog.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.SettingsDesigner.TypePickerDialog.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>

--- a/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
+++ b/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
@@ -261,6 +261,7 @@
     <Compile Include="..\Common\IVsSqm.vb">
       <Link>IVsSqm.vb</Link>
     </Compile>
+    <Compile Include="ComponentModel\AbstractControlTypeDescriptionProvider.vb" />
     <Compile Include="StrongNameHelpers.vb" />
     <Compile Include="..\Common\ManagedCodeMarkers.vb">
       <Link>ManagedCodeMarkers.vb</Link>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,40 +26,41 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
-            : System.Serialization.Formatters.Binary.BinaryFormatter
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
@@ -71,6 +72,7 @@
               <xsd:attribute name="name" use="required" type="xsd:string" />
               <xsd:attribute name="type" type="xsd:string" />
               <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
@@ -88,6 +90,7 @@
               <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
               <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
               <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
@@ -109,129 +112,78 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lblConditionalCompilationSymbols.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>None</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lblConditionalCompilationSymbols.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="lblConditionalCompilationSymbols.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 28</value>
+    <value>23, 27</value>
+  </data>
+  <data name="lblConditionalCompilationSymbols.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>23, 11, 3, 3</value>
   </data>
   <data name="lblConditionalCompilationSymbols.Size" type="System.Drawing.Size, System.Drawing">
-    <value>169, 14</value>
+    <value>158, 13</value>
   </data>
   <data name="lblConditionalCompilationSymbols.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <data name="lblConditionalCompilationSymbols.Text">
-    <value xml:space="preserve">Conditional compilation s&amp;ymbols:</value>
+  <data name="lblConditionalCompilationSymbols.Text" xml:space="preserve">
+    <value>Conditional compilation s&amp;ymbols:</value>
   </data>
-  <data name="&gt;&gt;lblConditionalCompilationSymbols.Name">
-    <value xml:space="preserve">lblConditionalCompilationSymbols</value>
+  <data name="&gt;&gt;lblConditionalCompilationSymbols.Name" xml:space="preserve">
+    <value>lblConditionalCompilationSymbols</value>
   </data>
-  <data name="&gt;&gt;lblConditionalCompilationSymbols.Type">
-    <value xml:space="preserve">System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;lblConditionalCompilationSymbols.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;lblConditionalCompilationSymbols.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;lblConditionalCompilationSymbols.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;lblConditionalCompilationSymbols.ZOrder">
-    <value xml:space="preserve">22</value>
+  <data name="&gt;&gt;lblConditionalCompilationSymbols.ZOrder" xml:space="preserve">
+    <value>25</value>
   </data>
   <data name="txtConditionalCompilationSymbols.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
   </data>
   <data name="txtConditionalCompilationSymbols.Location" type="System.Drawing.Point, System.Drawing">
-    <value>198, 25</value>
+    <value>187, 24</value>
+  </data>
+  <data name="txtConditionalCompilationSymbols.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 11, 3, 3</value>
   </data>
   <data name="txtConditionalCompilationSymbols.Size" type="System.Drawing.Size, System.Drawing">
-    <value>259, 20</value>
+    <value>271, 20</value>
   </data>
   <data name="txtConditionalCompilationSymbols.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;txtConditionalCompilationSymbols.Name">
-    <value xml:space="preserve">txtConditionalCompilationSymbols</value>
+  <data name="&gt;&gt;txtConditionalCompilationSymbols.Name" xml:space="preserve">
+    <value>txtConditionalCompilationSymbols</value>
   </data>
-  <data name="&gt;&gt;txtConditionalCompilationSymbols.Type">
-    <value xml:space="preserve">System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;txtConditionalCompilationSymbols.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;txtConditionalCompilationSymbols.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;txtConditionalCompilationSymbols.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;txtConditionalCompilationSymbols.ZOrder">
-    <value xml:space="preserve">21</value>
+  <data name="&gt;&gt;txtConditionalCompilationSymbols.ZOrder" xml:space="preserve">
+    <value>24</value>
   </data>
-  <data name="lblPlatformTarget.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+  <data name="chkDefineDebug.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
   </data>
-  <data name="lblPlatformTarget.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblPlatformTarget.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 54</value>
-  </data>
-  <data name="lblPlatformTarget.Size" type="System.Drawing.Size, System.Drawing">
-    <value>82, 14</value>
-  </data>
-  <data name="lblPlatformTarget.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="lblPlatformTarget.Text">
-    <value xml:space="preserve">Platform tar&amp;get:</value>
-  </data>
-  <data name="&gt;&gt;lblPlatformTarget.Name">
-    <value xml:space="preserve">lblPlatformTarget</value>
-  </data>
-  <data name="&gt;&gt;lblPlatformTarget.Type">
-    <value xml:space="preserve">System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPlatformTarget.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;lblPlatformTarget.ZOrder">
-    <value xml:space="preserve">23</value>
-  </data>
-  <data name="cboPlatformTarget.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="cboPlatformTarget.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="cboPlatformTarget.Location" type="System.Drawing.Point, System.Drawing">
-    <value>198, 51</value>
-  </data>
-  <data name="cboPlatformTarget.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 21</value>
-  </data>
-  <data name="cboPlatformTarget.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;cboPlatformTarget.Name">
-    <value xml:space="preserve">cboPlatformTarget</value>
-  </data>
-  <data name="&gt;&gt;cboPlatformTarget.Type">
-    <value xml:space="preserve">System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cboPlatformTarget.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;cboPlatformTarget.ZOrder">
-    <value xml:space="preserve">18</value>
-  </data>
-  <data name="chkAllowUnsafeCode.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="chkAllowUnsafeCode.AutoSize" type="System.Boolean, mscorlib">
+  <data name="chkDefineDebug.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="overarchingTableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
@@ -249,14 +201,14 @@
   <data name="outputTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="outputLineLabel.AccessibleRole" type="System.Windows.Forms.AccessibleRole, System.Windows.Forms">
-    <value>Separator</value>
-  </data>
   <data name="outputLineLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
   </data>
   <data name="outputLineLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>47, 6</value>
+    <value>48, 6</value>
+  </data>
+  <data name="outputLineLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 0, 0</value>
   </data>
   <data name="outputLineLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>491, 1</value>
@@ -264,17 +216,17 @@
   <data name="outputLineLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;outputLineLabel.Name">
-    <value xml:space="preserve">outputLineLabel</value>
+  <data name="&gt;&gt;outputLineLabel.Name" xml:space="preserve">
+    <value>outputLineLabel</value>
   </data>
-  <data name="&gt;&gt;outputLineLabel.Type">
-    <value xml:space="preserve">System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;outputLineLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;outputLineLabel.Parent">
-    <value xml:space="preserve">outputTableLayoutPanel</value>
+  <data name="&gt;&gt;outputLineLabel.Parent" xml:space="preserve">
+    <value>outputTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;outputLineLabel.ZOrder">
-    <value xml:space="preserve">0</value>
+  <data name="&gt;&gt;outputLineLabel.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="outputLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -286,49 +238,55 @@
     <value>3, 0</value>
   </data>
   <data name="outputLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>38, 14</value>
+    <value>39, 13</value>
   </data>
   <data name="outputLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="outputLabel.Text">
-    <value xml:space="preserve">Output</value>
+  <data name="outputLabel.Text" xml:space="preserve">
+    <value>Output</value>
   </data>
-  <data name="&gt;&gt;outputLabel.Name">
-    <value xml:space="preserve">outputLabel</value>
+  <data name="&gt;&gt;outputLabel.Name" xml:space="preserve">
+    <value>outputLabel</value>
   </data>
-  <data name="&gt;&gt;outputLabel.Type">
-    <value xml:space="preserve">System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;outputLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;outputLabel.Parent">
-    <value xml:space="preserve">outputTableLayoutPanel</value>
+  <data name="&gt;&gt;outputLabel.Parent" xml:space="preserve">
+    <value>outputTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;outputLabel.ZOrder">
-    <value xml:space="preserve">1</value>
+  <data name="&gt;&gt;outputLabel.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="outputTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 314</value>
+    <value>0, 377</value>
+  </data>
+  <data name="outputTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
   </data>
   <data name="outputTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="outputTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>538, 14</value>
+    <value>539, 13</value>
   </data>
   <data name="outputTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
   </data>
-  <data name="&gt;&gt;outputTableLayoutPanel.Name">
-    <value xml:space="preserve">outputTableLayoutPanel</value>
+  <data name="&gt;&gt;outputTableLayoutPanel.Name" xml:space="preserve">
+    <value>outputTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;outputTableLayoutPanel.Type">
-    <value xml:space="preserve">System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;outputTableLayoutPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;outputTableLayoutPanel.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;outputTableLayoutPanel.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;outputTableLayoutPanel.ZOrder">
-    <value xml:space="preserve">0</value>
+  <data name="&gt;&gt;outputTableLayoutPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="outputTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="outputLineLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="outputLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="generalHeaderTableLayoutPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
@@ -339,92 +297,32 @@
   <data name="generalHeaderTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="generalLineLabel.AccessibleRole" type="System.Windows.Forms.AccessibleRole, System.Windows.Forms">
-    <value>Separator</value>
-  </data>
   <data name="generalLineLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
   </data>
   <data name="generalLineLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>51, 6</value>
+    <value>50, 6</value>
+  </data>
+  <data name="generalLineLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 0, 0</value>
   </data>
   <data name="generalLineLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>487, 1</value>
+    <value>489, 1</value>
   </data>
   <data name="generalLineLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <data name="chkDefineDebug.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
+  <data name="&gt;&gt;generalLineLabel.Name" xml:space="preserve">
+    <value>generalLineLabel</value>
   </data>
-  <data name="chkDefineDebug.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="&gt;&gt;generalLineLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="chkDefineDebug.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 78</value>
+  <data name="&gt;&gt;generalLineLabel.Parent" xml:space="preserve">
+    <value>generalHeaderTableLayoutPanel</value>
   </data>
-  <data name="chkDefineDebug.Size" type="System.Drawing.Size, System.Drawing">
-    <value>109, 17</value>
-  </data>
-  <data name="chkDefineDebug.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="chkDefineDebug.Text">
-    <value xml:space="preserve">Define DEB&amp;UG constant</value>
-  </data>
-  <data name="&gt;&gt;chkDefineDebug.Name">
-    <value xml:space="preserve">chkDefineDebug</value>
-  </data>
-  <data name="&gt;&gt;chkDefineDebug.Type">
-    <value xml:space="preserve">System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkDefineDebug.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;chkDefineDebug.ZOrder">
-    <value xml:space="preserve">20</value>
-  </data>
-  <data name="chkDefineTrace.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="chkDefineTrace.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="chkDefineTrace.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 78</value>
-  </data>
-  <data name="chkDefineTrace.Size" type="System.Drawing.Size, System.Drawing">
-    <value>109, 17</value>
-  </data>
-  <data name="chkDefineTrace.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="chkDefineTrace.Text">
-    <value xml:space="preserve">Define &amp;TRACE constant</value>
-  </data>
-  <data name="&gt;&gt;chkDefineTrace.Name">
-    <value xml:space="preserve">chkDefineTrace</value>
-  </data>
-  <data name="&gt;&gt;chkDefineTrace.Type">
-    <value xml:space="preserve">System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkDefineTrace.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;chkDefineTrace.ZOrder">
-    <value xml:space="preserve">20</value>
-  </data>
-  <data name="&gt;&gt;generalLineLabel.Name">
-    <value xml:space="preserve">generalLineLabel</value>
-  </data>
-  <data name="&gt;&gt;generalLineLabel.Type">
-    <value xml:space="preserve">System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;generalLineLabel.Parent">
-    <value xml:space="preserve">generalHeaderTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;generalLineLabel.ZOrder">
-    <value xml:space="preserve">0</value>
+  <data name="&gt;&gt;generalLineLabel.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="generalLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -435,50 +333,59 @@
   <data name="generalLabel.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="generalLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 3, 0</value>
+  </data>
   <data name="generalLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>45, 14</value>
+    <value>44, 13</value>
   </data>
   <data name="generalLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="generalLabel.Text">
-    <value xml:space="preserve">General</value>
+  <data name="generalLabel.Text" xml:space="preserve">
+    <value>General</value>
   </data>
-  <data name="&gt;&gt;generalLabel.Name">
-    <value xml:space="preserve">generalLabel</value>
+  <data name="&gt;&gt;generalLabel.Name" xml:space="preserve">
+    <value>generalLabel</value>
   </data>
-  <data name="&gt;&gt;generalLabel.Type">
-    <value xml:space="preserve">System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;generalLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;generalLabel.Parent">
-    <value xml:space="preserve">generalHeaderTableLayoutPanel</value>
+  <data name="&gt;&gt;generalLabel.Parent" xml:space="preserve">
+    <value>generalHeaderTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;generalLabel.ZOrder">
-    <value xml:space="preserve">1</value>
+  <data name="&gt;&gt;generalLabel.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="generalHeaderTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
+  </data>
+  <data name="generalHeaderTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
   </data>
   <data name="generalHeaderTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="generalHeaderTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>538, 14</value>
+    <value>539, 13</value>
   </data>
   <data name="generalHeaderTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;generalHeaderTableLayoutPanel.Name">
-    <value xml:space="preserve">generalHeaderTableLayoutPanel</value>
+  <data name="&gt;&gt;generalHeaderTableLayoutPanel.Name" xml:space="preserve">
+    <value>generalHeaderTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;generalHeaderTableLayoutPanel.Type">
-    <value xml:space="preserve">System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;generalHeaderTableLayoutPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;generalHeaderTableLayoutPanel.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;generalHeaderTableLayoutPanel.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;generalHeaderTableLayoutPanel.ZOrder">
-    <value xml:space="preserve">1</value>
+  <data name="&gt;&gt;generalHeaderTableLayoutPanel.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="generalHeaderTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="generalLineLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="generalLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="treatWarningsAsErrorsTableLayoutPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
@@ -489,32 +396,32 @@
   <data name="treatWarningsAsErrorsTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="treatWarningsAsErrorsLineLabel.AccessibleRole" type="System.Windows.Forms.AccessibleRole, System.Windows.Forms">
-    <value>Separator</value>
-  </data>
   <data name="treatWarningsAsErrorsLineLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
   </data>
   <data name="treatWarningsAsErrorsLineLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>133, 6</value>
+    <value>126, 6</value>
+  </data>
+  <data name="treatWarningsAsErrorsLineLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 0, 0</value>
   </data>
   <data name="treatWarningsAsErrorsLineLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>405, 1</value>
+    <value>413, 1</value>
   </data>
   <data name="treatWarningsAsErrorsLineLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;treatWarningsAsErrorsLineLabel.Name">
-    <value xml:space="preserve">treatWarningsAsErrorsLineLabel</value>
+  <data name="&gt;&gt;treatWarningsAsErrorsLineLabel.Name" xml:space="preserve">
+    <value>treatWarningsAsErrorsLineLabel</value>
   </data>
-  <data name="&gt;&gt;treatWarningsAsErrorsLineLabel.Type">
-    <value xml:space="preserve">System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;treatWarningsAsErrorsLineLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;treatWarningsAsErrorsLineLabel.Parent">
-    <value xml:space="preserve">treatWarningsAsErrorsTableLayoutPanel</value>
+  <data name="&gt;&gt;treatWarningsAsErrorsLineLabel.Parent" xml:space="preserve">
+    <value>treatWarningsAsErrorsTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;treatWarningsAsErrorsLineLabel.ZOrder">
-    <value xml:space="preserve">0</value>
+  <data name="&gt;&gt;treatWarningsAsErrorsLineLabel.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="treatWarningsAsErrorsLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -525,50 +432,59 @@
   <data name="treatWarningsAsErrorsLabel.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="treatWarningsAsErrorsLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 3, 0</value>
+  </data>
   <data name="treatWarningsAsErrorsLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>127, 14</value>
+    <value>120, 13</value>
   </data>
   <data name="treatWarningsAsErrorsLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="treatWarningsAsErrorsLabel.Text">
-    <value xml:space="preserve">Treat warnings as errors</value>
+  <data name="treatWarningsAsErrorsLabel.Text" xml:space="preserve">
+    <value>Treat warnings as errors</value>
   </data>
-  <data name="&gt;&gt;treatWarningsAsErrorsLabel.Name">
-    <value xml:space="preserve">treatWarningsAsErrorsLabel</value>
+  <data name="&gt;&gt;treatWarningsAsErrorsLabel.Name" xml:space="preserve">
+    <value>treatWarningsAsErrorsLabel</value>
   </data>
-  <data name="&gt;&gt;treatWarningsAsErrorsLabel.Type">
-    <value xml:space="preserve">System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;treatWarningsAsErrorsLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;treatWarningsAsErrorsLabel.Parent">
-    <value xml:space="preserve">treatWarningsAsErrorsTableLayoutPanel</value>
+  <data name="&gt;&gt;treatWarningsAsErrorsLabel.Parent" xml:space="preserve">
+    <value>treatWarningsAsErrorsTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;treatWarningsAsErrorsLabel.ZOrder">
-    <value xml:space="preserve">1</value>
+  <data name="&gt;&gt;treatWarningsAsErrorsLabel.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="treatWarningsAsErrorsTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 212</value>
+    <value>0, 279</value>
+  </data>
+  <data name="treatWarningsAsErrorsTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
   </data>
   <data name="treatWarningsAsErrorsTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="treatWarningsAsErrorsTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>538, 14</value>
+    <value>539, 13</value>
   </data>
   <data name="treatWarningsAsErrorsTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
   </data>
-  <data name="&gt;&gt;treatWarningsAsErrorsTableLayoutPanel.Name">
-    <value xml:space="preserve">treatWarningsAsErrorsTableLayoutPanel</value>
+  <data name="&gt;&gt;treatWarningsAsErrorsTableLayoutPanel.Name" xml:space="preserve">
+    <value>treatWarningsAsErrorsTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;treatWarningsAsErrorsTableLayoutPanel.Type">
-    <value xml:space="preserve">System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;treatWarningsAsErrorsTableLayoutPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;treatWarningsAsErrorsTableLayoutPanel.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;treatWarningsAsErrorsTableLayoutPanel.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;treatWarningsAsErrorsTableLayoutPanel.ZOrder">
-    <value xml:space="preserve">2</value>
+  <data name="&gt;&gt;treatWarningsAsErrorsTableLayoutPanel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="treatWarningsAsErrorsTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="treatWarningsAsErrorsLineLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="treatWarningsAsErrorsLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="errorsAndWarningsTableLayoutPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
@@ -582,29 +498,29 @@
   <data name="errorsAndWarningsLineLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
   </data>
-  <data name="errorsAndWarningsLineLabel.AccessibleRole" type="System.Windows.Forms.AccessibleRole, System.Windows.Forms">
-    <value>Separator</value>
-  </data>
   <data name="errorsAndWarningsLineLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>111, 6</value>
+    <value>106, 6</value>
+  </data>
+  <data name="errorsAndWarningsLineLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 0, 0</value>
   </data>
   <data name="errorsAndWarningsLineLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>427, 1</value>
+    <value>433, 1</value>
   </data>
   <data name="errorsAndWarningsLineLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;errorsAndWarningsLineLabel.Name">
-    <value xml:space="preserve">errorsAndWarningsLineLabel</value>
+  <data name="&gt;&gt;errorsAndWarningsLineLabel.Name" xml:space="preserve">
+    <value>errorsAndWarningsLineLabel</value>
   </data>
-  <data name="&gt;&gt;errorsAndWarningsLineLabel.Type">
-    <value xml:space="preserve">System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;errorsAndWarningsLineLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;errorsAndWarningsLineLabel.Parent">
-    <value xml:space="preserve">errorsAndWarningsTableLayoutPanel</value>
+  <data name="&gt;&gt;errorsAndWarningsLineLabel.Parent" xml:space="preserve">
+    <value>errorsAndWarningsTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;errorsAndWarningsLineLabel.ZOrder">
-    <value xml:space="preserve">0</value>
+  <data name="&gt;&gt;errorsAndWarningsLineLabel.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="errorsAndWarningsLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -615,50 +531,59 @@
   <data name="errorsAndWarningsLabel.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="errorsAndWarningsLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 3, 0</value>
+  </data>
   <data name="errorsAndWarningsLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>105, 14</value>
+    <value>100, 13</value>
   </data>
   <data name="errorsAndWarningsLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="errorsAndWarningsLabel.Text">
-    <value xml:space="preserve">Errors and warnings</value>
+  <data name="errorsAndWarningsLabel.Text" xml:space="preserve">
+    <value>Errors and warnings</value>
   </data>
-  <data name="&gt;&gt;errorsAndWarningsLabel.Name">
-    <value xml:space="preserve">errorsAndWarningsLabel</value>
+  <data name="&gt;&gt;errorsAndWarningsLabel.Name" xml:space="preserve">
+    <value>errorsAndWarningsLabel</value>
   </data>
-  <data name="&gt;&gt;errorsAndWarningsLabel.Type">
-    <value xml:space="preserve">System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;errorsAndWarningsLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;errorsAndWarningsLabel.Parent">
-    <value xml:space="preserve">errorsAndWarningsTableLayoutPanel</value>
+  <data name="&gt;&gt;errorsAndWarningsLabel.Parent" xml:space="preserve">
+    <value>errorsAndWarningsTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;errorsAndWarningsLabel.ZOrder">
-    <value xml:space="preserve">1</value>
+  <data name="&gt;&gt;errorsAndWarningsLabel.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="errorsAndWarningsTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 129</value>
+    <value>0, 197</value>
+  </data>
+  <data name="errorsAndWarningsTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
   </data>
   <data name="errorsAndWarningsTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="errorsAndWarningsTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>538, 14</value>
+    <value>539, 13</value>
   </data>
   <data name="errorsAndWarningsTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
   </data>
-  <data name="&gt;&gt;errorsAndWarningsTableLayoutPanel.Name">
-    <value xml:space="preserve">errorsAndWarningsTableLayoutPanel</value>
+  <data name="&gt;&gt;errorsAndWarningsTableLayoutPanel.Name" xml:space="preserve">
+    <value>errorsAndWarningsTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;errorsAndWarningsTableLayoutPanel.Type">
-    <value xml:space="preserve">System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;errorsAndWarningsTableLayoutPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;errorsAndWarningsTableLayoutPanel.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;errorsAndWarningsTableLayoutPanel.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;errorsAndWarningsTableLayoutPanel.ZOrder">
-    <value xml:space="preserve">3</value>
+  <data name="&gt;&gt;errorsAndWarningsTableLayoutPanel.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="errorsAndWarningsTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="errorsAndWarningsLineLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="errorsAndWarningsLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="chkRegisterForCOM.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -667,28 +592,31 @@
     <value>True</value>
   </data>
   <data name="chkRegisterForCOM.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 394</value>
+    <value>23, 456</value>
+  </data>
+  <data name="chkRegisterForCOM.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>23, 3, 3, 3</value>
   </data>
   <data name="chkRegisterForCOM.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 17</value>
+    <value>142, 17</value>
   </data>
   <data name="chkRegisterForCOM.TabIndex" type="System.Int32, mscorlib">
     <value>26</value>
   </data>
-  <data name="chkRegisterForCOM.Text">
-    <value xml:space="preserve">Register for &amp;COM interop</value>
+  <data name="chkRegisterForCOM.Text" xml:space="preserve">
+    <value>Register for &amp;COM interop</value>
   </data>
-  <data name="&gt;&gt;chkRegisterForCOM.Name">
-    <value xml:space="preserve">chkRegisterForCOM</value>
+  <data name="&gt;&gt;chkRegisterForCOM.Name" xml:space="preserve">
+    <value>chkRegisterForCOM</value>
   </data>
-  <data name="&gt;&gt;chkRegisterForCOM.Type">
-    <value xml:space="preserve">System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;chkRegisterForCOM.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;chkRegisterForCOM.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;chkRegisterForCOM.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;chkRegisterForCOM.ZOrder">
-    <value xml:space="preserve">4</value>
+  <data name="&gt;&gt;chkRegisterForCOM.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
   <data name="chkXMLDocumentationFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -697,52 +625,55 @@
     <value>True</value>
   </data>
   <data name="chkXMLDocumentationFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 369</value>
+    <value>23, 431</value>
+  </data>
+  <data name="chkXMLDocumentationFile.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>23, 3, 3, 3</value>
   </data>
   <data name="chkXMLDocumentationFile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>136, 17</value>
+    <value>140, 17</value>
   </data>
   <data name="chkXMLDocumentationFile.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
   </data>
-  <data name="chkXMLDocumentationFile.Text">
-    <value xml:space="preserve">&amp;XML documentation file:</value>
+  <data name="chkXMLDocumentationFile.Text" xml:space="preserve">
+    <value>&amp;XML documentation file:</value>
   </data>
-  <data name="&gt;&gt;chkXMLDocumentationFile.Name">
-    <value xml:space="preserve">chkXMLDocumentationFile</value>
+  <data name="&gt;&gt;chkXMLDocumentationFile.Name" xml:space="preserve">
+    <value>chkXMLDocumentationFile</value>
   </data>
-  <data name="&gt;&gt;chkXMLDocumentationFile.Type">
-    <value xml:space="preserve">System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;chkXMLDocumentationFile.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;chkXMLDocumentationFile.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;chkXMLDocumentationFile.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;chkXMLDocumentationFile.ZOrder">
-    <value xml:space="preserve">5</value>
+  <data name="&gt;&gt;chkXMLDocumentationFile.ZOrder" xml:space="preserve">
+    <value>5</value>
   </data>
   <data name="txtXMLDocumentationFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
   </data>
   <data name="txtXMLDocumentationFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>198, 368</value>
+    <value>187, 430</value>
   </data>
   <data name="txtXMLDocumentationFile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>259, 20</value>
+    <value>271, 20</value>
   </data>
   <data name="txtXMLDocumentationFile.TabIndex" type="System.Int32, mscorlib">
     <value>25</value>
   </data>
-  <data name="&gt;&gt;txtXMLDocumentationFile.Name">
-    <value xml:space="preserve">txtXMLDocumentationFile</value>
+  <data name="&gt;&gt;txtXMLDocumentationFile.Name" xml:space="preserve">
+    <value>txtXMLDocumentationFile</value>
   </data>
-  <data name="&gt;&gt;txtXMLDocumentationFile.Type">
-    <value xml:space="preserve">System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;txtXMLDocumentationFile.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;txtXMLDocumentationFile.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;txtXMLDocumentationFile.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;txtXMLDocumentationFile.ZOrder">
-    <value xml:space="preserve">6</value>
+  <data name="&gt;&gt;txtXMLDocumentationFile.ZOrder" xml:space="preserve">
+    <value>6</value>
   </data>
   <data name="btnOutputPathBrowse.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
@@ -751,49 +682,58 @@
     <value>True</value>
   </data>
   <data name="btnOutputPathBrowse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>463, 339</value>
+    <value>464, 401</value>
+  </data>
+  <data name="btnOutputPathBrowse.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 11, 0, 3</value>
+  </data>
+  <data name="btnOutputPathBrowse.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
   </data>
   <data name="btnOutputPathBrowse.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
   </data>
-  <data name="btnOutputPathBrowse.Text">
-    <value xml:space="preserve">B&amp;rowse...</value>
+  <data name="btnOutputPathBrowse.Text" xml:space="preserve">
+    <value>B&amp;rowse...</value>
   </data>
-  <data name="&gt;&gt;btnOutputPathBrowse.Name">
-    <value xml:space="preserve">btnOutputPathBrowse</value>
+  <data name="&gt;&gt;btnOutputPathBrowse.Name" xml:space="preserve">
+    <value>btnOutputPathBrowse</value>
   </data>
-  <data name="&gt;&gt;btnOutputPathBrowse.Type">
-    <value xml:space="preserve">System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;btnOutputPathBrowse.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;btnOutputPathBrowse.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;btnOutputPathBrowse.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;btnOutputPathBrowse.ZOrder">
-    <value xml:space="preserve">7</value>
+  <data name="&gt;&gt;btnOutputPathBrowse.ZOrder" xml:space="preserve">
+    <value>7</value>
   </data>
   <data name="txtOutputPath.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
   </data>
   <data name="txtOutputPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>198, 340</value>
+    <value>187, 402</value>
+  </data>
+  <data name="txtOutputPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 11, 3, 3</value>
   </data>
   <data name="txtOutputPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>259, 20</value>
+    <value>271, 20</value>
   </data>
   <data name="txtOutputPath.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
   </data>
-  <data name="&gt;&gt;txtOutputPath.Name">
-    <value xml:space="preserve">txtOutputPath</value>
+  <data name="&gt;&gt;txtOutputPath.Name" xml:space="preserve">
+    <value>txtOutputPath</value>
   </data>
-  <data name="&gt;&gt;txtOutputPath.Type">
-    <value xml:space="preserve">System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;txtOutputPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;txtOutputPath.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;txtOutputPath.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;txtOutputPath.ZOrder">
-    <value xml:space="preserve">8</value>
+  <data name="&gt;&gt;txtOutputPath.ZOrder" xml:space="preserve">
+    <value>8</value>
   </data>
   <data name="lblOutputPath.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -802,58 +742,31 @@
     <value>True</value>
   </data>
   <data name="lblOutputPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 343</value>
+    <value>23, 406</value>
+  </data>
+  <data name="lblOutputPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>23, 11, 3, 3</value>
   </data>
   <data name="lblOutputPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>66, 14</value>
+    <value>66, 13</value>
   </data>
   <data name="lblOutputPath.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
   </data>
-  <data name="lblOutputPath.Text">
-    <value xml:space="preserve">&amp;Output path:</value>
+  <data name="lblOutputPath.Text" xml:space="preserve">
+    <value>&amp;Output path:</value>
   </data>
-  <data name="&gt;&gt;lblOutputPath.Name">
-    <value xml:space="preserve">lblOutputPath</value>
+  <data name="&gt;&gt;lblOutputPath.Name" xml:space="preserve">
+    <value>lblOutputPath</value>
   </data>
-  <data name="&gt;&gt;lblOutputPath.Type">
-    <value xml:space="preserve">System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;lblOutputPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;lblOutputPath.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;lblOutputPath.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;lblOutputPath.ZOrder">
-    <value xml:space="preserve">9</value>
-  </data>
-  <data name="rbWarningAll.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="rbWarningAll.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="rbWarningAll.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 261</value>
-  </data>
-  <data name="rbWarningAll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 17</value>
-  </data>
-  <data name="rbWarningAll.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
-  </data>
-  <data name="rbWarningAll.Text">
-    <value xml:space="preserve">A&amp;ll</value>
-  </data>
-  <data name="&gt;&gt;rbWarningAll.Name">
-    <value xml:space="preserve">rbWarningAll</value>
-  </data>
-  <data name="&gt;&gt;rbWarningAll.Type">
-    <value xml:space="preserve">System.Windows.Forms.RadioButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rbWarningAll.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;rbWarningAll.ZOrder">
-    <value xml:space="preserve">10</value>
+  <data name="&gt;&gt;lblOutputPath.ZOrder" xml:space="preserve">
+    <value>9</value>
   </data>
   <data name="rbWarningSpecific.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -862,52 +775,88 @@
     <value>True</value>
   </data>
   <data name="rbWarningSpecific.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 286</value>
+    <value>23, 349</value>
+  </data>
+  <data name="rbWarningSpecific.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>23, 3, 3, 11</value>
   </data>
   <data name="rbWarningSpecific.Size" type="System.Drawing.Size, System.Drawing">
-    <value>107, 17</value>
+    <value>111, 17</value>
   </data>
   <data name="rbWarningSpecific.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
   </data>
-  <data name="rbWarningSpecific.Text">
-    <value xml:space="preserve">Specif&amp;ic warnings:</value>
+  <data name="rbWarningSpecific.Text" xml:space="preserve">
+    <value>Specif&amp;ic warnings:</value>
   </data>
-  <data name="&gt;&gt;rbWarningSpecific.Name">
-    <value xml:space="preserve">rbWarningSpecific</value>
+  <data name="&gt;&gt;rbWarningSpecific.Name" xml:space="preserve">
+    <value>rbWarningSpecific</value>
   </data>
-  <data name="&gt;&gt;rbWarningSpecific.Type">
-    <value xml:space="preserve">System.Windows.Forms.RadioButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;rbWarningSpecific.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;rbWarningSpecific.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;rbWarningSpecific.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;rbWarningSpecific.ZOrder">
-    <value xml:space="preserve">11</value>
+  <data name="&gt;&gt;rbWarningSpecific.ZOrder" xml:space="preserve">
+    <value>10</value>
   </data>
   <data name="txtSpecificWarnings.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
   </data>
   <data name="txtSpecificWarnings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>198, 285</value>
+    <value>187, 351</value>
   </data>
   <data name="txtSpecificWarnings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>259, 20</value>
+    <value>271, 20</value>
   </data>
   <data name="txtSpecificWarnings.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
   </data>
-  <data name="&gt;&gt;txtSpecificWarnings.Name">
-    <value xml:space="preserve">txtSpecificWarnings</value>
+  <data name="&gt;&gt;txtSpecificWarnings.Name" xml:space="preserve">
+    <value>txtSpecificWarnings</value>
   </data>
-  <data name="&gt;&gt;txtSpecificWarnings.Type">
-    <value xml:space="preserve">System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;txtSpecificWarnings.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;txtSpecificWarnings.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;txtSpecificWarnings.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;txtSpecificWarnings.ZOrder">
-    <value xml:space="preserve">12</value>
+  <data name="&gt;&gt;txtSpecificWarnings.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="rbWarningAll.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="rbWarningAll.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rbWarningAll.Location" type="System.Drawing.Point, System.Drawing">
+    <value>23, 326</value>
+  </data>
+  <data name="rbWarningAll.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>23, 3, 3, 3</value>
+  </data>
+  <data name="rbWarningAll.Size" type="System.Drawing.Size, System.Drawing">
+    <value>36, 17</value>
+  </data>
+  <data name="rbWarningAll.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="rbWarningAll.Text" xml:space="preserve">
+    <value>A&amp;ll</value>
+  </data>
+  <data name="&gt;&gt;rbWarningAll.Name" xml:space="preserve">
+    <value>rbWarningAll</value>
+  </data>
+  <data name="&gt;&gt;rbWarningAll.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rbWarningAll.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;rbWarningAll.ZOrder" xml:space="preserve">
+    <value>12</value>
   </data>
   <data name="rbWarningNone.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -916,52 +865,58 @@
     <value>True</value>
   </data>
   <data name="rbWarningNone.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 237</value>
+    <value>23, 303</value>
+  </data>
+  <data name="rbWarningNone.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>23, 11, 3, 3</value>
   </data>
   <data name="rbWarningNone.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 17</value>
+    <value>51, 17</value>
   </data>
   <data name="rbWarningNone.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
   </data>
-  <data name="rbWarningNone.Text">
-    <value xml:space="preserve">&amp;None</value>
+  <data name="rbWarningNone.Text" xml:space="preserve">
+    <value>&amp;None</value>
   </data>
-  <data name="&gt;&gt;rbWarningNone.Name">
-    <value xml:space="preserve">rbWarningNone</value>
+  <data name="&gt;&gt;rbWarningNone.Name" xml:space="preserve">
+    <value>rbWarningNone</value>
   </data>
-  <data name="&gt;&gt;rbWarningNone.Type">
-    <value xml:space="preserve">System.Windows.Forms.RadioButton, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;rbWarningNone.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;rbWarningNone.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;rbWarningNone.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;rbWarningNone.ZOrder">
-    <value xml:space="preserve">13</value>
+  <data name="&gt;&gt;rbWarningNone.ZOrder" xml:space="preserve">
+    <value>13</value>
   </data>
   <data name="txtSupressWarnings.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
   </data>
   <data name="txtSupressWarnings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>198, 181</value>
+    <value>187, 248</value>
+  </data>
+  <data name="txtSupressWarnings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 11</value>
   </data>
   <data name="txtSupressWarnings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>259, 20</value>
+    <value>271, 20</value>
   </data>
   <data name="txtSupressWarnings.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
   </data>
-  <data name="&gt;&gt;txtSupressWarnings.Name">
-    <value xml:space="preserve">txtSupressWarnings</value>
+  <data name="&gt;&gt;txtSupressWarnings.Name" xml:space="preserve">
+    <value>txtSupressWarnings</value>
   </data>
-  <data name="&gt;&gt;txtSupressWarnings.Type">
-    <value xml:space="preserve">System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;txtSupressWarnings.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;txtSupressWarnings.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;txtSupressWarnings.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;txtSupressWarnings.ZOrder">
-    <value xml:space="preserve">14</value>
+  <data name="&gt;&gt;txtSupressWarnings.ZOrder" xml:space="preserve">
+    <value>14</value>
   </data>
   <data name="lblSupressWarnings.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -970,37 +925,55 @@
     <value>True</value>
   </data>
   <data name="lblSupressWarnings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 184</value>
+    <value>23, 251</value>
+  </data>
+  <data name="lblSupressWarnings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>23, 3, 3, 11</value>
   </data>
   <data name="lblSupressWarnings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 14</value>
+    <value>99, 13</value>
   </data>
   <data name="lblSupressWarnings.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
   </data>
-  <data name="lblSupressWarnings.Text">
-    <value xml:space="preserve">&amp;Suppress warnings:</value>
+  <data name="lblSupressWarnings.Text" xml:space="preserve">
+    <value>&amp;Suppress warnings:</value>
   </data>
-  <data name="&gt;&gt;lblSupressWarnings.Name">
-    <value xml:space="preserve">lblSupressWarnings</value>
+  <data name="&gt;&gt;lblSupressWarnings.Name" xml:space="preserve">
+    <value>lblSupressWarnings</value>
   </data>
-  <data name="&gt;&gt;lblSupressWarnings.Type">
-    <value xml:space="preserve">System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;lblSupressWarnings.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;lblSupressWarnings.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;lblSupressWarnings.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;lblSupressWarnings.ZOrder">
-    <value xml:space="preserve">15</value>
+  <data name="&gt;&gt;lblSupressWarnings.ZOrder" xml:space="preserve">
+    <value>15</value>
   </data>
   <data name="cboWarningLevel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
   </data>
-  <data name="cboWarningLevel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="cboWarningLevel.Items" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="cboWarningLevel.Items1" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="cboWarningLevel.Items2" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="cboWarningLevel.Items3" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="cboWarningLevel.Items4" xml:space="preserve">
+    <value>4</value>
   </data>
   <data name="cboWarningLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>198, 154</value>
+    <value>187, 221</value>
+  </data>
+  <data name="cboWarningLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 11, 3, 3</value>
   </data>
   <data name="cboWarningLevel.Size" type="System.Drawing.Size, System.Drawing">
     <value>125, 21</value>
@@ -1008,17 +981,17 @@
   <data name="cboWarningLevel.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
   </data>
-  <data name="&gt;&gt;cboWarningLevel.Name">
-    <value xml:space="preserve">cboWarningLevel</value>
+  <data name="&gt;&gt;cboWarningLevel.Name" xml:space="preserve">
+    <value>cboWarningLevel</value>
   </data>
-  <data name="&gt;&gt;cboWarningLevel.Type">
-    <value xml:space="preserve">System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;cboWarningLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;cboWarningLevel.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;cboWarningLevel.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;cboWarningLevel.ZOrder">
-    <value xml:space="preserve">16</value>
+  <data name="&gt;&gt;cboWarningLevel.ZOrder" xml:space="preserve">
+    <value>16</value>
   </data>
   <data name="lblWarningLevel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -1027,28 +1000,55 @@
     <value>True</value>
   </data>
   <data name="lblWarningLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 157</value>
+    <value>23, 225</value>
+  </data>
+  <data name="lblWarningLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>23, 11, 3, 3</value>
   </data>
   <data name="lblWarningLevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 14</value>
+    <value>75, 13</value>
   </data>
   <data name="lblWarningLevel.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
   </data>
-  <data name="lblWarningLevel.Text">
-    <value xml:space="preserve">W&amp;arning level:</value>
+  <data name="lblWarningLevel.Text" xml:space="preserve">
+    <value>W&amp;arning level:</value>
   </data>
-  <data name="&gt;&gt;lblWarningLevel.Name">
-    <value xml:space="preserve">lblWarningLevel</value>
+  <data name="&gt;&gt;lblWarningLevel.Name" xml:space="preserve">
+    <value>lblWarningLevel</value>
   </data>
-  <data name="&gt;&gt;lblWarningLevel.Type">
-    <value xml:space="preserve">System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;lblWarningLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;lblWarningLevel.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;lblWarningLevel.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;lblWarningLevel.ZOrder">
-    <value xml:space="preserve">17</value>
+  <data name="&gt;&gt;lblWarningLevel.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="cboPlatformTarget.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="cboPlatformTarget.Location" type="System.Drawing.Point, System.Drawing">
+    <value>187, 96</value>
+  </data>
+  <data name="cboPlatformTarget.Size" type="System.Drawing.Size, System.Drawing">
+    <value>125, 21</value>
+  </data>
+  <data name="cboPlatformTarget.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;cboPlatformTarget.Name" xml:space="preserve">
+    <value>cboPlatformTarget</value>
+  </data>
+  <data name="&gt;&gt;cboPlatformTarget.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cboPlatformTarget.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;cboPlatformTarget.ZOrder" xml:space="preserve">
+    <value>18</value>
   </data>
   <data name="chkOptimizeCode.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -1057,28 +1057,163 @@
     <value>True</value>
   </data>
   <data name="chkOptimizeCode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 101</value>
+    <value>23, 169</value>
+  </data>
+  <data name="chkOptimizeCode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>23, 3, 3, 11</value>
   </data>
   <data name="chkOptimizeCode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>89, 17</value>
+    <value>93, 17</value>
   </data>
   <data name="chkOptimizeCode.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
   </data>
-  <data name="chkOptimizeCode.Text">
-    <value xml:space="preserve">Optimi&amp;ze code</value>
+  <data name="chkOptimizeCode.Text" xml:space="preserve">
+    <value>Optimi&amp;ze code</value>
   </data>
-  <data name="&gt;&gt;chkOptimizeCode.Name">
-    <value xml:space="preserve">chkOptimizeCode</value>
+  <data name="&gt;&gt;chkOptimizeCode.Name" xml:space="preserve">
+    <value>chkOptimizeCode</value>
   </data>
-  <data name="&gt;&gt;chkOptimizeCode.Type">
-    <value xml:space="preserve">System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;chkOptimizeCode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;chkOptimizeCode.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;chkOptimizeCode.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;chkOptimizeCode.ZOrder">
-    <value xml:space="preserve">19</value>
+  <data name="&gt;&gt;chkOptimizeCode.ZOrder" xml:space="preserve">
+    <value>19</value>
+  </data>
+  <data name="chkAllowUnsafeCode.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="chkAllowUnsafeCode.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkAllowUnsafeCode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>23, 146</value>
+  </data>
+  <data name="chkAllowUnsafeCode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>23, 3, 3, 3</value>
+  </data>
+  <data name="chkAllowUnsafeCode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>113, 17</value>
+  </data>
+  <data name="chkAllowUnsafeCode.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="chkAllowUnsafeCode.Text" xml:space="preserve">
+    <value>Allow unsa&amp;fe code</value>
+  </data>
+  <data name="&gt;&gt;chkAllowUnsafeCode.Name" xml:space="preserve">
+    <value>chkAllowUnsafeCode</value>
+  </data>
+  <data name="&gt;&gt;chkAllowUnsafeCode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkAllowUnsafeCode.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;chkAllowUnsafeCode.ZOrder" xml:space="preserve">
+    <value>20</value>
+  </data>
+  <data name="chkPrefer32Bit.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="chkPrefer32Bit.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkPrefer32Bit.Location" type="System.Drawing.Point, System.Drawing">
+    <value>23, 123</value>
+  </data>
+  <data name="chkPrefer32Bit.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>23, 3, 3, 3</value>
+  </data>
+  <data name="chkPrefer32Bit.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 17</value>
+  </data>
+  <data name="chkPrefer32Bit.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="chkPrefer32Bit.Text" xml:space="preserve">
+    <value>&amp;Prefer 32-bit</value>
+  </data>
+  <data name="&gt;&gt;chkPrefer32Bit.Name" xml:space="preserve">
+    <value>chkPrefer32Bit</value>
+  </data>
+  <data name="&gt;&gt;chkPrefer32Bit.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkPrefer32Bit.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;chkPrefer32Bit.ZOrder" xml:space="preserve">
+    <value>21</value>
+  </data>
+  <data name="chkDefineTrace.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="chkDefineTrace.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkDefineTrace.Location" type="System.Drawing.Point, System.Drawing">
+    <value>23, 73</value>
+  </data>
+  <data name="chkDefineTrace.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>23, 3, 3, 3</value>
+  </data>
+  <data name="chkDefineTrace.Size" type="System.Drawing.Size, System.Drawing">
+    <value>140, 17</value>
+  </data>
+  <data name="chkDefineTrace.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="chkDefineTrace.Text" xml:space="preserve">
+    <value>Define &amp;TRACE constant</value>
+  </data>
+  <data name="&gt;&gt;chkDefineTrace.Name" xml:space="preserve">
+    <value>chkDefineTrace</value>
+  </data>
+  <data name="&gt;&gt;chkDefineTrace.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkDefineTrace.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;chkDefineTrace.ZOrder" xml:space="preserve">
+    <value>22</value>
+  </data>
+  <data name="lblPlatformTarget.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="lblPlatformTarget.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblPlatformTarget.Location" type="System.Drawing.Point, System.Drawing">
+    <value>23, 100</value>
+  </data>
+  <data name="lblPlatformTarget.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>23, 3, 3, 3</value>
+  </data>
+  <data name="lblPlatformTarget.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 13</value>
+  </data>
+  <data name="lblPlatformTarget.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="lblPlatformTarget.Text" xml:space="preserve">
+    <value>Platform tar&amp;get:</value>
+  </data>
+  <data name="&gt;&gt;lblPlatformTarget.Name" xml:space="preserve">
+    <value>lblPlatformTarget</value>
+  </data>
+  <data name="&gt;&gt;lblPlatformTarget.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPlatformTarget.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;lblPlatformTarget.ZOrder" xml:space="preserve">
+    <value>26</value>
   </data>
   <data name="lblSGenOption.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -1087,37 +1222,40 @@
     <value>True</value>
   </data>
   <data name="lblSGenOption.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 420</value>
+    <value>23, 487</value>
+  </data>
+  <data name="lblSGenOption.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>23, 11, 3, 3</value>
   </data>
   <data name="lblSGenOption.Size" type="System.Drawing.Size, System.Drawing">
-    <value>169, 14</value>
+    <value>157, 13</value>
   </data>
   <data name="lblSGenOption.TabIndex" type="System.Int32, mscorlib">
     <value>27</value>
   </data>
-  <data name="lblSGenOption.Text">
-    <value xml:space="preserve">G&amp;enerate serialization assembly:</value>
+  <data name="lblSGenOption.Text" xml:space="preserve">
+    <value>G&amp;enerate serialization assembly:</value>
   </data>
-  <data name="&gt;&gt;lblSGenOption.Name">
-    <value xml:space="preserve">lblSGenOption</value>
+  <data name="&gt;&gt;lblSGenOption.Name" xml:space="preserve">
+    <value>lblSGenOption</value>
   </data>
-  <data name="&gt;&gt;lblSGenOption.Type">
-    <value xml:space="preserve">System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;lblSGenOption.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;lblSGenOption.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;lblSGenOption.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;lblSGenOption.ZOrder">
-    <value xml:space="preserve">24</value>
+  <data name="&gt;&gt;lblSGenOption.ZOrder" xml:space="preserve">
+    <value>27</value>
   </data>
   <data name="cboSGenOption.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
   </data>
-  <data name="cboSGenOption.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
   <data name="cboSGenOption.Location" type="System.Drawing.Point, System.Drawing">
-    <value>198, 417</value>
+    <value>187, 479</value>
+  </data>
+  <data name="cboSGenOption.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>125, 0</value>
   </data>
   <data name="cboSGenOption.Size" type="System.Drawing.Size, System.Drawing">
     <value>125, 21</value>
@@ -1125,17 +1263,17 @@
   <data name="cboSGenOption.TabIndex" type="System.Int32, mscorlib">
     <value>28</value>
   </data>
-  <data name="&gt;&gt;cboSGenOption.Name">
-    <value xml:space="preserve">cboSGenOption</value>
+  <data name="&gt;&gt;cboSGenOption.Name" xml:space="preserve">
+    <value>cboSGenOption</value>
   </data>
-  <data name="&gt;&gt;cboSGenOption.Type">
-    <value xml:space="preserve">System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;cboSGenOption.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;cboSGenOption.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;cboSGenOption.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;cboSGenOption.ZOrder">
-    <value xml:space="preserve">25</value>
+  <data name="&gt;&gt;cboSGenOption.ZOrder" xml:space="preserve">
+    <value>28</value>
   </data>
   <data name="btnAdvanced.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
@@ -1144,114 +1282,102 @@
     <value>True</value>
   </data>
   <data name="btnAdvanced.Location" type="System.Drawing.Point, System.Drawing">
-    <value>463, 444</value>
+    <value>464, 506</value>
+  </data>
+  <data name="btnAdvanced.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 0, 3</value>
+  </data>
+  <data name="btnAdvanced.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
   </data>
   <data name="btnAdvanced.TabIndex" type="System.Int32, mscorlib">
     <value>29</value>
   </data>
-  <data name="btnAdvanced.Text">
-    <value xml:space="preserve">A&amp;dvanced...</value>
+  <data name="btnAdvanced.Text" xml:space="preserve">
+    <value>A&amp;dvanced...</value>
   </data>
-  <data name="&gt;&gt;btnAdvanced.Name">
-    <value xml:space="preserve">btnAdvanced</value>
+  <data name="&gt;&gt;btnAdvanced.Name" xml:space="preserve">
+    <value>btnAdvanced</value>
   </data>
-  <data name="&gt;&gt;btnAdvanced.Type">
-    <value xml:space="preserve">System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;btnAdvanced.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;btnAdvanced.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;btnAdvanced.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;btnAdvanced.ZOrder">
-    <value xml:space="preserve">26</value>
+  <data name="&gt;&gt;btnAdvanced.ZOrder" xml:space="preserve">
+    <value>29</value>
   </data>
   <data name="overarchingTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
+  </data>
+  <data name="overarchingTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
   </data>
   <data name="overarchingTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
     <value>18</value>
   </data>
   <data name="overarchingTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>538, 470</value>
+    <value>539, 533</value>
   </data>
   <data name="overarchingTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;overarchingTableLayoutPanel.Name">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;overarchingTableLayoutPanel.Name" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;overarchingTableLayoutPanel.Type">
-    <value xml:space="preserve">System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;overarchingTableLayoutPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;overarchingTableLayoutPanel.Parent">
-    <value xml:space="preserve">$this</value>
+  <data name="&gt;&gt;overarchingTableLayoutPanel.Parent" xml:space="preserve">
+    <value>$this</value>
   </data>
-  <data name="&gt;&gt;overarchingTableLayoutPanel.ZOrder">
-    <value xml:space="preserve">0</value>
+  <data name="&gt;&gt;overarchingTableLayoutPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
-  <data name="chkAllowUnsafeCode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 78</value>
+  <data name="overarchingTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="outputTableLayoutPanel" Row="15" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="generalHeaderTableLayoutPanel" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="treatWarningsAsErrorsTableLayoutPanel" Row="11" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="errorsAndWarningsTableLayoutPanel" Row="8" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkRegisterForCOM" Row="18" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkXMLDocumentationFile" Row="17" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="txtXMLDocumentationFile" Row="17" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="btnOutputPathBrowse" Row="16" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="txtOutputPath" Row="16" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lblOutputPath" Row="16" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="rbWarningSpecific" Row="14" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="txtSpecificWarnings" Row="14" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="rbWarningAll" Row="13" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="rbWarningNone" Row="12" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="txtSupressWarnings" Row="10" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lblSupressWarnings" Row="10" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cboWarningLevel" Row="9" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lblWarningLevel" Row="9" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cboPlatformTarget" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="chkOptimizeCode" Row="7" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkAllowUnsafeCode" Row="6" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkPrefer32Bit" Row="5" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkDefineTrace" Row="3" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkDefineDebug" Row="2" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="txtConditionalCompilationSymbols" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lblConditionalCompilationSymbols" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblPlatformTarget" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblSGenOption" Row="19" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cboSGenOption" Row="19" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="btnAdvanced" Row="20" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
-  <data name="chkAllowUnsafeCode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>109, 17</value>
+  <data name="chkDefineDebug.Location" type="System.Drawing.Point, System.Drawing">
+    <value>23, 50</value>
   </data>
-  <data name="chkAllowUnsafeCode.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+  <data name="chkDefineDebug.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>23, 3, 3, 3</value>
   </data>
-  <data name="chkAllowUnsafeCode.Text">
-    <value xml:space="preserve">Allow unsa&amp;fe code</value>
+  <data name="chkDefineDebug.Size" type="System.Drawing.Size, System.Drawing">
+    <value>142, 17</value>
   </data>
-  <data name="&gt;&gt;chkAllowUnsafeCode.Name">
-    <value xml:space="preserve">chkAllowUnsafeCode</value>
+  <data name="chkDefineDebug.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
-  <data name="&gt;&gt;chkAllowUnsafeCode.Type">
-    <value xml:space="preserve">System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="chkDefineDebug.Text" xml:space="preserve">
+    <value>Define DEB&amp;UG constant</value>
   </data>
-  <data name="&gt;&gt;chkAllowUnsafeCode.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;chkDefineDebug.Name" xml:space="preserve">
+    <value>chkDefineDebug</value>
   </data>
-  <data name="&gt;&gt;chkAllowUnsafeCode.ZOrder">
-    <value xml:space="preserve">20</value>
+  <data name="&gt;&gt;chkDefineDebug.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="chkPrefer32Bit.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
+  <data name="&gt;&gt;chkDefineDebug.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="chkPrefer32Bit.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="&gt;&gt;chkDefineDebug.ZOrder" xml:space="preserve">
+    <value>23</value>
   </data>
-  <data name="chkPrefer32Bit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>109, 17</value>
-  </data>
-  <data name="chkPrefer32Bit.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="chkPrefer32Bit.Text">
-    <value xml:space="preserve">&amp;Prefer 32-bit</value>
-  </data>
-  <data name="&gt;&gt;chkPrefer32Bit.Name">
-    <value xml:space="preserve">chkPrefer32Bit</value>
-  </data>
-  <data name="&gt;&gt;chkPrefer32Bit.Type">
-    <value xml:space="preserve">System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkPrefer32Bit.Parent">
-    <value xml:space="preserve">overarchingTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;chkPrefer32Bit.ZOrder">
-    <value xml:space="preserve">27</value>
-  </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>538, 470</value>
+    <value>539, 536</value>
   </data>
-  <data name="&gt;&gt;$this.Name">
-    <value xml:space="preserve">BuildPropPage</value>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>BuildPropPage</value>
   </data>
-  <data name="&gt;&gt;$this.Type">
-    <value xml:space="preserve">Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase, Microsoft.VisualStudio.Editors, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase, Microsoft.VisualStudio.AppDesigner, Version=42.42.42.42, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.resx
@@ -127,10 +127,10 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="lblConditionalCompilationSymbols.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 27</value>
+    <value>20, 27</value>
   </data>
   <data name="lblConditionalCompilationSymbols.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>23, 11, 3, 3</value>
+    <value>20, 11, 3, 3</value>
   </data>
   <data name="lblConditionalCompilationSymbols.Size" type="System.Drawing.Size, System.Drawing">
     <value>158, 13</value>
@@ -157,13 +157,13 @@
     <value>Left, Right</value>
   </data>
   <data name="txtConditionalCompilationSymbols.Location" type="System.Drawing.Point, System.Drawing">
-    <value>187, 24</value>
+    <value>184, 24</value>
   </data>
   <data name="txtConditionalCompilationSymbols.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 11, 3, 3</value>
   </data>
   <data name="txtConditionalCompilationSymbols.Size" type="System.Drawing.Size, System.Drawing">
-    <value>271, 20</value>
+    <value>274, 20</value>
   </data>
   <data name="txtConditionalCompilationSymbols.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -655,10 +655,10 @@
     <value>Left, Right</value>
   </data>
   <data name="txtXMLDocumentationFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>187, 430</value>
+    <value>184, 430</value>
   </data>
   <data name="txtXMLDocumentationFile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>271, 20</value>
+    <value>274, 20</value>
   </data>
   <data name="txtXMLDocumentationFile.TabIndex" type="System.Int32, mscorlib">
     <value>25</value>
@@ -712,13 +712,13 @@
     <value>Left, Right</value>
   </data>
   <data name="txtOutputPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>187, 402</value>
+    <value>184, 402</value>
   </data>
   <data name="txtOutputPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 11, 3, 3</value>
   </data>
   <data name="txtOutputPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>271, 20</value>
+    <value>274, 20</value>
   </data>
   <data name="txtOutputPath.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -742,10 +742,10 @@
     <value>True</value>
   </data>
   <data name="lblOutputPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 406</value>
+    <value>20, 406</value>
   </data>
   <data name="lblOutputPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>23, 11, 3, 3</value>
+    <value>20, 11, 3, 3</value>
   </data>
   <data name="lblOutputPath.Size" type="System.Drawing.Size, System.Drawing">
     <value>66, 13</value>
@@ -805,10 +805,10 @@
     <value>Left, Right</value>
   </data>
   <data name="txtSpecificWarnings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>187, 351</value>
+    <value>184, 351</value>
   </data>
   <data name="txtSpecificWarnings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>271, 20</value>
+    <value>274, 20</value>
   </data>
   <data name="txtSpecificWarnings.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -895,13 +895,13 @@
     <value>Left, Right</value>
   </data>
   <data name="txtSupressWarnings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>187, 248</value>
+    <value>184, 248</value>
   </data>
   <data name="txtSupressWarnings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 11</value>
   </data>
   <data name="txtSupressWarnings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>271, 20</value>
+    <value>274, 20</value>
   </data>
   <data name="txtSupressWarnings.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -925,10 +925,10 @@
     <value>True</value>
   </data>
   <data name="lblSupressWarnings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 251</value>
+    <value>20, 251</value>
   </data>
   <data name="lblSupressWarnings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>23, 3, 3, 11</value>
+    <value>20, 3, 3, 11</value>
   </data>
   <data name="lblSupressWarnings.Size" type="System.Drawing.Size, System.Drawing">
     <value>99, 13</value>
@@ -970,7 +970,7 @@
     <value>4</value>
   </data>
   <data name="cboWarningLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>187, 221</value>
+    <value>184, 221</value>
   </data>
   <data name="cboWarningLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 11, 3, 3</value>
@@ -1000,10 +1000,10 @@
     <value>True</value>
   </data>
   <data name="lblWarningLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 225</value>
+    <value>20, 225</value>
   </data>
   <data name="lblWarningLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>23, 11, 3, 3</value>
+    <value>20, 11, 3, 3</value>
   </data>
   <data name="lblWarningLevel.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 13</value>
@@ -1030,7 +1030,7 @@
     <value>Left</value>
   </data>
   <data name="cboPlatformTarget.Location" type="System.Drawing.Point, System.Drawing">
-    <value>187, 96</value>
+    <value>184, 96</value>
   </data>
   <data name="cboPlatformTarget.Size" type="System.Drawing.Size, System.Drawing">
     <value>125, 21</value>
@@ -1189,10 +1189,10 @@
     <value>True</value>
   </data>
   <data name="lblPlatformTarget.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 100</value>
+    <value>20, 100</value>
   </data>
   <data name="lblPlatformTarget.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>23, 3, 3, 3</value>
+    <value>20, 3, 3, 3</value>
   </data>
   <data name="lblPlatformTarget.Size" type="System.Drawing.Size, System.Drawing">
     <value>78, 13</value>
@@ -1222,10 +1222,10 @@
     <value>True</value>
   </data>
   <data name="lblSGenOption.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 487</value>
+    <value>20, 483</value>
   </data>
   <data name="lblSGenOption.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>23, 11, 3, 3</value>
+    <value>20, 3, 3, 3</value>
   </data>
   <data name="lblSGenOption.Size" type="System.Drawing.Size, System.Drawing">
     <value>157, 13</value>
@@ -1252,7 +1252,7 @@
     <value>Left</value>
   </data>
   <data name="cboSGenOption.Location" type="System.Drawing.Point, System.Drawing">
-    <value>187, 479</value>
+    <value>184, 479</value>
   </data>
   <data name="cboSGenOption.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>125, 0</value>
@@ -1282,10 +1282,10 @@
     <value>True</value>
   </data>
   <data name="btnAdvanced.Location" type="System.Drawing.Point, System.Drawing">
-    <value>464, 506</value>
+    <value>464, 507</value>
   </data>
   <data name="btnAdvanced.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 0, 3</value>
+    <value>3, 3, 0, 0</value>
   </data>
   <data name="btnAdvanced.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -1318,7 +1318,7 @@
     <value>18</value>
   </data>
   <data name="overarchingTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>539, 533</value>
+    <value>539, 531</value>
   </data>
   <data name="overarchingTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
@@ -538,24 +538,24 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
             Get
                 If m_ControlData Is Nothing Then
-                    m_ControlData = New PropertyControlData() { _
-                     New PropertyControlData(VsProjPropId.VBPROJPROPID_DefineConstants, "DefineConstants", Me.txtConditionalCompilationSymbols, AddressOf ConditionalCompilationSet, AddressOf ConditionalCompilationGet, ControlDataFlags.None, New Control() {Me.txtConditionalCompilationSymbols, Me.chkDefineDebug, Me.chkDefineTrace, Me.lblConditionalCompilationSymbols}), _
-                     New PropertyControlData(VsProjPropId80.VBPROJPROPID_PlatformTarget, "PlatformTarget", Me.cboPlatformTarget, AddressOf PlatformTargetSet, AddressOf PlatformTargetGet, ControlDataFlags.None, New Control() {Me.lblPlatformTarget}), _
-                     New PropertyControlData(VsProjPropId.VBPROJPROPID_AllowUnsafeBlocks, "AllowUnsafeBlocks", Me.chkAllowUnsafeCode), _
-                     New SingleConfigPropertyControlData(SingleConfigPropertyControlData.Configs.Release, _
-                        VsProjPropId.VBPROJPROPID_Optimize, "Optimize", Me.chkOptimizeCode), _
-                     New PropertyControlData(VsProjPropId.VBPROJPROPID_WarningLevel, "WarningLevel", Me.cboWarningLevel, AddressOf WarningLevelSet, AddressOf WarningLevelGet, ControlDataFlags.None, New Control() {lblWarningLevel}), _
-                     New PropertyControlData(VsProjPropId2.VBPROJPROPID_NoWarn, "NoWarn", Me.txtSupressWarnings, New Control() {Me.lblSupressWarnings}), _
-                     New PropertyControlData(VsProjPropId.VBPROJPROPID_TreatWarningsAsErrors, "TreatWarningsAsErrors", Me.rbWarningAll, AddressOf TreatWarningsInit, AddressOf TreatWarningsGet), _
-                     New PropertyControlData(VsProjPropId80.VBPROJPROPID_TreatSpecificWarningsAsErrors, "TreatSpecificWarningsAsErrors", Me.txtSpecificWarnings, AddressOf TreatSpecificWarningsInit, AddressOf TreatSpecificWarningsGet), _
-                     New SingleConfigPropertyControlData(SingleConfigPropertyControlData.Configs.Release, _
-                        VsProjPropId.VBPROJPROPID_OutputPath, "OutputPath", Me.txtOutputPath, New Control() {Me.lblOutputPath}), _
-                     New PropertyControlData(VsProjPropId.VBPROJPROPID_DocumentationFile, "DocumentationFile", Me.txtXMLDocumentationFile, AddressOf Me.XMLDocumentationFileInit, AddressOf Me.XMLDocumentationFileGet, ControlDataFlags.None, New Control() {Me.txtXMLDocumentationFile, Me.chkXMLDocumentationFile}), _
-                     New PropertyControlData(VsProjPropId.VBPROJPROPID_RegisterForComInterop, "RegisterForComInterop", Me.chkRegisterForCOM, AddressOf Me.RegisterForCOMInteropSet, AddressOf Me.RegisterForCOMInteropGet), _
-                     New PropertyControlData(VsProjPropId110.VBPROJPROPID_OutputTypeEx, "OutputTypeEx", Nothing, AddressOf Me.OutputTypeSet, Nothing), _
-                     New SingleConfigPropertyControlData(SingleConfigPropertyControlData.Configs.Release, _
-                        VsProjPropId80.VBPROJPROPID_GenerateSerializationAssemblies, "GenerateSerializationAssemblies", Me.cboSGenOption, New Control() {Me.lblSGenOption}), _
-                     New PropertyControlData(VsProjPropId110.VBPROJPROPID_Prefer32Bit, "Prefer32Bit", Me.chkPrefer32Bit, AddressOf Prefer32BitSet, AddressOf Prefer32BitGet) _
+                    m_ControlData = New PropertyControlData() {
+                     New PropertyControlData(VsProjPropId.VBPROJPROPID_DefineConstants, "DefineConstants", Me.txtConditionalCompilationSymbols, AddressOf ConditionalCompilationSet, AddressOf ConditionalCompilationGet, ControlDataFlags.None, New Control() {Me.txtConditionalCompilationSymbols, Me.chkDefineDebug, Me.chkDefineTrace, Me.lblConditionalCompilationSymbols}),
+                     New PropertyControlData(VsProjPropId80.VBPROJPROPID_PlatformTarget, "PlatformTarget", Me.cboPlatformTarget, AddressOf PlatformTargetSet, AddressOf PlatformTargetGet, ControlDataFlags.None, New Control() {Me.lblPlatformTarget}),
+                     New PropertyControlData(VsProjPropId.VBPROJPROPID_AllowUnsafeBlocks, "AllowUnsafeBlocks", Me.chkAllowUnsafeCode),
+                     New SingleConfigPropertyControlData(SingleConfigPropertyControlData.Configs.Release,
+                        VsProjPropId.VBPROJPROPID_Optimize, "Optimize", Me.chkOptimizeCode),
+                     New PropertyControlData(VsProjPropId.VBPROJPROPID_WarningLevel, "WarningLevel", Me.cboWarningLevel, AddressOf WarningLevelSet, AddressOf WarningLevelGet, ControlDataFlags.None, New Control() {lblWarningLevel}),
+                     New PropertyControlData(VsProjPropId2.VBPROJPROPID_NoWarn, "NoWarn", Me.txtSupressWarnings, New Control() {Me.lblSupressWarnings}),
+                     New PropertyControlData(VsProjPropId.VBPROJPROPID_TreatWarningsAsErrors, "TreatWarningsAsErrors", Me.rbWarningAll, AddressOf TreatWarningsInit, AddressOf TreatWarningsGet),
+                     New PropertyControlData(VsProjPropId80.VBPROJPROPID_TreatSpecificWarningsAsErrors, "TreatSpecificWarningsAsErrors", Me.txtSpecificWarnings, AddressOf TreatSpecificWarningsInit, AddressOf TreatSpecificWarningsGet),
+                     New SingleConfigPropertyControlData(SingleConfigPropertyControlData.Configs.Release,
+                        VsProjPropId.VBPROJPROPID_OutputPath, "OutputPath", Me.txtOutputPath, New Control() {Me.lblOutputPath}),
+                     New PropertyControlData(VsProjPropId.VBPROJPROPID_DocumentationFile, "DocumentationFile", Me.txtXMLDocumentationFile, AddressOf Me.XMLDocumentationFileInit, AddressOf Me.XMLDocumentationFileGet, ControlDataFlags.None, New Control() {Me.txtXMLDocumentationFile, Me.chkXMLDocumentationFile}),
+                     New PropertyControlData(VsProjPropId.VBPROJPROPID_RegisterForComInterop, "RegisterForComInterop", Me.chkRegisterForCOM, AddressOf Me.RegisterForCOMInteropSet, AddressOf Me.RegisterForCOMInteropGet),
+                     New PropertyControlData(VsProjPropId110.VBPROJPROPID_OutputTypeEx, "OutputTypeEx", Nothing, AddressOf Me.OutputTypeSet, Nothing),
+                     New SingleConfigPropertyControlData(SingleConfigPropertyControlData.Configs.Release,
+                        VsProjPropId80.VBPROJPROPID_GenerateSerializationAssemblies, "GenerateSerializationAssemblies", Me.cboSGenOption, New Control() {Me.lblSGenOption}),
+                     New PropertyControlData(VsProjPropId110.VBPROJPROPID_Prefer32Bit, "Prefer32Bit", Me.chkPrefer32Bit, AddressOf Prefer32BitSet, AddressOf Prefer32BitGet)
                      }
                 End If
                 Return m_ControlData
@@ -1192,8 +1192,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                                 If (Path.IsPathRooted(stOutputPath)) Then
                                     '// stOutputPath is an Absolute path so check to see if its within the project path
 
-                                    If (String.Compare(Path.GetFullPath(stProjectDirectory), _
-                                                       Microsoft.VisualBasic.Left(Path.GetFullPath(stOutputPath), Len(stProjectDirectory)), _
+                                    If (String.Compare(Path.GetFullPath(stProjectDirectory),
+                                                       Microsoft.VisualBasic.Left(Path.GetFullPath(stOutputPath), Len(stProjectDirectory)),
                                                        StringComparison.Ordinal) = 0) Then
 
                                         '// The output path is within the project so suggest the output directory (or suggest just the filename

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
@@ -102,45 +102,45 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         'Do not modify it using the code editor.
         <System.Diagnostics.DebuggerStepThrough()> Private Sub InitializeComponent()
             Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(BuildPropPage))
-            Me.lblConditionalCompilationSymbols = New System.Windows.Forms.Label
-            Me.txtConditionalCompilationSymbols = New System.Windows.Forms.TextBox
-            Me.chkDefineDebug = New System.Windows.Forms.CheckBox
-            Me.chkDefineTrace = New System.Windows.Forms.CheckBox
-            Me.lblPlatformTarget = New System.Windows.Forms.Label
-            Me.cboPlatformTarget = New System.Windows.Forms.ComboBox
-            Me.chkPrefer32Bit = New System.Windows.Forms.CheckBox
-            Me.chkAllowUnsafeCode = New System.Windows.Forms.CheckBox
-            Me.chkOptimizeCode = New System.Windows.Forms.CheckBox
-            Me.lblWarningLevel = New System.Windows.Forms.Label
-            Me.cboWarningLevel = New System.Windows.Forms.ComboBox
-            Me.lblSupressWarnings = New System.Windows.Forms.Label
-            Me.txtSupressWarnings = New System.Windows.Forms.TextBox
-            Me.rbWarningNone = New System.Windows.Forms.RadioButton
-            Me.rbWarningSpecific = New System.Windows.Forms.RadioButton
-            Me.rbWarningAll = New System.Windows.Forms.RadioButton
-            Me.txtSpecificWarnings = New System.Windows.Forms.TextBox
-            Me.lblOutputPath = New System.Windows.Forms.Label
-            Me.txtOutputPath = New System.Windows.Forms.TextBox
-            Me.btnOutputPathBrowse = New System.Windows.Forms.Button
-            Me.chkXMLDocumentationFile = New System.Windows.Forms.CheckBox
-            Me.chkRegisterForCOM = New System.Windows.Forms.CheckBox
-            Me.txtXMLDocumentationFile = New System.Windows.Forms.TextBox
-            Me.btnAdvanced = New System.Windows.Forms.Button
-            Me.overarchingTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel
-            Me.outputTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel
-            Me.outputLineLabel = New System.Windows.Forms.Label
-            Me.outputLabel = New System.Windows.Forms.Label
-            Me.generalHeaderTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel
-            Me.generalLineLabel = New System.Windows.Forms.Label
-            Me.generalLabel = New System.Windows.Forms.Label
-            Me.treatWarningsAsErrorsTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel
-            Me.treatWarningsAsErrorsLineLabel = New System.Windows.Forms.Label
-            Me.treatWarningsAsErrorsLabel = New System.Windows.Forms.Label
-            Me.errorsAndWarningsTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel
-            Me.errorsAndWarningsLineLabel = New System.Windows.Forms.Label
-            Me.errorsAndWarningsLabel = New System.Windows.Forms.Label
-            Me.lblSGenOption = New System.Windows.Forms.Label
-            Me.cboSGenOption = New System.Windows.Forms.ComboBox
+            Me.lblConditionalCompilationSymbols = New System.Windows.Forms.Label()
+            Me.txtConditionalCompilationSymbols = New System.Windows.Forms.TextBox()
+            Me.chkDefineDebug = New System.Windows.Forms.CheckBox()
+            Me.chkDefineTrace = New System.Windows.Forms.CheckBox()
+            Me.lblPlatformTarget = New System.Windows.Forms.Label()
+            Me.cboPlatformTarget = New System.Windows.Forms.ComboBox()
+            Me.chkPrefer32Bit = New System.Windows.Forms.CheckBox()
+            Me.chkAllowUnsafeCode = New System.Windows.Forms.CheckBox()
+            Me.chkOptimizeCode = New System.Windows.Forms.CheckBox()
+            Me.lblWarningLevel = New System.Windows.Forms.Label()
+            Me.cboWarningLevel = New System.Windows.Forms.ComboBox()
+            Me.lblSupressWarnings = New System.Windows.Forms.Label()
+            Me.txtSupressWarnings = New System.Windows.Forms.TextBox()
+            Me.rbWarningNone = New System.Windows.Forms.RadioButton()
+            Me.rbWarningSpecific = New System.Windows.Forms.RadioButton()
+            Me.rbWarningAll = New System.Windows.Forms.RadioButton()
+            Me.txtSpecificWarnings = New System.Windows.Forms.TextBox()
+            Me.lblOutputPath = New System.Windows.Forms.Label()
+            Me.txtOutputPath = New System.Windows.Forms.TextBox()
+            Me.btnOutputPathBrowse = New System.Windows.Forms.Button()
+            Me.chkXMLDocumentationFile = New System.Windows.Forms.CheckBox()
+            Me.chkRegisterForCOM = New System.Windows.Forms.CheckBox()
+            Me.txtXMLDocumentationFile = New System.Windows.Forms.TextBox()
+            Me.btnAdvanced = New System.Windows.Forms.Button()
+            Me.overarchingTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
+            Me.outputTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
+            Me.outputLineLabel = New System.Windows.Forms.Label()
+            Me.outputLabel = New System.Windows.Forms.Label()
+            Me.generalHeaderTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
+            Me.generalLineLabel = New System.Windows.Forms.Label()
+            Me.generalLabel = New System.Windows.Forms.Label()
+            Me.treatWarningsAsErrorsTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
+            Me.treatWarningsAsErrorsLineLabel = New System.Windows.Forms.Label()
+            Me.treatWarningsAsErrorsLabel = New System.Windows.Forms.Label()
+            Me.errorsAndWarningsTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
+            Me.errorsAndWarningsLineLabel = New System.Windows.Forms.Label()
+            Me.errorsAndWarningsLabel = New System.Windows.Forms.Label()
+            Me.lblSGenOption = New System.Windows.Forms.Label()
+            Me.cboSGenOption = New System.Windows.Forms.ComboBox()
             Me.overarchingTableLayoutPanel.SuspendLayout()
             Me.outputTableLayoutPanel.SuspendLayout()
             Me.generalHeaderTableLayoutPanel.SuspendLayout()
@@ -151,33 +151,28 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             'lblConditionalCompilationSymbols
             '
             resources.ApplyResources(Me.lblConditionalCompilationSymbols, "lblConditionalCompilationSymbols")
-            Me.lblConditionalCompilationSymbols.Margin = New System.Windows.Forms.Padding(23, 11, 3, 3)
             Me.lblConditionalCompilationSymbols.Name = "lblConditionalCompilationSymbols"
             '
             'txtConditionalCompilationSymbols
             '
             resources.ApplyResources(Me.txtConditionalCompilationSymbols, "txtConditionalCompilationSymbols")
-            Me.txtConditionalCompilationSymbols.Margin = New System.Windows.Forms.Padding(3, 11, 3, 3)
             Me.txtConditionalCompilationSymbols.Name = "txtConditionalCompilationSymbols"
             '
             'chkDefineDebug
             '
             resources.ApplyResources(Me.chkDefineDebug, "chkDefineDebug")
             Me.overarchingTableLayoutPanel.SetColumnSpan(Me.chkDefineDebug, 3)
-            Me.chkDefineDebug.Margin = New System.Windows.Forms.Padding(23, 3, 3, 3)
             Me.chkDefineDebug.Name = "chkDefineDebug"
             '
             'chkDefineTrace
             '
             resources.ApplyResources(Me.chkDefineTrace, "chkDefineTrace")
             Me.overarchingTableLayoutPanel.SetColumnSpan(Me.chkDefineTrace, 3)
-            Me.chkDefineTrace.Margin = New System.Windows.Forms.Padding(23, 3, 3, 3)
             Me.chkDefineTrace.Name = "chkDefineTrace"
             '
             'lblPlatformTarget
             '
             resources.ApplyResources(Me.lblPlatformTarget, "lblPlatformTarget")
-            Me.lblPlatformTarget.Margin = New System.Windows.Forms.Padding(23, 3, 3, 3)
             Me.lblPlatformTarget.Name = "lblPlatformTarget"
             '
             'cboPlatformTarget
@@ -191,27 +186,23 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             '
             resources.ApplyResources(Me.chkPrefer32Bit, "chkPrefer32Bit")
             Me.overarchingTableLayoutPanel.SetColumnSpan(Me.chkPrefer32Bit, 3)
-            Me.chkPrefer32Bit.Margin = New System.Windows.Forms.Padding(23, 3, 3, 3)
             Me.chkPrefer32Bit.Name = "chkPrefer32Bit"
             '
             'chkAllowUnsafeCode
             '
             resources.ApplyResources(Me.chkAllowUnsafeCode, "chkAllowUnsafeCode")
             Me.overarchingTableLayoutPanel.SetColumnSpan(Me.chkAllowUnsafeCode, 3)
-            Me.chkAllowUnsafeCode.Margin = New System.Windows.Forms.Padding(23, 3, 3, 3)
             Me.chkAllowUnsafeCode.Name = "chkAllowUnsafeCode"
             '
             'chkOptimizeCode
             '
             resources.ApplyResources(Me.chkOptimizeCode, "chkOptimizeCode")
             Me.overarchingTableLayoutPanel.SetColumnSpan(Me.chkOptimizeCode, 3)
-            Me.chkOptimizeCode.Margin = New System.Windows.Forms.Padding(23, 3, 3, 11)
             Me.chkOptimizeCode.Name = "chkOptimizeCode"
             '
             'lblWarningLevel
             '
             resources.ApplyResources(Me.lblWarningLevel, "lblWarningLevel")
-            Me.lblWarningLevel.Margin = New System.Windows.Forms.Padding(23, 11, 3, 3)
             Me.lblWarningLevel.Name = "lblWarningLevel"
             '
             'cboWarningLevel
@@ -219,40 +210,34 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             resources.ApplyResources(Me.cboWarningLevel, "cboWarningLevel")
             Me.cboWarningLevel.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
             Me.cboWarningLevel.FormattingEnabled = True
-            Me.cboWarningLevel.Items.AddRange(New Object() {"0", "1", "2", "3", "4"})
-            Me.cboWarningLevel.Margin = New System.Windows.Forms.Padding(3, 11, 3, 3)
+            Me.cboWarningLevel.Items.AddRange(New Object() {resources.GetString("cboWarningLevel.Items"), resources.GetString("cboWarningLevel.Items1"), resources.GetString("cboWarningLevel.Items2"), resources.GetString("cboWarningLevel.Items3"), resources.GetString("cboWarningLevel.Items4")})
             Me.cboWarningLevel.Name = "cboWarningLevel"
             '
             'lblSupressWarnings
             '
             resources.ApplyResources(Me.lblSupressWarnings, "lblSupressWarnings")
-            Me.lblSupressWarnings.Margin = New System.Windows.Forms.Padding(23, 3, 3, 11)
             Me.lblSupressWarnings.Name = "lblSupressWarnings"
             '
             'txtSupressWarnings
             '
             resources.ApplyResources(Me.txtSupressWarnings, "txtSupressWarnings")
-            Me.txtSupressWarnings.Margin = New System.Windows.Forms.Padding(3, 3, 3, 11)
             Me.txtSupressWarnings.Name = "txtSupressWarnings"
             '
             'rbWarningNone
             '
             resources.ApplyResources(Me.rbWarningNone, "rbWarningNone")
             Me.overarchingTableLayoutPanel.SetColumnSpan(Me.rbWarningNone, 3)
-            Me.rbWarningNone.Margin = New System.Windows.Forms.Padding(23, 11, 3, 3)
             Me.rbWarningNone.Name = "rbWarningNone"
             '
             'rbWarningSpecific
             '
             resources.ApplyResources(Me.rbWarningSpecific, "rbWarningSpecific")
-            Me.rbWarningSpecific.Margin = New System.Windows.Forms.Padding(23, 3, 3, 11)
             Me.rbWarningSpecific.Name = "rbWarningSpecific"
             '
             'rbWarningAll
             '
             resources.ApplyResources(Me.rbWarningAll, "rbWarningAll")
             Me.overarchingTableLayoutPanel.SetColumnSpan(Me.rbWarningAll, 3)
-            Me.rbWarningAll.Margin = New System.Windows.Forms.Padding(23, 3, 3, 3)
             Me.rbWarningAll.Name = "rbWarningAll"
             '
             'txtSpecificWarnings
@@ -263,32 +248,27 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             'lblOutputPath
             '
             resources.ApplyResources(Me.lblOutputPath, "lblOutputPath")
-            Me.lblOutputPath.Margin = New System.Windows.Forms.Padding(23, 11, 3, 3)
             Me.lblOutputPath.Name = "lblOutputPath"
             '
             'txtOutputPath
             '
             resources.ApplyResources(Me.txtOutputPath, "txtOutputPath")
-            Me.txtOutputPath.Margin = New System.Windows.Forms.Padding(3, 11, 3, 3)
             Me.txtOutputPath.Name = "txtOutputPath"
             '
             'btnOutputPathBrowse
             '
             resources.ApplyResources(Me.btnOutputPathBrowse, "btnOutputPathBrowse")
-            Me.btnOutputPathBrowse.Margin = New System.Windows.Forms.Padding(3, 11, 0, 3)
             Me.btnOutputPathBrowse.Name = "btnOutputPathBrowse"
             '
             'chkXMLDocumentationFile
             '
             resources.ApplyResources(Me.chkXMLDocumentationFile, "chkXMLDocumentationFile")
-            Me.chkXMLDocumentationFile.Margin = New System.Windows.Forms.Padding(23, 3, 3, 3)
             Me.chkXMLDocumentationFile.Name = "chkXMLDocumentationFile"
             '
             'chkRegisterForCOM
             '
             resources.ApplyResources(Me.chkRegisterForCOM, "chkRegisterForCOM")
             Me.overarchingTableLayoutPanel.SetColumnSpan(Me.chkRegisterForCOM, 3)
-            Me.chkRegisterForCOM.Margin = New System.Windows.Forms.Padding(23, 3, 3, 3)
             Me.chkRegisterForCOM.Name = "chkRegisterForCOM"
             '
             'txtXMLDocumentationFile
@@ -299,15 +279,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             'btnAdvanced
             '
             resources.ApplyResources(Me.btnAdvanced, "btnAdvanced")
-            Me.btnAdvanced.Margin = New System.Windows.Forms.Padding(3, 3, 0, 3)
             Me.btnAdvanced.Name = "btnAdvanced"
             '
             'overarchingTableLayoutPanel
             '
             resources.ApplyResources(Me.overarchingTableLayoutPanel, "overarchingTableLayoutPanel")
-            Me.overarchingTableLayoutPanel.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle)
-            Me.overarchingTableLayoutPanel.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
-            Me.overarchingTableLayoutPanel.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle)
             Me.overarchingTableLayoutPanel.Controls.Add(Me.outputTableLayoutPanel, 0, 15)
             Me.overarchingTableLayoutPanel.Controls.Add(Me.generalHeaderTableLayoutPanel, 0, 0)
             Me.overarchingTableLayoutPanel.Controls.Add(Me.treatWarningsAsErrorsTableLayoutPanel, 0, 11)
@@ -338,133 +314,91 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.overarchingTableLayoutPanel.Controls.Add(Me.lblSGenOption, 0, 19)
             Me.overarchingTableLayoutPanel.Controls.Add(Me.cboSGenOption, 1, 19)
             Me.overarchingTableLayoutPanel.Controls.Add(Me.btnAdvanced, 2, 20)
-            Me.overarchingTableLayoutPanel.Margin = New System.Windows.Forms.Padding(0)
             Me.overarchingTableLayoutPanel.Name = "overarchingTableLayoutPanel"
-            Me.overarchingTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
-            Me.overarchingTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
-            Me.overarchingTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
-            Me.overarchingTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
-            Me.overarchingTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
-            Me.overarchingTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
-            Me.overarchingTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
-            Me.overarchingTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
-            Me.overarchingTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
-            Me.overarchingTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
-            Me.overarchingTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
-            Me.overarchingTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
-            Me.overarchingTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
-            Me.overarchingTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
-            Me.overarchingTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
-            Me.overarchingTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
-            Me.overarchingTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
-            Me.overarchingTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
-            Me.overarchingTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
-            Me.overarchingTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
             '
             'outputTableLayoutPanel
             '
             resources.ApplyResources(Me.outputTableLayoutPanel, "outputTableLayoutPanel")
             Me.overarchingTableLayoutPanel.SetColumnSpan(Me.outputTableLayoutPanel, 3)
-            Me.outputTableLayoutPanel.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle)
-            Me.outputTableLayoutPanel.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
             Me.outputTableLayoutPanel.Controls.Add(Me.outputLineLabel, 1, 0)
             Me.outputTableLayoutPanel.Controls.Add(Me.outputLabel, 0, 0)
-            Me.outputTableLayoutPanel.Margin = New System.Windows.Forms.Padding(0)
             Me.outputTableLayoutPanel.Name = "outputTableLayoutPanel"
-            Me.outputTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
             '
             'outputLineLabel
             '
+            Me.outputLineLabel.AccessibleRole = System.Windows.Forms.AccessibleRole.Separator
             resources.ApplyResources(Me.outputLineLabel, "outputLineLabel")
             Me.outputLineLabel.BackColor = System.Drawing.SystemColors.ControlDark
-            Me.outputLineLabel.Margin = New System.Windows.Forms.Padding(3, 0, 0, 0)
             Me.outputLineLabel.Name = "outputLineLabel"
             '
             'outputLabel
             '
             resources.ApplyResources(Me.outputLabel, "outputLabel")
-            Me.outputLabel.Margin = New System.Windows.Forms.Padding(3, 0, 3, 0)
             Me.outputLabel.Name = "outputLabel"
             '
             'generalHeaderTableLayoutPanel
             '
             resources.ApplyResources(Me.generalHeaderTableLayoutPanel, "generalHeaderTableLayoutPanel")
             Me.overarchingTableLayoutPanel.SetColumnSpan(Me.generalHeaderTableLayoutPanel, 3)
-            Me.generalHeaderTableLayoutPanel.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle)
-            Me.generalHeaderTableLayoutPanel.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
             Me.generalHeaderTableLayoutPanel.Controls.Add(Me.generalLineLabel, 1, 0)
             Me.generalHeaderTableLayoutPanel.Controls.Add(Me.generalLabel, 0, 0)
-            Me.generalHeaderTableLayoutPanel.Margin = New System.Windows.Forms.Padding(0)
             Me.generalHeaderTableLayoutPanel.Name = "generalHeaderTableLayoutPanel"
-            Me.generalHeaderTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
             '
             'generalLineLabel
             '
+            Me.generalLineLabel.AccessibleRole = System.Windows.Forms.AccessibleRole.Separator
             resources.ApplyResources(Me.generalLineLabel, "generalLineLabel")
             Me.generalLineLabel.BackColor = System.Drawing.SystemColors.ControlDark
-            Me.generalLineLabel.Margin = New System.Windows.Forms.Padding(3, 0, 0, 0)
             Me.generalLineLabel.Name = "generalLineLabel"
             '
             'generalLabel
             '
             resources.ApplyResources(Me.generalLabel, "generalLabel")
-            Me.generalLabel.Margin = New System.Windows.Forms.Padding(0, 0, 3, 0)
             Me.generalLabel.Name = "generalLabel"
             '
             'treatWarningsAsErrorsTableLayoutPanel
             '
             resources.ApplyResources(Me.treatWarningsAsErrorsTableLayoutPanel, "treatWarningsAsErrorsTableLayoutPanel")
             Me.overarchingTableLayoutPanel.SetColumnSpan(Me.treatWarningsAsErrorsTableLayoutPanel, 3)
-            Me.treatWarningsAsErrorsTableLayoutPanel.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle)
-            Me.treatWarningsAsErrorsTableLayoutPanel.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
             Me.treatWarningsAsErrorsTableLayoutPanel.Controls.Add(Me.treatWarningsAsErrorsLineLabel, 1, 0)
             Me.treatWarningsAsErrorsTableLayoutPanel.Controls.Add(Me.treatWarningsAsErrorsLabel, 0, 0)
-            Me.treatWarningsAsErrorsTableLayoutPanel.Margin = New System.Windows.Forms.Padding(0)
             Me.treatWarningsAsErrorsTableLayoutPanel.Name = "treatWarningsAsErrorsTableLayoutPanel"
-            Me.treatWarningsAsErrorsTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
             '
             'treatWarningsAsErrorsLineLabel
             '
+            Me.treatWarningsAsErrorsLineLabel.AccessibleRole = System.Windows.Forms.AccessibleRole.Separator
             resources.ApplyResources(Me.treatWarningsAsErrorsLineLabel, "treatWarningsAsErrorsLineLabel")
             Me.treatWarningsAsErrorsLineLabel.BackColor = System.Drawing.SystemColors.ControlDark
-            Me.treatWarningsAsErrorsLineLabel.Margin = New System.Windows.Forms.Padding(3, 0, 0, 0)
             Me.treatWarningsAsErrorsLineLabel.Name = "treatWarningsAsErrorsLineLabel"
             '
             'treatWarningsAsErrorsLabel
             '
             resources.ApplyResources(Me.treatWarningsAsErrorsLabel, "treatWarningsAsErrorsLabel")
-            Me.treatWarningsAsErrorsLabel.Margin = New System.Windows.Forms.Padding(0, 0, 3, 0)
             Me.treatWarningsAsErrorsLabel.Name = "treatWarningsAsErrorsLabel"
             '
             'errorsAndWarningsTableLayoutPanel
             '
             resources.ApplyResources(Me.errorsAndWarningsTableLayoutPanel, "errorsAndWarningsTableLayoutPanel")
             Me.overarchingTableLayoutPanel.SetColumnSpan(Me.errorsAndWarningsTableLayoutPanel, 3)
-            Me.errorsAndWarningsTableLayoutPanel.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle)
-            Me.errorsAndWarningsTableLayoutPanel.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
             Me.errorsAndWarningsTableLayoutPanel.Controls.Add(Me.errorsAndWarningsLineLabel, 1, 0)
             Me.errorsAndWarningsTableLayoutPanel.Controls.Add(Me.errorsAndWarningsLabel, 0, 0)
-            Me.errorsAndWarningsTableLayoutPanel.Margin = New System.Windows.Forms.Padding(0)
             Me.errorsAndWarningsTableLayoutPanel.Name = "errorsAndWarningsTableLayoutPanel"
-            Me.errorsAndWarningsTableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle)
             '
             'errorsAndWarningsLineLabel
             '
+            Me.errorsAndWarningsLineLabel.AccessibleRole = System.Windows.Forms.AccessibleRole.Separator
             resources.ApplyResources(Me.errorsAndWarningsLineLabel, "errorsAndWarningsLineLabel")
             Me.errorsAndWarningsLineLabel.BackColor = System.Drawing.SystemColors.ControlDark
-            Me.errorsAndWarningsLineLabel.Margin = New System.Windows.Forms.Padding(3, 0, 0, 0)
             Me.errorsAndWarningsLineLabel.Name = "errorsAndWarningsLineLabel"
             '
             'errorsAndWarningsLabel
             '
             resources.ApplyResources(Me.errorsAndWarningsLabel, "errorsAndWarningsLabel")
-            Me.errorsAndWarningsLabel.Margin = New System.Windows.Forms.Padding(0, 0, 3, 0)
             Me.errorsAndWarningsLabel.Name = "errorsAndWarningsLabel"
             '
             'lblSGenOption
             '
             resources.ApplyResources(Me.lblSGenOption, "lblSGenOption")
-            Me.lblSGenOption.Margin = New System.Windows.Forms.Padding(23, 11, 3, 3)
             Me.lblSGenOption.Name = "lblSGenOption"
             '
             'cboSGenOption
@@ -472,7 +406,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             resources.ApplyResources(Me.cboSGenOption, "cboSGenOption")
             Me.cboSGenOption.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
             Me.cboSGenOption.FormattingEnabled = True
-            Me.cboSGenOption.MinimumSize = New System.Drawing.Size(125, 0)
             Me.cboSGenOption.Name = "cboSGenOption"
             '
             'BuildPropPage

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPageBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPageBase.vb
@@ -12,6 +12,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     ''' Base class for the C# / VB build property pages
     ''' </summary>
     ''' <remarks></remarks>
+    <TypeDescriptionProvider(GetType(AbstractControlTypeDescriptionProvider(Of BuildPropPageBase, PropPageUserControlBase)))>
     Friend MustInherit Class BuildPropPageBase
         Inherits PropPageUserControlBase
 


### PR DESCRIPTION
Tweaked the layout of the build property page:

- Aligned all labels horizontally with controls, removed 3 "design pixels" prefix that each label had
- Aligned "Generate serialization assembly" label vertically with its control
- Changed gaps between controls to match standard spaces (6 "design pixels" vertically between related controls)

To do this, I needed to do a few things first:

1. Added DependentUpon to the RESX so that they group under their controls
2. Needed to add the ability to design "abstract" controls via AbstractControlTypeDescriptionProvider
3. Needed to upgrade Form/resx from "2.0" -> "4.0"

Each of these are in their own commit if you're interested in the details (the churn for 3 is quite great).

### Before:
![image](https://cloud.githubusercontent.com/assets/1103906/15104484/eb78e64a-156d-11e6-99f9-52e865ecc562.png)

### After:
![image](https://cloud.githubusercontent.com/assets/1103906/15104487/f4952dec-156d-11e6-9969-0a69556db48d.png)

### Main changes highlighted:
![image](https://cloud.githubusercontent.com/assets/1103906/15104507/40be2a34-156e-11e6-8f7c-9b9017cd71ea.png)
