### PR TITLE
AppDesigner folders have the wrong expanded icon

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/ProjectSystem/PropertiesFolderProjectTreePropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/ProjectSystem/PropertiesFolderProjectTreePropertiesProviderTests.cs
@@ -312,6 +312,64 @@ Root (flags: {ProjectRoot})
             AssertAreEquivalent(expectedTree, result);
         }
 
+
+        [Theory]
+        [InlineData(@"
+Root (flags: {ProjectRoot})
+    Properties (flags: {Folder})
+        Folder (flags: {Folder})
+", @"
+Root (flags: {ProjectRoot})
+    Properties (flags: {Folder AppDesignerFolder BubbleUp}), Icon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 1}, ExpandedIcon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 1}
+        Folder (flags: {Folder})
+")]
+        public void ChangePropertyValues_TreeWithPropertiesCandidate_SetsIconAndExpandedIconToAppDesignerFolder(string input, string expected)
+        {
+            var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => true);
+            var imageProvider = IProjectImageProviderFactory.ImplementGetProjectImage(ProjectImageKey.AppDesignerFolder, new ProjectImageMoniker(new Guid("AE27A6B0-E345-4288-96DF-5EAF394EE369"), 1));
+            var propertiesProvider = CreateInstance(imageProvider, designerService);
+
+            var inputTree = ProjectTreeParser.Parse(input);
+            var expectedTree = ProjectTreeParser.Parse(expected);
+
+            var result = propertiesProvider.ChangePropertyValuesForEntireTree(inputTree);
+
+            AssertAreEquivalent(expectedTree, result);
+        }
+
+        [Theory]
+        [InlineData(@"
+Root (flags: {ProjectRoot})
+    Properties (flags: {Folder}), Icon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 1}, ExpandedIcon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 2}
+        Folder (flags: {Folder})
+", @"
+Root (flags: {ProjectRoot})
+    Properties (flags: {Folder AppDesignerFolder BubbleUp}), Icon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 1}, ExpandedIcon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 2}
+        Folder (flags: {Folder})
+")]
+        [InlineData(@"
+Root (flags: {ProjectRoot})
+    Properties (flags: {Folder}), Icon: {}, ExpandedIcon: {}
+        Folder (flags: {Folder})
+", @"
+Root (flags: {ProjectRoot})
+    Properties (flags: {Folder AppDesignerFolder BubbleUp}), Icon: {}, ExpandedIcon: {}
+        Folder (flags: {Folder})
+")]
+        public void ChangePropertyValues_TreeWithPropertiesCandidateWhenImageProviderReturnsNull_DoesNotSetIconAndExpandedIcon(string input, string expected)
+        {
+            var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => true);
+            var imageProvider = IProjectImageProviderFactory.ImplementGetProjectImage(ProjectImageKey.AppDesignerFolder, null);
+            var propertiesProvider = CreateInstance(imageProvider, designerService);
+
+            var inputTree = ProjectTreeParser.Parse(input);
+            var expectedTree = ProjectTreeParser.Parse(expected);
+
+            var result = propertiesProvider.ChangePropertyValuesForEntireTree(inputTree);
+
+            AssertAreEquivalent(expectedTree, result);
+        }
+
         [Fact]
         public void ChangePropertyValues_ProjectWithNullPropertiesFolder_DefaultsToProperties()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/ProjectSystem/ProjectTreeParserTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/ProjectSystem/ProjectTreeParserTests.cs
@@ -47,6 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         [InlineData(@"Root (visibility: visible,   ")]
         [InlineData(@"Root (flags: { ")]
         [InlineData(@"Root (flags: {  ")]
+        [InlineData(@"Root, Icon: {407FAC73-908A-4477-8176-A3128544AE4F }")]
         public void Parse_IdExpected_EncounteredDelimiter_ThrowsFormat(string input)
         {   
             AssertThrows(input, ProjectTreeFormatError.IdExpected_EncounteredDelimiter);
@@ -58,6 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         [InlineData(@"Root (visibility: ")]
         [InlineData(@"Root (visibility: visible, ")]
         [InlineData(@"Root (flags: {")]
+        [InlineData(@"Root, Icon: {")]
         public void Parse_IdExpected_EncounteredEndOfString_ThrowsFormat(string input)
         {
             AssertThrows(input, ProjectTreeFormatError.IdExpected_EncounteredEndOfString);
@@ -66,6 +68,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         [Theory]
         [InlineData(@"Root, FilePath:")]
+        [InlineData(@"Root, FilePath: ""C:\Temp"",")]
         [InlineData(@"Root (),")]
         [InlineData(@"Root (visibility")]
         [InlineData(@"Root (visibility:")]
@@ -103,6 +106,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
         [InlineData(@"Root (), Filepath")]
         [InlineData(@"Root (), filepath")]
         [InlineData(@"Root (), filepath:")]
+        [InlineData(@"Root (), icon:")]
+        [InlineData(@"Root (), expandedIcon:")]
+        [InlineData(@"Root (), Unrecognized:")]
+        [InlineData(@"Root (), Icon: {407FAC73-908A-4477-8176-A3128544AE4F 1}, unreognized:")]
         public void Parse_UnrecognizedPropertyName_ThrowsFormat(string input)
         {
             AssertThrows(input, ProjectTreeFormatError.UnrecognizedPropertyName);
@@ -121,12 +128,37 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         [Theory]
-        [InlineData(@"Root, FilePath: ""C:\Temp"",")]
         [InlineData(@"Root, FilePath: ""C:\Temp""""")]
         [InlineData(@"Root, FilePath: ""C:\Temp""A")]
         public void Parse_EndOfStringExpected_ThrowsFormat(string input)
         {
             AssertThrows(input, ProjectTreeFormatError.EndOfStringExpected);
+        }
+
+        [Theory]
+        [InlineData(@"Root, Icon: {1}")]
+        [InlineData(@"Root, Icon: {A}")]
+        [InlineData(@"Root, Icon: {{407FAC73-908A-4477-8176-A3128544AE4F}")]
+        [InlineData(@"Root, ExpandedIcon: {1}")]
+        [InlineData(@"Root, ExpandedIcon: {A}")]
+        [InlineData(@"Root, ExpandedIcon: {{407FAC73-908A-4477-8176-A3128544AE4F}")]
+        [InlineData(@"Root, ExpandedIcon: {1}")]
+        [InlineData(@"Root, ExpandedIcon: {A}")]
+        [InlineData(@"Root, Icon: {407FAC73-908A-4477-8176-A3128544AE4F 1}, ExpandedIcon: {1}")]
+        [InlineData(@"Root, Icon: {407FAC73-908A-4477-8176-A3128544AE4F 1}, ExpandedIcon: {A}")]
+        [InlineData(@"Root, Icon: {407FAC73-908A-4477-8176-A3128544AE4F 1}, ExpandedIcon: {{407FAC73-908A-4477-8176-A3128544AE4F}")]
+        public void Parse_GuidExpected_ThrowsFormat(string input)
+        {
+            AssertThrows(input, ProjectTreeFormatError.GuidExpected);
+        }
+
+        [Theory]
+        [InlineData(@"Root, Icon: {407FAC73-908A-4477-8176-A3128544AE4F A}")]
+        [InlineData(@"Root, ExpandedIcon: {407FAC73-908A-4477-8176-A3128544AE4F A}")]
+        [InlineData(@"Root, Icon: {407FAC73-908A-4477-8176-A3128544AE4F 1}, ExpandedIcon: {407FAC73-908A-4477-8176-A3128544AE4F A}")]
+        public void Parse_IntegerExpected_ThrowsFormat(string input)
+        {
+            AssertThrows(input, ProjectTreeFormatError.IntegerExpected);
         }
 
         // Input                                                                                    // Expected
@@ -204,16 +236,16 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         // Input                                                                                    // Expected
         [Theory]
-        [InlineData(@"Project Root (flags: {})",                                             @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]""")]
-        [InlineData(@"Project Root (flags: {A})",                                            @"Project Root[caption] (visibility: visible, flags: {A[capability]}), FilePath: ""[filepath]""")]
-        [InlineData(@"Project Root (flags: {A B})",                                          @"Project Root[caption] (visibility: visible, flags: {A[capability] B[capability]}), FilePath: ""[filepath]""")]
-        [InlineData(@"Project Root (flags: {A B C})",                                        @"Project Root[caption] (visibility: visible, flags: {A[capability] B[capability] C[capability]}), FilePath: ""[filepath]""")]
-        [InlineData(@"Project Root (flags: {Folder})",                                       @"Project Root[caption] (visibility: visible, flags: {Folder[capability]}), FilePath: ""[filepath]""")]
-        [InlineData(@"Project Root (flags: {Folder IncludeInProjectCandidate})",             @"Project Root[caption] (visibility: visible, flags: {Folder[capability] IncludeInProjectCandidate[capability]}), FilePath: ""[filepath]""")]
-        [InlineData(@"Project Root (flags: {AppDesigner Folder IncludeInProjectCandidate})", @"Project Root[caption] (visibility: visible, flags: {AppDesigner[capability] Folder[capability] IncludeInProjectCandidate[capability]}), FilePath: ""[filepath]""")]
-        [InlineData(@"Project Root (flags: {App:Designer})",                                 @"Project Root[caption] (visibility: visible, flags: {App:Designer[capability]}), FilePath: ""[filepath]""")]
-        [InlineData(@"Project Root (visibility: visible, flags: {App:Designer})",            @"Project Root[caption] (visibility: visible, flags: {App:Designer[capability]}), FilePath: ""[filepath]""")]
-        [InlineData(@"Project Root (flags: {App:Designer}, visibility: visible)",            @"Project Root[caption] (visibility: visible, flags: {App:Designer[capability]}), FilePath: ""[filepath]""")]
+        [InlineData(@"Project Root (flags: {})",                                                    @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]""")]
+        [InlineData(@"Project Root (flags: {A})",                                                   @"Project Root[caption] (visibility: visible, flags: {A[capability]}), FilePath: ""[filepath]""")]
+        [InlineData(@"Project Root (flags: {A B})",                                                 @"Project Root[caption] (visibility: visible, flags: {A[capability] B[capability]}), FilePath: ""[filepath]""")]
+        [InlineData(@"Project Root (flags: {A B C})",                                               @"Project Root[caption] (visibility: visible, flags: {A[capability] B[capability] C[capability]}), FilePath: ""[filepath]""")]
+        [InlineData(@"Project Root (flags: {Folder})",                                              @"Project Root[caption] (visibility: visible, flags: {Folder[capability]}), FilePath: ""[filepath]""")]
+        [InlineData(@"Project Root (flags: {Folder IncludeInProjectCandidate})",                    @"Project Root[caption] (visibility: visible, flags: {Folder[capability] IncludeInProjectCandidate[capability]}), FilePath: ""[filepath]""")]
+        [InlineData(@"Project Root (flags: {AppDesigner Folder IncludeInProjectCandidate})",        @"Project Root[caption] (visibility: visible, flags: {AppDesigner[capability] Folder[capability] IncludeInProjectCandidate[capability]}), FilePath: ""[filepath]""")]
+        [InlineData(@"Project Root (flags: {App:Designer})",                                        @"Project Root[caption] (visibility: visible, flags: {App:Designer[capability]}), FilePath: ""[filepath]""")]
+        [InlineData(@"Project Root (visibility: visible, flags: {App:Designer})",                   @"Project Root[caption] (visibility: visible, flags: {App:Designer[capability]}), FilePath: ""[filepath]""")]
+        [InlineData(@"Project Root (flags: {App:Designer}, visibility: visible)",                   @"Project Root[caption] (visibility: visible, flags: {App:Designer[capability]}), FilePath: ""[filepath]""")]
         public void Parse_RootWithCapabilities_CanParse(string input, string expected)
         {
             AssertProjectTree(input, expected);
@@ -233,6 +265,23 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public void Parse_RootWithFilePath_CanParse(string input, string expected)
         {
             AssertProjectTree(input, expected);
+        }
+
+        // Input                                                                                                                                    // Expected
+        [Theory]
+        [InlineData(@"Project Root (), Icon: {}",                                                                                                   @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]"", Icon: {[icon]}, ExpandedIcon: {[icon]}")]
+        [InlineData(@"Project Root (), Icon: {}, ExpandedIcon: {}",                                                                                 @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]"", Icon: {[icon]}, ExpandedIcon: {[icon]}")]
+        [InlineData(@"Project Root (), ExpandedIcon: {}",                                                                                           @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]"", Icon: {[icon]}, ExpandedIcon: {[icon]}")]
+        [InlineData(@"Project Root (), ExpandedIcon: {}, Icon: {}",                                                                                 @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]"", Icon: {[icon]}, ExpandedIcon: {[icon]}")]
+        [InlineData(@"Project Root (), Icon: {41F80260-959C-4556-852C-F7D1B31DD201 0}",                                                             @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]"", Icon: {41F80260-959C-4556-852C-F7D1B31DD201 0[icon]}, ExpandedIcon: {[icon]}")]
+        [InlineData(@"Project Root (), Icon: {41F80260-959C-4556-852C-F7D1B31DD201 1}",                                                             @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]"", Icon: {41F80260-959C-4556-852C-F7D1B31DD201 1[icon]}, ExpandedIcon: {[icon]}")]
+        [InlineData(@"Project Root (), Icon: {41F80260-959C-4556-852C-F7D1B31DD201 2}",                                                             @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]"", Icon: {41F80260-959C-4556-852C-F7D1B31DD201 2[icon]}, ExpandedIcon: {[icon]}")]
+        [InlineData(@"Project Root (), Icon: {41F80260-959C-4556-852C-F7D1B31DD201 10}",                                                            @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]"", Icon: {41F80260-959C-4556-852C-F7D1B31DD201 10[icon]}, ExpandedIcon: {[icon]}")]
+        [InlineData(@"Project Root (), Icon: {41F80260-959C-4556-852C-F7D1B31DD201 10}, ExpandedIcon: {41F80260-959C-4556-852C-F7D1B31DD201 0}",    @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]"", Icon: {41F80260-959C-4556-852C-F7D1B31DD201 10[icon]}, ExpandedIcon: {41F80260-959C-4556-852C-F7D1B31DD201 0[icon]}")]
+        [InlineData(@"Project Root (), Icon: {41F80260-959C-4556-852C-F7D1B31DD201 10}, ExpandedIcon: {F88CB78E-D07D-4131-8E53-B601CEB30517 0}",    @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]"", Icon: {41F80260-959C-4556-852C-F7D1B31DD201 10[icon]}, ExpandedIcon: {F88CB78E-D07D-4131-8E53-B601CEB30517 0[icon]}")]
+        public void Parse_RootWithIcons_CanParse(string input, string expected)
+        {
+            AssertProjectTree(input, expected, ProjectTreeWriterOptions.AllProperties);
         }
 
         [Theory]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeFormatError.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeFormatError.cs
@@ -14,5 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         UnrecognizedPropertyValue,
         IndentTooManyLevels,
         MultipleRoots,
+        IntegerExpected,
+        GuidExpected,
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectTree.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectTree.cs
@@ -77,15 +77,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 get { return Children; }
             }
 
-            ProjectImageMoniker IProjectTree.ExpandedIcon
+            public ProjectImageMoniker Icon
             {
-                get
-                {
-                    throw new NotImplementedException();
-                }
+                get;
+                set;
             }
 
-            public ProjectImageMoniker Icon
+            public ProjectImageMoniker ExpandedIcon
             {
                 get;
                 set;
@@ -188,7 +186,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             IProjectTree IProjectTree.SetExpandedIcon(ProjectImageMoniker expandedIcon)
             {
-                throw new NotImplementedException();
+                ExpandedIcon = expandedIcon;
+
+                return this;
             }
 
             IProjectTree IProjectTree.SetIcon(ProjectImageMoniker icon)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.cs
@@ -183,7 +183,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                     break;
 
                 default:
-                    throw _tokenizer.FormatException(ProjectTreeFormatError.UnrecognizedPropertyName, "Expected 'visibility' or 'flags', but encountered '{propertyName}'.");
+                    throw _tokenizer.FormatException(ProjectTreeFormatError.UnrecognizedPropertyName, $"Expected 'visibility' or 'flags', but encountered '{propertyName}'.");
             }
         }
 
@@ -204,7 +204,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                     break;
 
                 default:
-                    throw _tokenizer.FormatException(ProjectTreeFormatError.UnrecognizedPropertyValue, "Expected 'visible' or 'invisible', but encountered '{visibility}'.");
+                    throw _tokenizer.FormatException(ProjectTreeFormatError.UnrecognizedPropertyValue, $"Expected 'visible' or 'invisible', but encountered '{visibility}'.");
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriter.cs
@@ -47,6 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             WriteCaption(tree);
             WriteProperties(tree);
             WriteFilePath(tree);
+            WriteIcons(tree);
             WriteChildren(tree, indentLevel);
         }
 
@@ -160,6 +161,32 @@ namespace Microsoft.VisualStudio.ProjectSystem
             }
 
             _builder.Append('}');
+        }
+
+        private void WriteIcons(IProjectTree tree)
+        {
+            if (!_options.HasFlag(ProjectTreeWriterOptions.Icons))
+                return;
+
+            WriteIcon("Icon", tree.Icon);
+            WriteIcon("ExpandedIcon", tree.ExpandedIcon);
+        }
+
+        private void WriteIcon(string name, ProjectImageMoniker icon)
+        {
+            _builder.AppendFormat(", {0}: {{", name);
+
+            if (icon != null)
+            {
+                _builder.AppendFormat("{1} {2}", name, icon.Guid.ToString("D").ToUpperInvariant(), icon.Id);
+            }
+
+            if (TagElements)
+            {
+                _builder.Append("[icon]");
+            }
+
+            _builder.Append("}");
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriterOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriterOptions.cs
@@ -12,6 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         FilePath = 2,
         Capabilities = 4,
         Visibility = 8,
-        AllProperties = FilePath | Visibility | Capabilities
+        Icons = 16,
+        AllProperties = FilePath | Visibility | Capabilities | Icons
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractSpecialItemProjectTreePropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractSpecialItemProjectTreePropertiesProvider.cs
@@ -57,8 +57,15 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             if (IsSupported && IsCandidateSpecialItem(propertyContext, propertyValues.Flags))
             {
-                propertyValues.Icon = _imageProvider.GetProjectImage(ImageKey);
                 propertyValues.Flags = propertyValues.Flags.Union(Flags);
+
+                // Avoid overwriting icon if the image provider didn't provide one
+                ProjectImageMoniker icon = _imageProvider.GetProjectImage(ImageKey);
+                if (icon != null)
+                {
+                    propertyValues.Icon = icon;
+                    propertyValues.ExpandedIcon = icon;
+                }
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/ProjectSystem/MyProjectFolderProjectTreePropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/ProjectSystem/MyProjectFolderProjectTreePropertiesProviderTests.cs
@@ -334,6 +334,63 @@ Root (flags: {ProjectRoot})
             AssertAreEquivalent(expectedTree, result);
         }
 
+        [Theory]
+        [InlineData(@"
+Root (flags: {ProjectRoot})
+    My Project (flags: {Folder})
+        Folder (flags: {Folder})
+", @"
+Root (flags: {ProjectRoot})
+    My Project (flags: {Folder AppDesignerFolder BubbleUp}), Icon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 1}, ExpandedIcon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 1}
+        Folder (flags: {Folder})
+")]
+        public void ChangePropertyValues_TreeWithPropertiesCandidate_SetsIconAndExpandedIconToAppDesignerFolder(string input, string expected)
+        {
+            var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => true);
+            var imageProvider = IProjectImageProviderFactory.ImplementGetProjectImage(ProjectImageKey.AppDesignerFolder, new ProjectImageMoniker(new Guid("AE27A6B0-E345-4288-96DF-5EAF394EE369"), 1));
+            var propertiesProvider = CreateInstance(imageProvider, designerService);
+
+            var inputTree = ProjectTreeParser.Parse(input);
+            var expectedTree = ProjectTreeParser.Parse(expected);
+
+            var result = propertiesProvider.ChangePropertyValuesForEntireTree(inputTree);
+
+            AssertAreEquivalent(expectedTree, result);
+        }
+
+        [Theory]
+        [InlineData(@"
+Root (flags: {ProjectRoot})
+    My Project (flags: {Folder}), Icon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 1}, ExpandedIcon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 2}
+        Folder (flags: {Folder})
+", @"
+Root (flags: {ProjectRoot})
+    My Project (flags: {Folder AppDesignerFolder BubbleUp}), Icon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 1}, ExpandedIcon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 2}
+        Folder (flags: {Folder})
+")]
+        [InlineData(@"
+Root (flags: {ProjectRoot})
+    My Project (flags: {Folder}), Icon: {}, ExpandedIcon: {}
+        Folder (flags: {Folder})
+", @"
+Root (flags: {ProjectRoot})
+    My Project (flags: {Folder AppDesignerFolder BubbleUp}), Icon: {}, ExpandedIcon: {}
+        Folder (flags: {Folder})
+")]
+        public void ChangePropertyValues_TreeWithPropertiesCandidateWhenImageProviderReturnsNull_DoesNotSetIconAndExpandedIcon(string input, string expected)
+        {
+            var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => true);
+            var imageProvider = IProjectImageProviderFactory.ImplementGetProjectImage(ProjectImageKey.AppDesignerFolder, null);
+            var propertiesProvider = CreateInstance(imageProvider, designerService);
+
+            var inputTree = ProjectTreeParser.Parse(input);
+            var expectedTree = ProjectTreeParser.Parse(expected);
+
+            var result = propertiesProvider.ChangePropertyValuesForEntireTree(inputTree);
+
+            AssertAreEquivalent(expectedTree, result);
+        }
+
         [Fact]
         public void ChangePropertyValues_ProjectWithNullMyProjectFolder_DefaultsToMyProject()
         {


### PR DESCRIPTION
Fixes the expanded icon for AppDesigner folder ("My Project", "Properties") to match csproj/msvbprj.

This involved changing the ProjectTreeWriter/ProjectTreeParser to write/parse Icon and ExpandedIcon.