### PR TITLE
Stop upper casing XML doc extension in Build property page

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
@@ -1068,7 +1068,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="e"></param>
         ''' <remarks></remarks>
         Private Sub XMLDocumentationEnable_CheckStateChanged(ByVal sender As Object, ByVal e As System.EventArgs) Handles chkXMLDocumentationFile.CheckStateChanged
-            Const XML_FILE_EXTENSION As String = ".XML"
+            Const XML_FILE_EXTENSION As String = ".xml"
 
             If Me.chkXMLDocumentationFile.Checked Then
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1103906/15166182/2e3205b6-16d1-11e6-80bd-efdd7d856382.png)

Something that has annoyed me to no end.