### PR TITLE
Fixes CTRL + A clears text boxes

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
+++ b/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
@@ -263,6 +263,9 @@
       <Link>IVsSqm.vb</Link>
     </Compile>
     <Compile Include="ComponentModel\AbstractControlTypeDescriptionProvider.vb" />
+    <Compile Include="PropPages\TextBoxWithWorkaroundForAutoCompleteAppend.vb">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="StrongNameHelpers.vb" />
     <Compile Include="..\Common\ManagedCodeMarkers.vb">
       <Link>ManagedCodeMarkers.vb</Link>
@@ -666,16 +669,11 @@
     <Folder Include="Resources\Common\" />
   </ItemGroup>
   <Import Project="..\..\build\Targets\VSL.Imports.targets" />
-
-
   <!-- We don't generate yet generate pkgdef, but we want it to end up in VSIX,
        implement the right output group so that ProjectSystemSetup pulls it in -->
-  <Target Name="PkgdefProjectOutputGroup"
-        Outputs="@(PkgdefOutputGroupOutput)">
-
+  <Target Name="PkgdefProjectOutputGroup" Outputs="@(PkgdefOutputGroupOutput)">
     <ItemGroup>
       <PkgdefOutputGroupOutput Include="Microsoft.VisualStudio.Editors.pkgdef" />
     </ItemGroup>
-
   </Target>
 </Project>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.vb
@@ -53,8 +53,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Friend WithEvents rbStartProject As System.Windows.Forms.RadioButton
         Friend WithEvents rbStartProgram As System.Windows.Forms.RadioButton
         Friend WithEvents rbStartURL As System.Windows.Forms.RadioButton
-        Friend WithEvents StartProgram As System.Windows.Forms.TextBox
-        Friend WithEvents StartURL As System.Windows.Forms.TextBox
+        Friend WithEvents StartProgram As TextBoxWithWorkaroundForAutoCompleteAppend
+        Friend WithEvents StartURL As TextBoxWithWorkaroundForAutoCompleteAppend
         Friend WithEvents RemoteDebugEnabled As System.Windows.Forms.CheckBox
         Friend WithEvents StartArguments As MultilineTextBoxRejectsEnter
         Friend WithEvents StartWorkingDirectory As System.Windows.Forms.TextBox
@@ -84,8 +84,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.rbStartProject = New System.Windows.Forms.RadioButton
             Me.rbStartProgram = New System.Windows.Forms.RadioButton
             Me.rbStartURL = New System.Windows.Forms.RadioButton
-            Me.StartProgram = New System.Windows.Forms.TextBox
-            Me.StartURL = New System.Windows.Forms.TextBox
+            Me.StartProgram = New TextBoxWithWorkaroundForAutoCompleteAppend
+            Me.StartURL = New TextBoxWithWorkaroundForAutoCompleteAppend
             Me.StartProgramBrowse = New System.Windows.Forms.Button
             Me.StartOptionsLabelLine = New System.Windows.Forms.Label
             Me.StartOptionsLabel = New System.Windows.Forms.Label

--- a/src/Microsoft.VisualStudio.Editors/PropPages/TextBoxWithWorkaroundForAutoCompleteAppend.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TextBoxWithWorkaroundForAutoCompleteAppend.vb
@@ -1,0 +1,25 @@
+﻿Imports System.Windows.Forms
+
+Namespace Microsoft.VisualStudio.Editors.PropertyPages
+
+    Friend Class TextBoxWithWorkaroundForAutoCompleteAppend
+        Inherits TextBox
+
+        Protected Overrides Function ProcessCmdKey(ByRef msg As Message, keyData As Keys) As Boolean
+
+            ' WORKAROUND: See: https://github.com/dotnet/roslyn/issues/7894
+            ' Shell has a bug where it clears the text box on CTRL+A when Append is turned on
+            ' Prevent it from seeing CTRL+A, and instead handle SelectAll ourselves
+            If keyData = (Keys.Control Or Keys.A) Then
+                SelectAll()
+                Return True
+            End If
+
+            Return MyBase.ProcessCmdKey(msg, keyData)
+
+        End Function
+
+    End Class
+
+End Namespace
+


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/7894.

This is a workaround until the WinForms/Shell bug (filed internally) is fixed.