### PR TITLE
Fixed can't "open" Properties folder

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Input/ProjectCommandAttribute.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Input/ProjectCommandAttribute.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Input
         public ProjectCommandAttribute(string group, params long[] commandIds)
             : base(typeof(IAsyncCommandGroupHandler))
         {
-            Group = group;
+            Group = new Guid(group);
             CommandIds = commandIds;
         }
 
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Input
             get;
         }
 
-        public string Group
+        public Guid Group
         {
             get;
         }


### PR DESCRIPTION
Double-clicking the Properties folder/right-click -> Open no longer opened the AppDesigner.

CPS made a contract break for the IAsyncCommandGroupHandler's metadata where Group changed from a string to a GUID. This caused CPS to no longer see OpenProjectDesignerOnDefaultActionCommand or OpenProjectDesignerCommand.