### PR TITLE
Fixed: language service host wasn't being initialized

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/LanguageServices/CSharpLanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/LanguageServices/CSharpLanguageServiceHost.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.ComponentModel.Composition;
+using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 {
@@ -25,14 +26,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             get { return CSharpIntellisenseProvider; }
         }
 
-        /// <summary>
-        /// Invoked when the UnconfiguredProject is first loaded to initialize language services.
-        /// </summary>
-        [ProjectAutoLoad(ProjectLoadCheckpoint.InitialActiveConfigurationKnown)]
+        [ProjectAutoLoad(ProjectLoadCheckpoint.ProjectFactoryCompleted)]
         [AppliesTo(ProjectCapability.CSharpLanguageService)]
-        private void Initialize()
+        private Task OnProjectFactoryCompleted()
         {
-            var nowait = InitializeAsync();
+            return InitializeAsync();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/LanguageServices/VisualBasicLanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/LanguageServices/VisualBasicLanguageServiceHost.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.ComponentModel.Composition;
+using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 {
@@ -25,14 +26,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             get { return VisualBasicIntelliSenseProvider; }
         }
 
-        /// <summary>
-        /// Invoked when the UnconfiguredProject is first loaded to initialize language services.
-        /// </summary>
-        [ProjectAutoLoad(ProjectLoadCheckpoint.InitialActiveConfigurationKnown)]
+        [ProjectAutoLoad(ProjectLoadCheckpoint.ProjectFactoryCompleted)]
         [AppliesTo(ProjectCapability.VisualBasicLanguageService)]
-        private void Initialize()
+        private Task OnProjectFactoryCompleted()
         {
-            var nowait = this.InitializeAsync();
+            return InitializeAsync();
         }
     }
 }


### PR DESCRIPTION
The contract changed for AutoLoad components from `void Initialize` -> `Task Initialize`: https://github.com/Microsoft/VSProjectSystem/pull/127.

Make note VB source files are still ending up in misc workspace -need to figure out what's going wrong.