### PR TITLE
Stop treating NullReferenceException as unrecoverable

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
@@ -230,8 +230,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <param name="IgnoreOutOfMemory">If True, out of memory will not be considered unrecoverable.</param>
         ''' <remarks></remarks>
         Public Function IsUnrecoverable(ByVal ex As Exception, Optional ByVal IgnoreOutOfMemory As Boolean = False) As Boolean
-            If TypeOf ex Is NullReferenceException _
-                OrElse (Not IgnoreOutOfMemory AndAlso TypeOf ex Is OutOfMemoryException) _
+            If (Not IgnoreOutOfMemory AndAlso TypeOf ex Is OutOfMemoryException) _
                 OrElse TypeOf ex Is StackOverflowException _
                 OrElse TypeOf ex Is ThreadAbortException _
                 OrElse TypeOf ex Is AccessViolationException _


### PR DESCRIPTION
We're going to silently watson these: https://github.com/dotnet/roslyn/issues/11229.

While these null refs are "leaking" - they are immediately swallowed, while I completely hate the pattern of swallowing exceptions, at least the current model shows an "Error Page" with the exception. We'll end up watsoning when we've implemented the issue above.