### PR TITLE
Format property pages

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
@@ -24,7 +24,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     ''' Base class for managed property pages internal used in VisualStudio
     ''' </summary>
     ''' <remarks></remarks>
-    <ComVisible(False)> _
+    <ComVisible(False)>
     Public Class PropPageUserControlBase
         Inherits System.Windows.Forms.UserControl
         Implements IPropertyPageInternal
@@ -85,8 +85,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                         ' Notify child pages that the project reloaded happened if they are
                         ' listening for such a change
-                        If HostDialog IsNot Nothing AndAlso _
-                           HostDialog.PropPage IsNot Nothing AndAlso _
+                        If HostDialog IsNot Nothing AndAlso
+                           HostDialog.PropPage IsNot Nothing AndAlso
                            HostDialog.PropPage.IsInProjectCheckoutSection Then
 
                             HostDialog.PropPage._projectReloadedDuringCheckout = True
@@ -439,7 +439,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Protected ReadOnly Property PropertyPageSite() As OLE.Interop.IPropertyPageSite
             Get
                 If _site IsNot Nothing Then
-                    Dim OleSite As OLE.Interop.IPropertyPageSite = _
+                    Dim OleSite As OLE.Interop.IPropertyPageSite =
                         DirectCast(_site.GetService(GetType(OLE.Interop.IPropertyPageSite)), OLE.Interop.IPropertyPageSite)
                     Debug.Assert(OleSite IsNot Nothing, "IPropertyPageSiteInternal didn't provide an IPropertyPageSite through GetService")
                     Return OleSite
@@ -639,7 +639,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' The property name and DISPIDs must both refer to the same property.
         ''' </remarks>
         Protected Function GetCurrentProperty(ByVal dispid As Integer, ByVal PropertyName As String, ByRef obj As Object) As Boolean
-            PropertyName = common.Utils.NothingToEmptyString(PropertyName) 'Nothing not allowed in GetCommonPropertyDescriptor()
+            PropertyName = Common.Utils.NothingToEmptyString(PropertyName) 'Nothing not allowed in GetCommonPropertyDescriptor()
 
             'Check current property pages
             If GetPropertyFromRunningPages(Me, dispid, obj) Then
@@ -661,7 +661,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     End If
                 Next
 
-                Debug.Assert(IsCommonProperty OrElse IsPropertyOnThisPage, _
+                Debug.Assert(IsCommonProperty OrElse IsPropertyOnThisPage,
                     "GetCurrentProperty: Property was found in an open page, so this time the function will succeed.  However, the property was not " _
                     & "found as a common property or a property on this page, so the same query would fail if the other page were not open.  This probably " _
                     & "indicates an error in the caller.")
@@ -733,7 +733,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <value></value>
         ''' <remarks>When the user selects multiple projects, certain functionality is disabled</remarks>
-        <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)> _
+        <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
         Public ReadOnly Property MultiProjectSelect() As Boolean
             Get
                 Return _multiProjectSelect
@@ -745,7 +745,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <value></value>
         ''' <remarks></remarks>
-        <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)> _
+        <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
         Protected ReadOnly Property ServiceProvider() As Microsoft.VisualStudio.Shell.ServiceProvider
             Get
                 If _serviceProvider Is Nothing Then
@@ -771,7 +771,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <value></value>
         ''' <remarks></remarks>
-        <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)> _
+        <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
         Protected ReadOnly Property DTE() As EnvDTE.DTE
             Get
                 Return _DTE
@@ -783,7 +783,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <value></value>
         ''' <remarks></remarks>
-        <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)> _
+        <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
         Public ReadOnly Property DTEProject() As EnvDTE.Project
             Get
                 Return _DTEProject
@@ -797,7 +797,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <value></value>
         ''' <remarks></remarks>
-        <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)> _
+        <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
         Public ReadOnly Property ProjectProperties() As VSLangProj.ProjectProperties
             Get
                 Return _projectPropertiesObject
@@ -815,7 +815,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
 
             For Each pcd As PropertyControlData In Me.ControlData
-                If pcd.FormControl Is control OrElse _
+                If pcd.FormControl Is control OrElse
                 (pcd.AssociatedControls IsNot Nothing AndAlso Array.IndexOf(pcd.AssociatedControls, control) >= 0) Then
                     'The control is associated with this property control data
                     pcd.EnableAssociatedControl(control, enabled)
@@ -1113,7 +1113,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="DebugMessage">The message to be printed first to trace output.</param>
         ''' <param name="Properties">The properties to print to trace output.</param>
         ''' <remarks></remarks>
-        <Conditional("DEBUG")> _
+        <Conditional("DEBUG")>
         Private Sub TraceTypeDescriptorCollection(ByVal DebugMessage As String, ByVal Properties As PropertyDescriptorCollection)
 #If DEBUG Then
             If Common.Switches.PDExtenders.TraceVerbose Then
@@ -1311,7 +1311,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 'Get the Extender Objects for the properties
                 'This must done after getting the DTE so that ServiceProvider can be obtained
 
-                Dim aem As Microsoft.VisualStudio.Editors.PropertyPages.AutomationExtenderManager = _
+                Dim aem As Microsoft.VisualStudio.Editors.PropertyPages.AutomationExtenderManager =
                     Microsoft.VisualStudio.Editors.PropertyPages.AutomationExtenderManager.GetAutomationExtenderManager(ServiceProvider)
 
                 '... First for the actual objects passed in to SetObjects
@@ -1482,7 +1482,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <remarks>This should normally be overridden in the derived class to provide the page's specific list of
         '''   PropertyControlData.  No need to call the base's default version.
         ''' </remarks>
-        <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)> _
+        <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
         Protected Overridable ReadOnly Property ControlData() As PropertyControlData()
             Get
                 Return New PropertyControlData() {}
@@ -1909,7 +1909,7 @@ NextControl:
                     Control = FirstDirtyControl
                 End If
 
-                Throw New ValidationException(ValidationResult.Failed, ex.Message, Control, innerexception:=ex)
+                Throw New ValidationException(ValidationResult.Failed, ex.Message, Control, InnerException:=ex)
             End Try
 
         End Sub
@@ -2070,7 +2070,7 @@ NextControl:
                             If TypeOf ex Is System.Reflection.TargetInvocationException Then
                                 ex = ex.InnerException
                             End If
-                            Throw New ValidationException(ValidationResult.Failed, _controlData.DisplayPropertyName & ":" & vbCrLf & ex.Message, control, innerexception:=ex)
+                            Throw New ValidationException(ValidationResult.Failed, _controlData.DisplayPropertyName & ":" & vbCrLf & ex.Message, control, InnerException:=ex)
                         End Try
                     Next _controlData
 
@@ -2870,7 +2870,7 @@ NextControl:
         ''' </summary>
         ''' <value></value>
         ''' <remarks></remarks>
-        <Browsable(False)> _
+        <Browsable(False)>
         Public Property IsDirty() As Boolean
             Get
                 Return m_IsDirty
@@ -2956,8 +2956,8 @@ NextControl:
         ''' </summary>
         ''' <value></value>
         ''' <remarks></remarks>
-        <Browsable(False), _
-        DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)> _
+        <Browsable(False),
+        DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
         Protected ReadOnly Property VsUIShellService() As IVsUIShell
             Get
                 If (_UIShellService Is Nothing) Then
@@ -2972,8 +2972,8 @@ NextControl:
         ''' </summary>
         ''' <value></value>
         ''' <remarks></remarks>
-        <Browsable(False), _
-        DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)> _
+        <Browsable(False),
+        DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
         Protected ReadOnly Property VsUIShell2Service() As IVsUIShell2
             Get
                 If (_UIShell2Service Is Nothing) Then
@@ -3255,7 +3255,7 @@ NextControl:
             'Const BIF_BROWSEINCLUDEFILES As Integer = &H4000   '    Browsing for Everything
             'Const BIF_SHAREABLE As Integer = &H8000            '    sharable resources displayed (remote shares, requires BIF_USENEWUI)
             '
-            Dim uishell As Microsoft.VisualStudio.Shell.Interop.IVsUIShell = _
+            Dim uishell As Microsoft.VisualStudio.Shell.Interop.IVsUIShell =
                 CType(ServiceProvider.GetService(GetType(Shell.Interop.IVsUIShell).GUID), Shell.Interop.IVsUIShell)
 
             Dim DirName As String
@@ -4029,7 +4029,7 @@ NextControl:
         End Function
 
 
-        <EditorBrowsable(EditorBrowsableState.Advanced)> _
+        <EditorBrowsable(EditorBrowsableState.Advanced)>
         Protected Overrides Sub WndProc(ByRef m As Message)
             If m.Msg = Microsoft.VisualStudio.Editors.AppDesCommon.WmUserConstants.WM_PAGE_POSTVALIDATION Then
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AdvancedServicesDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AdvancedServicesDialog.vb
@@ -253,7 +253,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Sub
 
 
-        <SuppressMessage("Microsoft.Globalization", "CA1303:DoNotPassLiteralsAsLocalizedParameters")> _
+        <SuppressMessage("Microsoft.Globalization", "CA1303:DoNotPassLiteralsAsLocalizedParameters")>
         Private Sub UpdateCustomConnectionStringControlBasedOnCheckState()
             Select Case UseCustomConnectionStringCheckBox.CheckState
                 Case System.Windows.Forms.CheckState.Indeterminate

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
@@ -347,11 +347,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Get
                 If m_ControlData Is Nothing Then
 
-                    m_TargetFrameworkPropertyControlData = New TargetFrameworkPropertyControlData( _
-                            VslangProj100.VsProjPropId100.VBPROJPROPID_TargetFrameworkMoniker, Const_TargetFrameworkMoniker, _
-                            TargetFramework, _
-                            AddressOf SetTargetFrameworkMoniker, AddressOf GetTargetFrameworkMoniker, _
-                            ControlDataFlags.ProjectMayBeReloadedDuringPropertySet Or ControlDataFlags.NoOptimisticFileCheckout, _
+                    m_TargetFrameworkPropertyControlData = New TargetFrameworkPropertyControlData(
+                            VslangProj100.VsProjPropId100.VBPROJPROPID_TargetFrameworkMoniker, Const_TargetFrameworkMoniker,
+                            TargetFramework,
+                            AddressOf SetTargetFrameworkMoniker, AddressOf GetTargetFrameworkMoniker,
+                            ControlDataFlags.ProjectMayBeReloadedDuringPropertySet Or ControlDataFlags.NoOptimisticFileCheckout,
                             New Control() {Me.TargetFrameworkLabel})
 
                     'StartupObject must be kept at the end of the list because it depends on the initialization of "OutputType" values
@@ -387,8 +387,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Protected Overrides ReadOnly Property ValidationControlGroups() As Control()()
             Get
                 If m_controlGroup Is Nothing Then
-                    m_controlGroup = New Control()() { _
-                        New Control() {IconRadioButton, Win32ResourceRadioButton, ApplicationIcon, ApplicationManifest, Win32ResourceFile, AppIconBrowse, Win32ResourceFileBrowse} _
+                    m_controlGroup = New Control()() {
+                        New Control() {IconRadioButton, Win32ResourceRadioButton, ApplicationIcon, ApplicationManifest, Win32ResourceFile, AppIconBrowse, Win32ResourceFileBrowse}
                         }
                 End If
                 Return m_controlGroup
@@ -1061,11 +1061,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 sInitialDirectory = System.IO.Path.GetDirectoryName(sInitialDirectory)
             End If
 
-            Dim fileNames As ArrayList = Utils.GetFilesViaBrowse(ServiceProvider, Me.Handle, sInitialDirectory, SR.GetString(SR.PPG_AddWin32ResourceTitle), _
-                    Common.CombineDialogFilters( _
-                        Common.CreateDialogFilter(SR.GetString(SR.PPG_AddWin32ResourceFilter), "res"), _
-                        Common.Utils.GetAllFilesDialogFilter() _
-                        ), _
+            Dim fileNames As ArrayList = Utils.GetFilesViaBrowse(ServiceProvider, Me.Handle, sInitialDirectory, SR.GetString(SR.PPG_AddWin32ResourceTitle),
+                    Common.CombineDialogFilters(
+                        Common.CreateDialogFilter(SR.GetString(SR.PPG_AddWin32ResourceFilter), "res"),
+                        Common.Utils.GetAllFilesDialogFilter()
+                        ),
                         0, False, sFileName)
             If fileNames IsNot Nothing AndAlso fileNames.Count = 1 Then
                 sFileName = CStr(fileNames(0))

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageBase.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         'Required by the Windows Form Designer
         Private _components As System.ComponentModel.IContainer
 
-        <System.Diagnostics.DebuggerStepThrough()> _
+        <System.Diagnostics.DebuggerStepThrough()>
         Private Sub InitializeComponent()
             Me.SuspendLayout()
             Me.ResumeLayout(False)
@@ -181,8 +181,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 sInitialDirectory = System.IO.Path.GetDirectoryName(sInitialDirectory)
             End If
 
-            Dim fileNames As ArrayList = Utils.GetFilesViaBrowse(ServiceProvider, Me.Handle, sInitialDirectory, SR.GetString(SR.PPG_AddExistingFilesTitle), _
-                        Common.CreateDialogFilter(SR.GetString(SR.PPG_AddIconFilesFilter), ".ico"), _
+            Dim fileNames As ArrayList = Utils.GetFilesViaBrowse(ServiceProvider, Me.Handle, sInitialDirectory, SR.GetString(SR.PPG_AddExistingFilesTitle),
+                        Common.CreateDialogFilter(SR.GetString(SR.PPG_AddIconFilesFilter), ".ico"),
                         0, False, sFileName)
 
             If fileNames IsNot Nothing AndAlso fileNames.Count = 1 Then

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBBase.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         'NOTE: The following procedure is required by the Windows Form Designer
         'It can be modified using the Windows Form Designer.  
         'Do not modify it using the code editor.
-        <System.Diagnostics.DebuggerStepThrough()> _
+        <System.Diagnostics.DebuggerStepThrough()>
         Private Sub InitializeComponent()
             Me.SuspendLayout()
             '

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
@@ -437,7 +437,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <remarks></remarks>
         Private Sub SetCommonControls()
-            m_CommonControls = New CommonControls( _
+            m_CommonControls = New CommonControls(
                 Me.IconCombobox, Me.IconLabel, Me.IconPicturebox)
         End Sub
 
@@ -449,11 +449,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <remarks></remarks>
         Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
             Get
-                Dim ControlsThatDependOnStartupObjectProperty As Control() = { _
-                    StartupObjectLabel, UseApplicationFrameworkCheckBox, WindowsAppGroupBox _
+                Dim ControlsThatDependOnStartupObjectProperty As Control() = {
+                    StartupObjectLabel, UseApplicationFrameworkCheckBox, WindowsAppGroupBox
                 }
-                Dim ControlsThatDependOnOutputTypeProperty As Control() = { _
-                    ApplicationTypeComboBox, ApplicationTypeLabel _
+                Dim ControlsThatDependOnOutputTypeProperty As Control() = {
+                    ApplicationTypeComboBox, ApplicationTypeLabel
                 }
 
                 If m_ControlData Is Nothing Then
@@ -989,7 +989,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                             For Each FullName As String In GetFormEntryPoints(IncludeSplashScreen:=True)
                                 Dim SplashForm As String = RemoveCurrentRootNamespace(FullName)
                                 'Only add forms to this list, skip 'Sub Main'
-                                If (Not SplashForm.Equals(Const_MyApplicationEntryPoint, StringComparison.OrdinalIgnoreCase)) AndAlso _
+                                If (Not SplashForm.Equals(Const_MyApplicationEntryPoint, StringComparison.OrdinalIgnoreCase)) AndAlso
                                     (Not SplashForm.Equals(Const_SubMain, StringComparison.OrdinalIgnoreCase)) Then
                                     'We don't allow the splash form and main form to be the same, so don't
                                     '  put the main into the splash form list
@@ -1645,7 +1645,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="AppType"></param>
         ''' <remarks></remarks>
         Private Sub SetMyType(ByVal AppType As ApplicationTypes, ByVal ReadyToApply As Boolean)
-            Debug.Assert(UseApplicationFrameworkCheckBox.CheckState <> CheckState.Indeterminate OrElse Not MyApplicationFrameworkSupported() OrElse MyTypeDisabled(), _
+            Debug.Assert(UseApplicationFrameworkCheckBox.CheckState <> CheckState.Indeterminate OrElse Not MyApplicationFrameworkSupported() OrElse MyTypeDisabled(),
                 "UseApplicationFrameworkCheckbox shouldn't be indeterminate")
             Dim NewMyType As String = MyTypeFromApplicationType(AppType, UseApplicationFrameworkCheckBox.CheckState = CheckState.Unchecked OrElse Not MyApplicationFrameworkSupported() OrElse MyTypeDisabled())
             Debug.Assert(NewMyType IsNot Nothing)

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.vb
@@ -55,9 +55,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
             MyBase.PageRequiresScaling = False
 
-            _fileVersionTextBoxes = New System.Windows.Forms.TextBox(3) { _
+            _fileVersionTextBoxes = New System.Windows.Forms.TextBox(3) {
                 Me.FileVersionMajorTextBox, Me.FileVersionMinorTextBox, Me.FileVersionBuildTextBox, Me.FileVersionRevisionTextBox}
-            _assemblyVersionTextBoxes = New System.Windows.Forms.TextBox(3) { _
+            _assemblyVersionTextBoxes = New System.Windows.Forms.TextBox(3) {
                 Me.AssemblyVersionMajorTextBox, Me.AssemblyVersionMinorTextBox, Me.AssemblyVersionBuildTextBox, Me.AssemblyVersionRevisionTextBox}
             _neutralLanguageNoneText = SR.GetString(SR.PPG_NeutralLanguage_None)
         End Sub
@@ -460,12 +460,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="Version">[Out] the resulting combined version string, if valid.</param>
         ''' <remarks></remarks>
         Private Sub ValidateVersion(ByVal VersionTextboxes As System.Windows.Forms.TextBox(), ByVal MaxVersionPartValue As UInteger, ByVal PropertyName As String, ByVal WildcardsAllowed As Boolean, ByRef version As String)
-            InternalParseVersion(VersionTextboxes(0).Text, _
-                VersionTextboxes(1).Text, _
-                VersionTextboxes(2).Text, _
-                VersionTextboxes(3).Text, _
-                PropertyName, _
-                MaxVersionPartValue, _
+            InternalParseVersion(VersionTextboxes(0).Text,
+                VersionTextboxes(1).Text,
+                VersionTextboxes(2).Text,
+                VersionTextboxes(3).Text,
+                PropertyName,
+                MaxVersionPartValue,
                 WildcardsAllowed, version)
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventCommandLineDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventCommandLineDialog.vb
@@ -397,13 +397,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 Try
                     Dim sp As IServiceProvider = ServiceProvider
                     If sp IsNot Nothing Then
-                        Dim vshelp As VsHelp.Help = CType(sp.GetService(GetType(VsHelp.Help)), VsHelp.Help)
+                        Dim vshelp As VSHelp.Help = CType(sp.GetService(GetType(VSHelp.Help)), VSHelp.Help)
                         vshelp.DisplayTopicFromF1Keyword(HelpTopic)
                     Else
                         System.Diagnostics.Debug.Fail("Can not find ServiceProvider")
                     End If
 
-                Catch ex as System.Exception
+                Catch ex As System.Exception
                     System.Diagnostics.Debug.Fail("Unexpected exception during Help invocation " + ex.Message)
                 End Try
             End If

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventCommandLineDialogService.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventCommandLineDialogService.vb
@@ -10,7 +10,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     '   Build Event Service Class. Implements SVsBuildEventCommandLineDialogService 
     '   exposed via the IVsBuildEventCommandLineDialogService interface.
     '--------------------------------------------------------------------------
-    <CLSCompliant(False)> _
+    <CLSCompliant(False)>
     Friend NotInheritable Class BuildEventCommandLineDialogService
         Implements Interop.IVsBuildEventCommandLineDialogService
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.vb
@@ -167,26 +167,26 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Tokens_MAX
         End Enum
 
-        Private Shared ReadOnly s_tokenNames() As String = { _
-            "OutDir", _
-            "ConfigurationName", _
-            "ProjectName", _
-            "TargetName", _
-            "TargetPath", _
-            "ProjectPath", _
-            "ProjectFileName", _
-            "TargetExt", _
-            "TargetFileName", _
-            "DevEnvDir", _
-            "TargetDir", _
-            "ProjectDir", _
-            "SolutionFileName", _
-            "SolutionPath", _
-            "SolutionDir", _
-            "SolutionName", _
-            "PlatformName", _
-            "ProjectExt", _
-            "SolutionExt" _
+        Private Shared ReadOnly s_tokenNames() As String = {
+            "OutDir",
+            "ConfigurationName",
+            "ProjectName",
+            "TargetName",
+            "TargetPath",
+            "ProjectPath",
+            "ProjectFileName",
+            "TargetExt",
+            "TargetFileName",
+            "DevEnvDir",
+            "TargetDir",
+            "ProjectDir",
+            "SolutionFileName",
+            "SolutionPath",
+            "SolutionDir",
+            "SolutionName",
+            "PlatformName",
+            "ProjectExt",
+            "SolutionExt"
         }
 
         ''' <summary>
@@ -197,10 +197,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
             Get
                 If m_ControlData Is Nothing Then
-                    m_ControlData = New PropertyControlData() { _
-                    New PropertyControlData(VsProjPropId2.VBPROJPROPID_PreBuildEvent, "PreBuildEvent", Me.txtPreBuildEventCommandLine, ControlDataFlags.None, New Control() {btnPreBuildBuilder, lblPreBuildEventCommandLine}), _
-                    New PropertyControlData(VsProjPropId2.VBPROJPROPID_PostBuildEvent, "PostBuildEvent", Me.txtPostBuildEventCommandLine, ControlDataFlags.None, New Control() {btnPostBuildBuilder, lblPostBuildEventCommandLine}), _
-                    New PropertyControlData(VsProjPropId2.VBPROJPROPID_RunPostBuildEvent, "RunPostBuildEvent", Me.cboRunPostBuildEvent, New Control() {Me.lblRunPostBuildEvent}) _
+                    m_ControlData = New PropertyControlData() {
+                    New PropertyControlData(VsProjPropId2.VBPROJPROPID_PreBuildEvent, "PreBuildEvent", Me.txtPreBuildEventCommandLine, ControlDataFlags.None, New Control() {btnPreBuildBuilder, lblPreBuildEventCommandLine}),
+                    New PropertyControlData(VsProjPropId2.VBPROJPROPID_PostBuildEvent, "PostBuildEvent", Me.txtPostBuildEventCommandLine, ControlDataFlags.None, New Control() {btnPostBuildBuilder, lblPostBuildEventCommandLine}),
+                    New PropertyControlData(VsProjPropId2.VBPROJPROPID_RunPostBuildEvent, "RunPostBuildEvent", Me.cboRunPostBuildEvent, New Control() {Me.lblRunPostBuildEvent})
                     }
                 End If
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CompilePropPage2.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CompilePropPage2.vb
@@ -5,8 +5,8 @@ Imports System.ComponentModel
 Imports System.IO
 Imports System.Windows.Forms
 Imports VSLangProj80
-Imports VSLangProj90
-Imports VsLangProj110
+Imports VslangProj90
+Imports VSLangProj110
 
 'This is the VB version of this page.  BuildPropPage.vb is the C#/J# version.
 
@@ -568,22 +568,22 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     '  individually.
                     _objectCache = New FakeAllConfigurationsPropertyControlData.ConfigurationObjectCache(ProjectHierarchy, ServiceProvider)
 
-                    m_ControlData = New PropertyControlData() { _
-                        New FakeAllConfigurationsPropertyControlData(_objectCache, VsProjPropId2.VBPROJPROPID_NoWarn, "NoWarn", Nothing, AddressOf Me.NoWarnSet, AddressOf Me.NoWarnGet, ControlDataFlags.UserHandledEvents, Nothing), _
-                        New FakeAllConfigurationsPropertyControlData(_objectCache, VsProjPropId80.VBPROJPROPID_TreatSpecificWarningsAsErrors, "TreatSpecificWarningsAsErrors", Nothing, AddressOf Me.SpecWarnAsErrorSet, AddressOf Me.SpecWarnAsErrorGet, ControlDataFlags.UserHandledEvents, Nothing), _
-                        New PropertyControlData(VsProjPropId.VBPROJPROPID_OptionExplicit, "OptionExplicit", Me.OptionExplicitComboBox, New Control() {Me.OptionExplicitLabel}), _
-                        New PropertyControlData(VsProjPropId.VBPROJPROPID_OptionStrict, "OptionStrict", Me.OptionStrictComboBox, AddressOf Me.OptionStrictSet, AddressOf Me.OptionStrictGet, ControlDataFlags.UserHandledEvents, New Control() {Me.OptionStrictLabel}), _
-                        New PropertyControlData(VsProjPropId.VBPROJPROPID_OptionCompare, "OptionCompare", Me.OptionCompareComboBox, New Control() {Me.OptionCompareLabel}), _
-                        New PropertyControlData(VBProjPropId90.VBPROJPROPID_OptionInfer, "OptionInfer", Me.OptionInferComboBox, New Control() {Me.OptionInferLabel}), _
-                        New SingleConfigPropertyControlData(SingleConfigPropertyControlData.Configs.Release, _
-                            VsProjPropId.VBPROJPROPID_OutputPath, "OutputPath", Me.BuildOutputPathTextBox, Nothing, AddressOf Me.OutputPathGet, ControlDataFlags.None, New Control() {Me.BuildOutputPathLabel}), _
-                        New FakeAllConfigurationsPropertyControlData(_objectCache, VsProjPropId.VBPROJPROPID_DocumentationFile, "DocumentationFile", Nothing, AddressOf Me.DocumentationFileNameSet, AddressOf Me.DocumentationFileNameGet, ControlDataFlags.UserHandledEvents, New Control() {Me.GenerateXMLCheckBox}), _
-                        New FakeAllConfigurationsPropertyControlData(_objectCache, VsProjPropId.VBPROJPROPID_WarningLevel, "WarningLevel", Me.DisableAllWarningsCheckBox, AddressOf Me.WarningLevelSet, AddressOf Me.WarningLevelGet, ControlDataFlags.UserHandledEvents, Nothing), _
-                        New FakeAllConfigurationsPropertyControlData(_objectCache, VsProjPropId.VBPROJPROPID_TreatWarningsAsErrors, "TreatWarningsAsErrors", Me.WarningsAsErrorCheckBox, Nothing, Nothing, ControlDataFlags.UserHandledEvents, Nothing), _
-                        New FakeAllConfigurationsPropertyControlData(_objectCache, VsProjPropId.VBPROJPROPID_RegisterForComInterop, "RegisterForComInterop", Me.RegisterForComInteropCheckBox, Nothing, Nothing, ControlDataFlags.UserHandledEvents, Nothing), _
-                        New PropertyControlData(VsProjPropId80.VBPROJPROPID_ComVisible, "ComVisible", Nothing, AddressOf Me.ComVisibleSet, AddressOf Me.ComVisibleGet, ControlDataFlags.Hidden Or ControlDataFlags.PersistedInAssemblyInfoFile), _
-                        New PropertyControlData(VsProjPropId80.VBPROJPROPID_PlatformTarget, "PlatformTarget", Me.TargetCPUComboBox, AddressOf PlatformTargetSet, AddressOf PlatformTargetGet, ControlDataFlags.None, New Control() {TargetCPULabel}), _
-                        New PropertyControlData(VsProjPropId110.VBPROJPROPID_Prefer32Bit, "Prefer32Bit", Me.Prefer32BitCheckBox, AddressOf Prefer32BitSet, AddressOf Prefer32BitGet) _
+                    m_ControlData = New PropertyControlData() {
+                        New FakeAllConfigurationsPropertyControlData(_objectCache, VsProjPropId2.VBPROJPROPID_NoWarn, "NoWarn", Nothing, AddressOf Me.NoWarnSet, AddressOf Me.NoWarnGet, ControlDataFlags.UserHandledEvents, Nothing),
+                        New FakeAllConfigurationsPropertyControlData(_objectCache, VsProjPropId80.VBPROJPROPID_TreatSpecificWarningsAsErrors, "TreatSpecificWarningsAsErrors", Nothing, AddressOf Me.SpecWarnAsErrorSet, AddressOf Me.SpecWarnAsErrorGet, ControlDataFlags.UserHandledEvents, Nothing),
+                        New PropertyControlData(VsProjPropId.VBPROJPROPID_OptionExplicit, "OptionExplicit", Me.OptionExplicitComboBox, New Control() {Me.OptionExplicitLabel}),
+                        New PropertyControlData(VsProjPropId.VBPROJPROPID_OptionStrict, "OptionStrict", Me.OptionStrictComboBox, AddressOf Me.OptionStrictSet, AddressOf Me.OptionStrictGet, ControlDataFlags.UserHandledEvents, New Control() {Me.OptionStrictLabel}),
+                        New PropertyControlData(VsProjPropId.VBPROJPROPID_OptionCompare, "OptionCompare", Me.OptionCompareComboBox, New Control() {Me.OptionCompareLabel}),
+                        New PropertyControlData(VBProjPropId90.VBPROJPROPID_OptionInfer, "OptionInfer", Me.OptionInferComboBox, New Control() {Me.OptionInferLabel}),
+                        New SingleConfigPropertyControlData(SingleConfigPropertyControlData.Configs.Release,
+                            VsProjPropId.VBPROJPROPID_OutputPath, "OutputPath", Me.BuildOutputPathTextBox, Nothing, AddressOf Me.OutputPathGet, ControlDataFlags.None, New Control() {Me.BuildOutputPathLabel}),
+                        New FakeAllConfigurationsPropertyControlData(_objectCache, VsProjPropId.VBPROJPROPID_DocumentationFile, "DocumentationFile", Nothing, AddressOf Me.DocumentationFileNameSet, AddressOf Me.DocumentationFileNameGet, ControlDataFlags.UserHandledEvents, New Control() {Me.GenerateXMLCheckBox}),
+                        New FakeAllConfigurationsPropertyControlData(_objectCache, VsProjPropId.VBPROJPROPID_WarningLevel, "WarningLevel", Me.DisableAllWarningsCheckBox, AddressOf Me.WarningLevelSet, AddressOf Me.WarningLevelGet, ControlDataFlags.UserHandledEvents, Nothing),
+                        New FakeAllConfigurationsPropertyControlData(_objectCache, VsProjPropId.VBPROJPROPID_TreatWarningsAsErrors, "TreatWarningsAsErrors", Me.WarningsAsErrorCheckBox, Nothing, Nothing, ControlDataFlags.UserHandledEvents, Nothing),
+                        New FakeAllConfigurationsPropertyControlData(_objectCache, VsProjPropId.VBPROJPROPID_RegisterForComInterop, "RegisterForComInterop", Me.RegisterForComInteropCheckBox, Nothing, Nothing, ControlDataFlags.UserHandledEvents, Nothing),
+                        New PropertyControlData(VsProjPropId80.VBPROJPROPID_ComVisible, "ComVisible", Nothing, AddressOf Me.ComVisibleSet, AddressOf Me.ComVisibleGet, ControlDataFlags.Hidden Or ControlDataFlags.PersistedInAssemblyInfoFile),
+                        New PropertyControlData(VsProjPropId80.VBPROJPROPID_PlatformTarget, "PlatformTarget", Me.TargetCPUComboBox, AddressOf PlatformTargetSet, AddressOf PlatformTargetGet, ControlDataFlags.None, New Control() {TargetCPULabel}),
+                        New PropertyControlData(VsProjPropId110.VBPROJPROPID_Prefer32Bit, "Prefer32Bit", Me.Prefer32BitCheckBox, AddressOf Prefer32BitSet, AddressOf Prefer32BitGet)
                     }
                 End If
                 Return m_ControlData
@@ -980,16 +980,16 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End Sub
         End Class
 
-        Private _errorInfos As ErrorInfo() = { _
-            New ErrorInfo(SR.GetString(SR.PPG_Compile_42016), "42016,41999", ErrorNotification.None, True, New Integer() {42016, 41999}), _
-            New ErrorInfo(SR.GetString(SR.PPG_Compile_42017_42018_42019), "42017,42018,42019,42032,42036", ErrorNotification.None, True, New Integer() {42017, 42018, 42019, 42032, 42036}), _
-            New ErrorInfo(SR.GetString(SR.PPG_Compile_42020), "42020,42021,42022", ErrorNotification.None, True, New Integer() {42020, 42021, 42022}), _
-            New ErrorInfo(SR.GetString(SR.PPG_Compile_42104), "42104,42108,42109,42030", ErrorNotification.None, False, New Integer() {42104, 42108, 42109, 42030}), _
-            New ErrorInfo(SR.GetString(SR.PPG_Compile_42105_42106_42107), "42105,42106,42107", ErrorNotification.None, False, New Integer() {42105, 42106, 42107}), _
-            New ErrorInfo(SR.GetString(SR.PPG_Compile_42353_42354_42355), "42353,42354,42355", ErrorNotification.None, False, New Integer() {42353, 42354, 42355}), _
-            New ErrorInfo(SR.GetString(SR.PPG_Compile_42024), "42024,42099", ErrorNotification.None, False, New Integer() {42024, 42099}), _
-            New ErrorInfo(SR.GetString(SR.PPG_Compile_42025), "42025", ErrorNotification.None, False, New Integer() {42025}), _
-            New ErrorInfo(SR.GetString(SR.PPG_Compile_42004), "41998,42004,42026,", ErrorNotification.None, False, New Integer() {41998, 42004, 42026}), _
+        Private _errorInfos As ErrorInfo() = {
+            New ErrorInfo(SR.GetString(SR.PPG_Compile_42016), "42016,41999", ErrorNotification.None, True, New Integer() {42016, 41999}),
+            New ErrorInfo(SR.GetString(SR.PPG_Compile_42017_42018_42019), "42017,42018,42019,42032,42036", ErrorNotification.None, True, New Integer() {42017, 42018, 42019, 42032, 42036}),
+            New ErrorInfo(SR.GetString(SR.PPG_Compile_42020), "42020,42021,42022", ErrorNotification.None, True, New Integer() {42020, 42021, 42022}),
+            New ErrorInfo(SR.GetString(SR.PPG_Compile_42104), "42104,42108,42109,42030", ErrorNotification.None, False, New Integer() {42104, 42108, 42109, 42030}),
+            New ErrorInfo(SR.GetString(SR.PPG_Compile_42105_42106_42107), "42105,42106,42107", ErrorNotification.None, False, New Integer() {42105, 42106, 42107}),
+            New ErrorInfo(SR.GetString(SR.PPG_Compile_42353_42354_42355), "42353,42354,42355", ErrorNotification.None, False, New Integer() {42353, 42354, 42355}),
+            New ErrorInfo(SR.GetString(SR.PPG_Compile_42024), "42024,42099", ErrorNotification.None, False, New Integer() {42024, 42099}),
+            New ErrorInfo(SR.GetString(SR.PPG_Compile_42025), "42025", ErrorNotification.None, False, New Integer() {42025}),
+            New ErrorInfo(SR.GetString(SR.PPG_Compile_42004), "41998,42004,42026,", ErrorNotification.None, False, New Integer() {41998, 42004, 42026}),
             New ErrorInfo(SR.GetString(SR.PPG_Compile_42029), "42029,42031", ErrorNotification.None, False, New Integer() {42029, 42031})}
 
         Private Sub PopulateErrorList()
@@ -1505,9 +1505,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <returns></returns>
         ''' <remarks></remarks>
         Private Function IsSameAsOptionStrictOff() As Boolean
-            If _specWarnAsError IsNot Nothing AndAlso _
-               _noWarn IsNot Nothing AndAlso _
-               AreNumbersInList(_noWarn, _optionStrictIDs) = TriState.True AndAlso _
+            If _specWarnAsError IsNot Nothing AndAlso
+               _noWarn IsNot Nothing AndAlso
+               AreNumbersInList(_noWarn, _optionStrictIDs) = TriState.True AndAlso
                AreNumbersInList(_specWarnAsError, _optionStrictIDs) = TriState.False _
             Then
                 Return True
@@ -1523,9 +1523,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <returns></returns>
         ''' <remarks></remarks>
         Private Function IsSameAsOptionStrictOn() As Boolean
-            If _specWarnAsError IsNot Nothing AndAlso _
-               _noWarn IsNot Nothing AndAlso _
-               AreNumbersInList(_specWarnAsError, _optionStrictIDs) = TriState.True AndAlso _
+            If _specWarnAsError IsNot Nothing AndAlso
+               _noWarn IsNot Nothing AndAlso
+               AreNumbersInList(_specWarnAsError, _optionStrictIDs) = TriState.True AndAlso
                AreNumbersInList(_noWarn, _optionStrictIDs) = TriState.False _
             Then
                 Return True
@@ -1682,10 +1682,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 Try
                     Dim absPath As String = Path.Combine(GetProjectPath(), GetProjectRelativeDirectoryPath(Trim(BuildOutputPathTextBox.Text)))
                     If Not CheckPath(absPath) Then
-                        If DesignerFramework.DesignerMessageBox.Show(ServiceProvider, _
-                                                                    SR.GetString(SR.PPG_OutputPathNotSecure), _
-                                                                    DesignerFramework.DesignUtil.GetDefaultCaption(ServiceProvider), _
-                                                                    MessageBoxButtons.OKCancel, _
+                        If DesignerFramework.DesignerMessageBox.Show(ServiceProvider,
+                                                                    SR.GetString(SR.PPG_OutputPathNotSecure),
+                                                                    DesignerFramework.DesignUtil.GetDefaultCaption(ServiceProvider),
+                                                                    MessageBoxButtons.OKCancel,
                                                                     MessageBoxIcon.Warning) = DialogResult.Cancel _
                         Then
                             ' Set the focus back to the offending control!

--- a/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.vb
@@ -385,8 +385,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     data.DisplayPropertyName = SR.GetString(SR.PPG_Property_StartProgram)
                     datalist.Add(data)
 
-                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_StartAction, "StartAction", Nothing, _
-                                AddressOf Me.StartActionSet, AddressOf Me.StartActionGet, ControlDataFlags.PersistedInProjectUserFile, _
+                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_StartAction, "StartAction", Nothing,
+                                AddressOf Me.StartActionSet, AddressOf Me.StartActionGet, ControlDataFlags.PersistedInProjectUserFile,
                                 New Control() {startActionTableLayoutPanel, rbStartProject, rbStartProgram, rbStartURL, StartProgram, StartURL, StartProgramBrowse})
                     datalist.Add(data)
 
@@ -418,9 +418,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Protected Overrides ReadOnly Property ValidationControlGroups() As Control()()
             Get
                 If _controlGroup Is Nothing Then
-                    _controlGroup = New Control()() { _
-                        New Control() {rbStartProject, rbStartProgram, rbStartURL, StartProgram, StartURL, StartProgramBrowse}, _
-                        New Control() {RemoteDebugEnabled, StartWorkingDirectory, RemoteDebugMachine, StartWorkingDirectoryBrowse} _
+                    _controlGroup = New Control()() {
+                        New Control() {rbStartProject, rbStartProgram, rbStartURL, StartProgram, StartURL, StartProgramBrowse},
+                        New Control() {RemoteDebugEnabled, StartWorkingDirectory, RemoteDebugMachine, StartWorkingDirectoryBrowse}
                         }
                 End If
                 Return _controlGroup

--- a/src/Microsoft.VisualStudio.Editors/PropPages/PropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/PropPage.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
 #Region "ApplicationPropPageComClass (Not directly used, inherited from by J#/C#)"
 
-    <System.Runtime.InteropServices.GuidAttribute("1C25D270-6E41-4360-9221-1D22E4942FAD"), ComVisible(True), CLSCompliantAttribute(False)> _
+    <System.Runtime.InteropServices.GuidAttribute("1C25D270-6E41-4360-9221-1D22E4942FAD"), ComVisible(True), CLSCompliantAttribute(False)>
     Public NotInheritable Class ApplicationPropPageComClass 'See class hierarchy comments above
         Inherits VBPropPageBase
 
@@ -56,7 +56,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 #Region "ApplicationWithMyPropPageComClass (VB Application property page)"
 
     'Note: This is the VB Application page (naming is historical)
-    <System.Runtime.InteropServices.GuidAttribute("8998E48E-B89A-4034-B66E-353D8C1FDC2E"), ComVisible(True), CLSCompliantAttribute(False)> _
+    <System.Runtime.InteropServices.GuidAttribute("8998E48E-B89A-4034-B66E-353D8C1FDC2E"), ComVisible(True), CLSCompliantAttribute(False)>
     Public NotInheritable Class ApplicationWithMyPropPageComClass 'See class hierarchy comments above
         Inherits VBPropPageBase
 
@@ -82,7 +82,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
 #Region "WPFApplicationWithMyPropPageComClass (VB Application page for WPF)"
 
-    <System.Runtime.InteropServices.GuidAttribute("00aa1f44-2ba3-4eaa-b54a-ce18000e6c5d"), ComVisible(True), CLSCompliantAttribute(False)> _
+    <System.Runtime.InteropServices.GuidAttribute("00aa1f44-2ba3-4eaa-b54a-ce18000e6c5d"), ComVisible(True), CLSCompliantAttribute(False)>
     Public NotInheritable Class WPFApplicationWithMyPropPageComClass 'See class hierarchy comments above
         Inherits VBPropPageBase
 
@@ -109,7 +109,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
 #Region "CSharpApplicationPropPageComClass (C#/J# Application property page)"
 
-    <System.Runtime.InteropServices.GuidAttribute("5E9A8AC2-4F34-4521-858F-4C248BA31532"), ComVisible(True), CLSCompliantAttribute(False)> _
+    <System.Runtime.InteropServices.GuidAttribute("5E9A8AC2-4F34-4521-858F-4C248BA31532"), ComVisible(True), CLSCompliantAttribute(False)>
     Public NotInheritable Class CSharpApplicationPropPageComClass 'See class hierarchy comments above
         Inherits VBPropPageBase
 
@@ -138,7 +138,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
 #Region "CompilePropPageComClass"
 
-    <System.Runtime.InteropServices.GuidAttribute("EDA661EA-DC61-4750-B3A5-F6E9C74060F5"), ComVisible(True), CLSCompliantAttribute(False)> _
+    <System.Runtime.InteropServices.GuidAttribute("EDA661EA-DC61-4750-B3A5-F6E9C74060F5"), ComVisible(True), CLSCompliantAttribute(False)>
     Public NotInheritable Class CompilePropPageComClass
         Inherits VBPropPageBase
 
@@ -180,7 +180,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
 #Region "ServicesPropPageComClass"
 
-    <System.Runtime.InteropServices.GuidAttribute("43E38D2E-43B8-4204-8225-9357316137A4"), ComVisible(True), CLSCompliantAttribute(False)> _
+    <System.Runtime.InteropServices.GuidAttribute("43E38D2E-43B8-4204-8225-9357316137A4"), ComVisible(True), CLSCompliantAttribute(False)>
     Public NotInheritable Class ServicesPropPageComClass
         Inherits VBPropPageBase
 
@@ -206,7 +206,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
 #Region "DebugPropPageComClass"
 
-    <System.Runtime.InteropServices.GuidAttribute("6185191F-1008-4FB2-A715-3A4E4F27E610"), ComVisible(True), CLSCompliantAttribute(False)> _
+    <System.Runtime.InteropServices.GuidAttribute("6185191F-1008-4FB2-A715-3A4E4F27E610"), ComVisible(True), CLSCompliantAttribute(False)>
     Public NotInheritable Class DebugPropPageComClass
         Inherits VBPropPageBase
 
@@ -232,7 +232,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
 #Region "VBBasePropPageComClass"
 
-    <System.Runtime.InteropServices.GuidAttribute("4E43F4AB-9F03-4129-95BF-B8FF870AF6AB"), ComVisible(True), CLSCompliantAttribute(False)> _
+    <System.Runtime.InteropServices.GuidAttribute("4E43F4AB-9F03-4129-95BF-B8FF870AF6AB"), ComVisible(True), CLSCompliantAttribute(False)>
     Public NotInheritable Class ReferencePropPageComClass
         Inherits VBPropPageBase
 
@@ -258,7 +258,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
 #Region "BuildPropPageComClass"
 
-    <System.Runtime.InteropServices.GuidAttribute("A54AD834-9219-4aa6-B589-607AF21C3E26"), ComVisible(True), CLSCompliantAttribute(False)> _
+    <System.Runtime.InteropServices.GuidAttribute("A54AD834-9219-4aa6-B589-607AF21C3E26"), ComVisible(True), CLSCompliantAttribute(False)>
     Public NotInheritable Class BuildPropPageComClass
         Inherits VBPropPageBase
 
@@ -283,7 +283,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
 #Region "BuildEventsPropPageComClass"
 
-    <System.Runtime.InteropServices.GuidAttribute("1E78F8DB-6C07-4d61-A18F-7514010ABD56"), ComVisible(True), CLSCompliantAttribute(False)> _
+    <System.Runtime.InteropServices.GuidAttribute("1E78F8DB-6C07-4d61-A18F-7514010ABD56"), ComVisible(True), CLSCompliantAttribute(False)>
     Public NotInheritable Class BuildEventsPropPageComClass
         Inherits VBPropPageBase
 
@@ -308,7 +308,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
 #Region "ReferencePathsPropPageComClass"
 
-    <System.Runtime.InteropServices.GuidAttribute("031911C8-6148-4e25-B1B1-44BCA9A0C45C"), ComVisible(True), CLSCompliantAttribute(False)> _
+    <System.Runtime.InteropServices.GuidAttribute("031911C8-6148-4e25-B1B1-44BCA9A0C45C"), ComVisible(True), CLSCompliantAttribute(False)>
     Public NotInheritable Class ReferencePathsPropPageComClass
         Inherits VBPropPageBase
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePathsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePathsPropPage.vb
@@ -246,7 +246,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
             Get
                 If m_ControlData Is Nothing Then
-                    m_ControlData = New PropertyControlData() { _
+                    m_ControlData = New PropertyControlData() {
                         New PropertyControlData(VsProjPropId.VBPROJPROPID_ReferencePath, "ReferencePath", Nothing, AddressOf Me.ReferencePathSet, AddressOf Me.ReferencePathGet, ControlDataFlags.PersistedInProjectUserFile)}
                 End If
                 Return m_ControlData
@@ -544,9 +544,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Sub
 
         Protected Overrides Function GetF1HelpKeyword() As String
-            If IsJSProject Then
+            If IsJSProject() Then
                 Return HelpKeywords.JSProjPropReferencePaths
-            ElseIf IsCSProject Then
+            ElseIf IsCSProject() Then
                 Return HelpKeywords.CSProjPropReferencePaths
             Else
                 Debug.Assert(IsVBProject, "Unknown project type")

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
@@ -448,8 +448,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
             Get
                 If m_ControlData Is Nothing Then
-                    m_ControlData = New PropertyControlData() { _
-                        New PropertyControlData(1, "ImportList", Me.ImportList, AddressOf Me.ImportListSet, AddressOf Me.ImportListGet, ControlDataFlags.UserPersisted) _
+                    m_ControlData = New PropertyControlData() {
+                        New PropertyControlData(1, "ImportList", Me.ImportList, AddressOf Me.ImportListSet, AddressOf Me.ImportListGet, ControlDataFlags.UserPersisted)
                         }
                 End If
                 Return m_ControlData
@@ -558,7 +558,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
 
             ' NOTE: 6 is 2 times of the margin we used. The exactly number is not important, because it actually does not make any difference on the page.
-            Return New Size(Math.Max(preferredSize.Width, Math.Max(referenceAreaPreferredSize.Width, importsAreaPreferredSize.Width) + 6), _
+            Return New Size(Math.Max(preferredSize.Width, Math.Max(referenceAreaPreferredSize.Width, importsAreaPreferredSize.Width) + 6),
                     Math.Max(preferredSize.Height, referenceAreaPreferredSize.Height + importsAreaPreferredSize.Height + 6))
         End Function
 
@@ -1422,14 +1422,14 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 Dim serviceType As ServiceReferenceType = ServiceReferenceType.SRT_WCFReference Or ServiceReferenceType.SRT_ASMXReference
 
                 Try
-                    AddServiceRefDlg.ShowAddWebReferenceDialog( _
-                                ShellUtil.VsHierarchyFromDTEProject(ServiceProvider, DTEProject), _
-                                Nothing, _
-                                serviceType, _
-                                Nothing, _
-                                Nothing, _
-                                Nothing, _
-                                result, _
+                    AddServiceRefDlg.ShowAddWebReferenceDialog(
+                                ShellUtil.VsHierarchyFromDTEProject(ServiceProvider, DTEProject),
+                                Nothing,
+                                serviceType,
+                                Nothing,
+                                Nothing,
+                                Nothing,
+                                result,
                                 Cancelled)
                     If Cancelled = 0 Then
                         Debug.Assert(Not _updatingReferences, "We shouldn't be in another updating session")
@@ -1537,7 +1537,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     If ((ImportListSelectedItem IsNot Nothing) AndAlso (ImportListSelectedItem.Length > 0)) Then
                         Dim selectedItemIdentity As New ImportIdentity(DirectCast(ImportListSelectedItem, String))
                         If userImportId.Equals(selectedItemIdentity) _
-                                    AndAlso Not ScrubbedUserImportText.Equals(ImportListSelectedItem, _
+                                    AndAlso Not ScrubbedUserImportText.Equals(ImportListSelectedItem,
                                                                                 StringComparison.Ordinal) Then
                             EnableUpdateUserImportButton = True
                         End If
@@ -1895,7 +1895,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 ' If there are elements in the listview, size the name, version, and path columns by item text if not empty
                 With ReferenceList.Items(0)
                     ' For the first column, if not offset, check the .text property, otherwise check the subitems
-                    If (ColOffset = 0 AndAlso .Text <> "") OrElse _
+                    If (ColOffset = 0 AndAlso .Text <> "") OrElse
                         (ColOffset > 0 AndAlso .SubItems(s_REFCOLUMN_NAME + ColOffset).Text <> "") Then
                         AutoSizeMethod(s_REFCOLUMN_NAME) = Microsoft.VisualStudio.Editors.Interop.NativeMethods.LVSCW_AUTOSIZE
                     End If
@@ -1993,8 +1993,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <remarks></remarks>
         Private Sub UpdateUserImportButton_Click(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles UpdateUserImportButton.Click
 
-            Debug.Assert(ImportList.SelectedItems.Count <= 1 AndAlso _
-                        ImportListSelectedItem IsNot Nothing AndAlso _
+            Debug.Assert(ImportList.SelectedItems.Count <= 1 AndAlso
+                        ImportListSelectedItem IsNot Nothing AndAlso
                         ImportListSelectedItem.Length > 0, "Why do we try to update more than one selected item?!")
 
             Dim UserImports As String() = GetCurrentImportsList()
@@ -2409,8 +2409,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                                 Dim webCompo As WebReferenceComponent = TryCast(ReferenceList.Items(i).Tag, WebReferenceComponent)
                                 Dim serviceCompo As ServiceReferenceComponent = TryCast(ReferenceList.Items(i).Tag, ServiceReferenceComponent)
 
-                                If refCompo IsNot Nothing AndAlso refCompo.CurrentObject Is updateItem.Reference OrElse _
-                                   webCompo IsNot Nothing AndAlso webCompo.WebReference Is updateItem.WebReference OrElse _
+                                If refCompo IsNot Nothing AndAlso refCompo.CurrentObject Is updateItem.Reference OrElse
+                                   webCompo IsNot Nothing AndAlso webCompo.WebReference Is updateItem.WebReference OrElse
                                    serviceCompo IsNot Nothing AndAlso serviceCompo.ReferenceGroup Is updateItem.ServiceReference Then
                                     If updateItem.UpdateType = ReferenceUpdateType.ReferenceRemoved Then
                                         '(Note: we don't want to call IsImplicitlyAddedReference on the reference in this case, because it has already
@@ -2607,13 +2607,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private Const s_aliasGroup As String = "(?<" & s_aliasGroupName & ">[^=""'\s]+)"
 
         ' Regular expression for parsing XML imports statement (<xmlns[:Alias]='url'>).
-        Private Shared s_xmlImportRegex As New Regex( _
-            "^\s*\<\s*[xX][mM][lL][nN][sS]\s*(:\s*" & s_aliasGroup & ")?\s*=\s*(""[^""]*""|'[^']*')\s*\>\s*$", _
+        Private Shared s_xmlImportRegex As New Regex(
+            "^\s*\<\s*[xX][mM][lL][nN][sS]\s*(:\s*" & s_aliasGroup & ")?\s*=\s*(""[^""]*""|'[^']*')\s*\>\s*$",
             RegexOptions.Compiled)
 
         ' Regular expression for parsing VB alias imports statement (Alias=Namespace).
-        Private Shared s_vbImportRegex As New Regex( _
-            "^\s*" & s_aliasGroup & "\s*=\s*.*$", _
+        Private Shared s_vbImportRegex As New Regex(
+            "^\s*" & s_aliasGroup & "\s*=\s*.*$",
             RegexOptions.Compiled)
 
         ' Kind of import - VB regular, VB Alias, xmlns.
@@ -2669,8 +2669,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <returns>True if both imports are XML (both are non-XML) and identities much case-sensitive (case-insensitive).</returns>
         ''' <remarks>Checks a</remarks>
         Public Shadows Function Equals(ByVal other As ImportIdentity) As Boolean Implements IEquatable(Of ImportIdentity).Equals
-            Return _kind = other._kind AndAlso _
-                _identity.Equals(other._identity, _
+            Return _kind = other._kind AndAlso
+                _identity.Equals(other._identity,
                     Utils.IIf(_kind = ImportKind.XmlNamespace, StringComparison.Ordinal, StringComparison.OrdinalIgnoreCase))
         End Function
     End Structure

--- a/src/Microsoft.VisualStudio.Editors/PropPages/SKUMatrix.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/SKUMatrix.vb
@@ -11,7 +11,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     Friend NotInheritable Class SKUMatrix
 
         ' This guid is duplicated in "src\appid\VW8Express\stub\guids.h" and "src\wizard\vbdesigner\AppDesigner\PropPages\SKUMatrix.vb"
-        Private Shared Readonly s_guidShowEnableUnmanagedDebugging As New Guid("2172A533-76E4-483F-BFB9-71D9B8253B13")
+        Private Shared ReadOnly s_guidShowEnableUnmanagedDebugging As New Guid("2172A533-76E4-483F-BFB9-71D9B8253B13")
 
         Private Sub New()
             'Disallow creation
@@ -26,8 +26,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 'we do not need to worry about it here).
 
                 Select Case PropertyId
-                    Case VsProjPropId.VBPROJPROPID_RemoteDebugEnabled, _
-                        VsProjPropId.VBPROJPROPID_EnableSQLServerDebugging, _
+                    Case VsProjPropId.VBPROJPROPID_RemoteDebugEnabled,
+                        VsProjPropId.VBPROJPROPID_EnableSQLServerDebugging,
                         VsProjPropId.VBPROJPROPID_StartAction
 
                         Return True
@@ -39,18 +39,18 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 'These properties are to be hidden for the VB Express SKU
                 If VSProductSKU.IsVB Then
                     Select Case PropertyId
-                        Case VsProjPropId.VBPROJPROPID_RegisterForComInterop, _
-                         VsProjPropId.VBPROJPROPID_IncrementalBuild, _
-                         VsProjPropId.VBPROJPROPID_DocumentationFile, _
-                         VsProjPropId2.VBPROJPROPID_PreBuildEvent, _
-                         VsProjPropId2.VBPROJPROPID_PostBuildEvent, _
+                        Case VsProjPropId.VBPROJPROPID_RegisterForComInterop,
+                         VsProjPropId.VBPROJPROPID_IncrementalBuild,
+                         VsProjPropId.VBPROJPROPID_DocumentationFile,
+                         VsProjPropId2.VBPROJPROPID_PreBuildEvent,
+                         VsProjPropId2.VBPROJPROPID_PostBuildEvent,
                          VsProjPropId2.VBPROJPROPID_RunPostBuildEvent
                             Return True
                     End Select
                 End If
             ElseIf VSProductSKU.IsStandard Then
                 Select Case PropertyId
-                    Case VsProjPropId.VBPROJPROPID_EnableSQLServerDebugging, _
+                    Case VsProjPropId.VBPROJPROPID_EnableSQLServerDebugging,
                         VsProjPropId.VBPROJPROPID_RemoteDebugEnabled
 
                         Return True

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ServiceReferenceComponent.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ServiceReferenceComponent.vb
@@ -22,9 +22,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             _referenceGroup = referenceGroup
         End Sub
 
-        <VBDescription(My.Resources.Designer.ConstantResourceIDs.PPG_ServiceReferenceNamespaceDescription)> _
-        <MergablePropertyAttribute(False)> _
-        <HelpKeyword("ServiceReference Properties.Namespace")> _
+        <VBDescription(My.Resources.Designer.ConstantResourceIDs.PPG_ServiceReferenceNamespaceDescription)>
+        <MergablePropertyAttribute(False)>
+        <HelpKeyword("ServiceReference Properties.Namespace")>
         Public Property [Namespace]() As String
             Get
                 Return _referenceGroup.GetNamespace()
@@ -39,10 +39,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return False
         End Function
 
-        <VBDisplayNameAttribute(My.Resources.Designer.ConstantResourceIDs.PPG_ServiceReferenceUrlName)> _
-        <VBDescription(My.Resources.Designer.ConstantResourceIDs.PPG_ServiceReferenceUrlDescription)> _
-        <HelpKeyword("ServiceReference Properties.ServiceReferenceURL")> _
-        <MergablePropertyAttribute(False)> _
+        <VBDisplayNameAttribute(My.Resources.Designer.ConstantResourceIDs.PPG_ServiceReferenceUrlName)>
+        <VBDescription(My.Resources.Designer.ConstantResourceIDs.PPG_ServiceReferenceUrlDescription)>
+        <HelpKeyword("ServiceReference Properties.ServiceReferenceURL")>
+        <MergablePropertyAttribute(False)>
         Public Property ServiceReferenceURL() As String
             Get
                 If _referenceGroup.GetReferenceCount() = 1 Then
@@ -75,7 +75,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 Else
                     If value <> "" Then
                         _referenceGroup.AddReference(Nothing, value)
-                    ENd If
+                    End If
                 End If
             End Set
         End Property

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ServicesAuthenticationForm.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ServicesAuthenticationForm.vb
@@ -10,7 +10,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private _serviceProvider As IServiceProvider
         Private _authenticationUrl As String
 
-        <SuppressMessage("Microsoft.Design", "CA1054:UriParametersShouldNotBeStrings")> _
+        <SuppressMessage("Microsoft.Design", "CA1054:UriParametersShouldNotBeStrings")>
         Public Sub New(ByVal authenticationUrl As String, ByVal authenticationHost As String, ByVal serviceProvider As IServiceProvider)
             InitializeComponent()
             AuthenticationServiceUrl.Text = authenticationHost
@@ -19,7 +19,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Sub
 
 
-        <SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings")> _
+        <SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings")>
         Public ReadOnly Property AuthenticationUrl() As String
             Get
                 Return _authenticationUrl
@@ -39,7 +39,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Property
 
         'Form overrides dispose to clean up the component list.
-        <System.Diagnostics.DebuggerNonUserCode()> _
+        <System.Diagnostics.DebuggerNonUserCode()>
         Protected Overrides Sub Dispose(ByVal disposing As Boolean)
             Try
                 If disposing AndAlso _components IsNot Nothing Then
@@ -68,7 +68,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         'NOTE: The following procedure is required by the Windows Form Designer
         'It can be modified using the Windows Form Designer.  
         'Do not modify it using the code editor.
-        <System.Diagnostics.DebuggerStepThrough()> _
+        <System.Diagnostics.DebuggerStepThrough()>
         Private Sub InitializeComponent()
             Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(ServicesAuthenticationForm))
             Me.InnerTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel
@@ -188,11 +188,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         End Sub
 
-        <SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")> _
+        <SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")>
         Private Sub ShowHelp()
             Try
                 If _serviceProvider IsNot Nothing Then
-                    Dim vshelp As VsHelp.Help = CType(_serviceProvider.GetService(GetType(VsHelp.Help)), VsHelp.Help)
+                    Dim vshelp As VSHelp.Help = CType(_serviceProvider.GetService(GetType(VSHelp.Help)), VSHelp.Help)
                     vshelp.DisplayTopicFromF1Keyword(HelpKeywords.VBProjPropSettingsLogin)
                 Else
                     System.Diagnostics.Debug.Fail("Can not find ServiceProvider")

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ServicesPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ServicesPropPage.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private Sub InitializeComponent()
             Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(ServicesPropPage))
             Me.EnableApplicationServices = New System.Windows.Forms.CheckBox
-            Me.HelpLabel = New VsThemedLinklabel
+            Me.HelpLabel = New VSThemedLinkLabel
             Me.TableLayoutPanel1 = New System.Windows.Forms.TableLayoutPanel
             Me.AuthenticationProviderGroupBox = New System.Windows.Forms.GroupBox
             Me.TableLayoutPanel2 = New System.Windows.Forms.TableLayoutPanel
@@ -167,7 +167,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         End Sub
 
-        Friend WithEvents HelpLabel As VsThemedLinkLabel
+        Friend WithEvents HelpLabel As VSThemedLinkLabel
         Friend WithEvents TableLayoutPanel1 As System.Windows.Forms.TableLayoutPanel
         Friend WithEvents AuthenticationProviderGroupBox As System.Windows.Forms.GroupBox
         Friend WithEvents AuthenticationServiceUrlLabel As System.Windows.Forms.Label
@@ -205,7 +205,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 Dim newDoc As XmlDocument = ServicesPropPageAppConfigHelper.AppConfigXmlDocument(PropertyPageSite, ProjectHierarchy, False)
                 'We want to change the document & properties if stuff has changed.  If both documents are null, Object.Equals will return true and
                 'we don't need to update.  Other than that, we want to update if one of the documents are null or if neither is and their xml differs.
-                If Not _alreadyLoaded OrElse (Not Object.Equals(newDoc, CurrentAppConfigDocument) AndAlso (newDoc Is Nothing OrElse CurrentAppConfigDocument Is Nothing OrElse _
+                If Not _alreadyLoaded OrElse (Not Object.Equals(newDoc, CurrentAppConfigDocument) AndAlso (newDoc Is Nothing OrElse CurrentAppConfigDocument Is Nothing OrElse
                         newDoc.OuterXml <> CurrentAppConfigDocument.OuterXml)) Then
                     _alreadyLoaded = True
                     CurrentAppConfigDocument = newDoc
@@ -258,9 +258,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 DesignerFramework.DesignerMessageBox.Show(ServiceProvider, SR.GetString(SR.PPG_Services_VersionWarning), Nothing, MessageBoxButtons.OK, MessageBoxIcon.Warning)
                 _ignoreCheckedChanged = True
                 EnableApplicationServices.Checked = False
-            Else If Not EnableApplicationServices.Checked Then
-                Dim result As DialogResult = DesignerFramework.DesignerMessageBox.Show(ServiceProvider, _
-                    SR.GetString(SR.PPG_Services_ConfirmRemoveServices), SR.GetString(SR.PPG_Services_ConfirmRemoveServices_Caption), _
+            ElseIf Not EnableApplicationServices.Checked Then
+                Dim result As DialogResult = DesignerFramework.DesignerMessageBox.Show(ServiceProvider,
+                    SR.GetString(SR.PPG_Services_ConfirmRemoveServices), SR.GetString(SR.PPG_Services_ConfirmRemoveServices_Caption),
                     MessageBoxButtons.OKCancel, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2)
                 If result = DialogResult.Cancel Then
                     _ignoreCheckedChanged = True
@@ -485,12 +485,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             EnsureXmlUpToDate()
         End Sub
 
-        <SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")> _
+        <SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")>
         Private Sub InvokeHelp()
             Try
                 Dim sp As IServiceProvider = ServiceProvider
                 If sp IsNot Nothing Then
-                    Dim vshelp As VsHelp.Help = CType(sp.GetService(GetType(VsHelp.Help)), VsHelp.Help)
+                    Dim vshelp As VSHelp.Help = CType(sp.GetService(GetType(VSHelp.Help)), VSHelp.Help)
                     vshelp.DisplayTopicFromF1Keyword(GetF1HelpKeyword)
                 Else
                     System.Diagnostics.Debug.Fail("Can not find ServiceProvider")

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ServicesPropPageConfigHelper.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ServicesPropPageConfigHelper.vb
@@ -113,7 +113,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Dim flags As UInteger = CUInt(__PSFFLAGS.PSFF_CreateIfNotExist Or __PSFFLAGS.PSFF_FullPath)
 
             Dim ProjSpecialFiles As IVsProjectSpecialFiles = TryCast(hierarchy, IVsProjectSpecialFiles)
-            ProjSpecialFiles.GetFile(__PSFFILEID.PSFFILEID_AppConfig, Flags, appConfigItemId, fileName)
+            ProjSpecialFiles.GetFile(__PSFFILEID.PSFFILEID_AppConfig, flags, appConfigItemId, fileName)
 
             Dim sb As New StringBuilder
             Using writer As New XmlTextWriter(New StringWriter(sb, CultureInfo.InvariantCulture))
@@ -137,14 +137,14 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return True
         End Function
 
-        Private Shared Function IsCheckoutOrCancelError(ByVal cex As ComException) As Boolean
+        Private Shared Function IsCheckoutOrCancelError(ByVal cex As COMException) As Boolean
             Return cex IsNot Nothing AndAlso (cex.ErrorCode = &H80041004 OrElse cex.ErrorCode = &H8004000C)
         End Function
 
         'This code is stolen from SecurityPropertyPage.  If you don't do this, the document doesn't get written unless it
         'happens to be open
 
-        <SuppressMessage("Microsoft.Globalization", "CA1303:DoNotPassLiteralsAsLocalizedParameters")> _
+        <SuppressMessage("Microsoft.Globalization", "CA1303:DoNotPassLiteralsAsLocalizedParameters")>
         Private Shared Sub SaveAppConfig(ByVal fileName As String, ByVal provider As IServiceProvider, ByVal hierarchy As IVsHierarchy)
             Dim rdt As IVsRunningDocumentTable = TryCast(provider.GetService(GetType(IVsRunningDocumentTable)), IVsRunningDocumentTable)
             Debug.Assert((rdt IsNot Nothing), "What?  No RDT?")
@@ -161,7 +161,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
             Try
                 VSErrorHandler.ThrowOnFailure(hierarchy.ParseCanonicalName(fileName, itemId))
-                VSErrorHandler.ThrowOnFailure(rdt.FindAndLockDocument(CType(_VSRDTFLAGS.RDT_NoLock, UInteger), fileName, hier, itemid, localPunk, docCookie))
+                VSErrorHandler.ThrowOnFailure(rdt.FindAndLockDocument(CType(_VSRDTFLAGS.RDT_NoLock, UInteger), fileName, hier, itemId, localPunk, docCookie))
             Finally
                 If (localPunk <> IntPtr.Zero) Then
                     Marshal.Release(localPunk)
@@ -170,7 +170,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End Try
 
             Try
-                VSErrorHandler.ThrowOnFailure(rdt.GetDocumentInfo(docCookie, flags, readLocks, editLocks, localFileName, hier, itemid, localPunk))
+                VSErrorHandler.ThrowOnFailure(rdt.GetDocumentInfo(docCookie, flags, readLocks, editLocks, localFileName, hier, itemId, localPunk))
             Finally
                 If (localPunk <> IntPtr.Zero) Then
                     Marshal.Release(localPunk)
@@ -665,7 +665,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         'Change the input string from "serviceUri" to "ClientSettingsProvider.ServiceUri"
         Private Shared Function AppSettingsName(ByVal inputName As String) As String
-            Return String.Concat(s_clientSettingsProviderPrefix, Char.ToUpperInvariant(inputName(0)), inputName.SubString(1))
+            Return String.Concat(s_clientSettingsProviderPrefix, Char.ToUpperInvariant(inputName(0)), inputName.Substring(1))
         End Function
 
         Private Shared Function EnsureNode(ByVal doc As XmlDocument, ByVal nodeName As String, ByVal parentNode As XmlNode) As XmlNode
@@ -698,7 +698,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Function
 
         Friend Shared Function IsClientMembershipProviderType(ByVal fullTypeName As String, Optional ByVal projectHierarchy As IVsHierarchy = Nothing) As Boolean
-            Return TypesMatch(fullTypeName, GetSupportedType(s_clientFormsMembershipProviderType, projectHierarchy)) OrElse _
+            Return TypesMatch(fullTypeName, GetSupportedType(s_clientFormsMembershipProviderType, projectHierarchy)) OrElse
             TypesMatch(fullTypeName, GetSupportedType(s_clientWindowsMembershipProviderType, projectHierarchy))
         End Function
 
@@ -758,14 +758,14 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Dim membershipConnectionStringName As String = GetAttribute(membershipProviderNode, s_connectionStringName)
 
             'If no connection strings are specified, use the default
-            If appSettingsConnectionStringName Is Nothing AndAlso _
-                    roleManagerConnectionStringName Is Nothing AndAlso _
+            If appSettingsConnectionStringName Is Nothing AndAlso
+                    roleManagerConnectionStringName Is Nothing AndAlso
                     membershipConnectionStringName Is Nothing Then
                 connectionStringSpecified = True
                 Return Nothing
             End If
 
-            If appSettingsConnectionStringName <> roleManagerConnectionStringName OrElse _
+            If appSettingsConnectionStringName <> roleManagerConnectionStringName OrElse
                     appSettingsConnectionStringName <> membershipConnectionStringName Then
                 connectionStringSpecified = False
                 Return Nothing
@@ -977,9 +977,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             val = val.Trim()
             If val = String.Empty Then Return String.Empty
             If val.EndsWith("/") Then
-                return val & suffix
+                Return val & suffix
             End If
-            return val & "/" & suffix
+            Return val & "/" & suffix
         End Function
 
         Friend Shared ReadOnly Property AuthenticationSuffix() As String
@@ -1001,7 +1001,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Property
 
         Private Shared Function GetSuffix(ByVal input As String) As String
-            return String.Format("{0}_JSON_AppService.axd", input)
+            Return String.Format("{0}_JSON_AppService.axd", input)
         End Function
 
         Friend Shared Function ClientSettingsProviderName() As String

--- a/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkMoniker.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkMoniker.vb
@@ -51,8 +51,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Gets the supported target framework monikers from DTAR
         ''' </summary>
         ''' <param name="vsFrameworkMultiTargeting"></param>
-        Public Shared Function GetSupportedTargetFrameworkMonikers( _
-            ByVal vsFrameworkMultiTargeting As IVsFrameworkMultiTargeting, _
+        Public Shared Function GetSupportedTargetFrameworkMonikers(
+            ByVal vsFrameworkMultiTargeting As IVsFrameworkMultiTargeting,
             ByVal currentProject As Project) As IEnumerable(Of TargetFrameworkMoniker)
 
             Dim supportedFrameworksArray As Array = Nothing
@@ -93,10 +93,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                             ' For web projects, filter out frameworks that don't contain System.Web (e.g. client profiles).
                             Dim systemWebPath As String = Nothing
-                            If VSErrorHandler.Failed(vsFrameworkMultiTargeting.ResolveAssemblyPath( _
-                                  "System.Web.dll", _
-                                  moniker, _
-                                  systemWebPath)) OrElse _
+                            If VSErrorHandler.Failed(vsFrameworkMultiTargeting.ResolveAssemblyPath(
+                                  "System.Web.dll",
+                                  moniker,
+                                  systemWebPath)) OrElse
                                String.IsNullOrEmpty(systemWebPath) Then
                                 Continue For
                             End If

--- a/src/Microsoft.VisualStudio.Editors/PropPages/UnusedReferencePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/UnusedReferencePropPage.vb
@@ -315,7 +315,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 End If
 
                 ' Are there any unused references?
-                If Status = ReferenceUsageResult.ReferenceUsageOK AndAlso _unusedReferenceListReady AndAlso _
+                If Status = ReferenceUsageResult.ReferenceUsageOK AndAlso _unusedReferenceListReady AndAlso
                     UnusedReferenceList IsNot Nothing AndAlso UnusedReferenceList.Items.Count > 0 Then
                     ' Do initial enabling of remove button
                     EnableRemoveRefs(True)
@@ -379,7 +379,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                 For refIndex As Integer = 0 To UnusedRefsList.Count - 1
                     ' Convert VSLangProj.Reference to formatted list view item and insert into references list
-                    lviRef = ReferencePropPage.ReferenceToListViewItem( _
+                    lviRef = ReferencePropPage.ReferenceToListViewItem(
                         CType(UnusedRefsList(refIndex), VSLangProj.Reference), UnusedRefsList(refIndex))
 
                     lviRef.Checked = True
@@ -427,7 +427,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
             ' Request unused references from 
             Dim UnusedRefPathsString As String = Nothing
-            Dim Result As ReferenceUsageResult = _
+            Dim Result As ReferenceUsageResult =
                 _refUsageProvider.GetUnusedReferences(_hier, UnusedRefPathsString)
 
             Try

--- a/src/Microsoft.VisualStudio.Editors/PropPages/VBDescriptionAttribute.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/VBDescriptionAttribute.vb
@@ -7,7 +7,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     ''' <Summary>
     '''  a sub class of DescriptionAttribute to help localizating the description...
     ''' </Summary>
-    <AttributeUsage(AttributeTargets.All)> _
+    <AttributeUsage(AttributeTargets.All)>
     Friend Class VBDescriptionAttribute
         Inherits DescriptionAttribute
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/VBDisplayNameAttribute.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/VBDisplayNameAttribute.vb
@@ -7,7 +7,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     ''' <Summary>
     '''  a sub class of DisplayNameAttribute to help localizating the property name...
     ''' </Summary>
-    <AttributeUsage(AttributeTargets.All)> _
+    <AttributeUsage(AttributeTargets.All)>
     Friend Class VBDisplayNameAttribute
         Inherits DisplayNameAttribute
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WebReferenceComponent.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WebReferenceComponent.vb
@@ -20,9 +20,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             _projectItem = projectItem
         End Sub
 
-        <VBDescription(My.Resources.Designer.ConstantResourceIDs.PPG_WebReferenceNameDescription)> _
-        <MergablePropertyAttribute(False)> _
-        <HelpKeyword("Folder Properties.FileName")> _
+        <VBDescription(My.Resources.Designer.ConstantResourceIDs.PPG_WebReferenceNameDescription)>
+        <MergablePropertyAttribute(False)>
+        <HelpKeyword("Folder Properties.FileName")>
         Public Property Name() As String
             Get
                 Try
@@ -49,9 +49,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End Get
         End Property
 
-        <VBDisplayNameAttribute(My.Resources.Designer.ConstantResourceIDs.PPG_UrlBehaviorName)> _
-        <VBDescriptionAttribute(My.Resources.Designer.ConstantResourceIDs.PPG_UrlBehaviorDescription)> _
-        <HelpKeyword("Folder Properties.UrlBehavior")> _
+        <VBDisplayNameAttribute(My.Resources.Designer.ConstantResourceIDs.PPG_UrlBehaviorName)>
+        <VBDescriptionAttribute(My.Resources.Designer.ConstantResourceIDs.PPG_UrlBehaviorDescription)>
+        <HelpKeyword("Folder Properties.UrlBehavior")>
         Public Property UrlBehavior() As UrlBehaviorType
             Get
                 Dim prop As EnvDTE.[Property] = GetItemProperty("UrlBehavior")
@@ -78,10 +78,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return False
         End Function
 
-        <VBDisplayNameAttribute(My.Resources.Designer.ConstantResourceIDs.PPG_WebReferenceUrlName)> _
-        <VBDescription(My.Resources.Designer.ConstantResourceIDs.PPG_WebReferenceUrlDescription)> _
-        <HelpKeyword("Folder Properties.WebReference")> _
-        <MergablePropertyAttribute(False)> _
+        <VBDisplayNameAttribute(My.Resources.Designer.ConstantResourceIDs.PPG_WebReferenceUrlName)>
+        <VBDescription(My.Resources.Designer.ConstantResourceIDs.PPG_WebReferenceUrlDescription)>
+        <HelpKeyword("Folder Properties.WebReference")>
+        <MergablePropertyAttribute(False)>
         Public Property WebReferenceURL() As String
             Get
                 Dim prop As EnvDTE.[Property] = GetItemProperty("WebReference")
@@ -202,7 +202,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     End Class
 
 #Region "UrlBehaviorType"
-    <TypeConverter(GetType(UrlBehaviorTypeConverter))> _
+    <TypeConverter(GetType(UrlBehaviorTypeConverter))>
     Friend Enum UrlBehaviorType
         [Static]
         Dynamic


### PR DESCRIPTION
Format the property pages code to correct casing, remove line continuation chars, etc so that VS stops doing it when we change them.