### PR TITLE
Do not treat folder as AppDesigner folder if not part of the project

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/ProjectSystem/PropertiesFolderProjectTreePropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/ProjectSystem/PropertiesFolderProjectTreePropertiesProviderTests.cs
@@ -216,24 +216,42 @@ Root (flags: {ProjectRoot})
         [InlineData(@"
 Root(flags: {ProjectRoot})
     Properties (flags: {Folder AppDesignerFolder BubbleUp})
+", @"
+Root(flags: {ProjectRoot})
+    Properties (flags: {Folder AppDesignerFolder BubbleUp})
 ")]
         [InlineData(@"
 Root(flags: {ProjectRoot})
     Properties (flags: {Folder AppDesignerFolder})
+", @"
+Root(flags: {ProjectRoot})
+    Properties (flags: {Folder AppDesignerFolder BubbleUp})
+")]
+        [InlineData(@"
+Root(flags: {ProjectRoot})
+    Properties (flags: {Folder BubbleUp})
+", @"
+Root(flags: {ProjectRoot})
+    Properties (flags: {Folder AppDesignerFolder BubbleUp})
 ")]
         [InlineData(@"
 Root(flags: {ProjectRoot})
     Properties (flags: {Folder Unrecognized AppDesignerFolder})
+", @"
+Root(flags: {ProjectRoot})
+    Properties (flags: {Folder Unrecognized AppDesignerFolder BubbleUp})
 ")]
-        public void ChangePropertyValues_TreeWithPropertiesCandidateAlreadyMarkedAsAppDesigner_ReturnsUnmodifiedTree(string input)
+        public void ChangePropertyValues_TreeWithPropertiesCandidateAlreadyMarkedAsAppDesignerOrBubbleup_AddsRemainingFlags(string input, string expected)
         {
             var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => true);
             var propertiesProvider = CreateInstance(designerService);
 
-            var tree = ProjectTreeParser.Parse(input);
-            var result = propertiesProvider.ChangePropertyValuesForEntireTree(tree);
+            var inputTree = ProjectTreeParser.Parse(input);
+            var expectedTree = ProjectTreeParser.Parse(expected);
 
-            AssertAreEquivalent(tree, result);
+            var result = propertiesProvider.ChangePropertyValuesForEntireTree(inputTree);
+
+            AssertAreEquivalent(expectedTree, result);
         }
 
         [Theory]
@@ -432,6 +450,8 @@ Root (flags: {ProjectRoot})
 
         private void AssertAreEquivalent(IProjectTree expected, IProjectTree actual)
         {
+            Assert.NotSame(expected, actual);
+
             string expectedAsString = ProjectTreeWriter.WriteToString(expected);
             string actualAsString = ProjectTreeWriter.WriteToString(actual);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ProjectRootImageProjectTreeModifierTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ProjectRootImageProjectTreeModifierTests.cs
@@ -62,7 +62,7 @@ Root (flags: {ProjectRoot})
             var tree = ProjectTreeParser.Parse(input);
             var result = propertiesProvider.ChangePropertyValuesForEntireTree(tree);
 
-            Assert.Equal(new ProjectImageMoniker(new Guid("{A140CD9F-FF94-483C-87B1-9EF5BE9F469A}"), 1), tree.Icon);
+            Assert.Equal(new ProjectImageMoniker(new Guid("{A140CD9F-FF94-483C-87B1-9EF5BE9F469A}"), 1), result.Icon);
         }
 
         [Theory]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractAppDesignerFolderProjectTreePropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractAppDesignerFolderProjectTreePropertiesProvider.cs
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         protected override sealed bool IsCandidateSpecialFolder(IProjectTreeCustomizablePropertyContext propertyContext, ProjectTreeFlags flags)
         {
-            if (propertyContext.ParentNodeFlags.IsProjectRoot() && flags.IsFolder())
+            if (propertyContext.ParentNodeFlags.IsProjectRoot() && flags.IsFolder() && flags.IsIncludedInProject())
             {
                 string folderName = GetAppDesignerFolderName();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/ProjectSystem/MyProjectFolderProjectTreePropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/ProjectSystem/MyProjectFolderProjectTreePropertiesProviderTests.cs
@@ -216,24 +216,42 @@ Root (flags: {ProjectRoot})
         [InlineData(@"
 Root(flags: {ProjectRoot})
     My Project (flags: {Folder AppDesignerFolder BubbleUp})
+", @"
+Root(flags: {ProjectRoot})
+    My Project (flags: {Folder AppDesignerFolder BubbleUp})
 ")]
         [InlineData(@"
 Root(flags: {ProjectRoot})
     My Project (flags: {Folder AppDesignerFolder})
+", @"
+Root(flags: {ProjectRoot})
+    My Project (flags: {Folder AppDesignerFolder BubbleUp})
+")]
+        [InlineData(@"
+Root(flags: {ProjectRoot})
+    My Project (flags: {Folder BubbleUp})
+", @"
+Root(flags: {ProjectRoot})
+    My Project (flags: {Folder AppDesignerFolder BubbleUp})
 ")]
         [InlineData(@"
 Root(flags: {ProjectRoot})
     My Project (flags: {Folder Unrecognized AppDesignerFolder})
+", @"
+Root(flags: {ProjectRoot})
+    My Project (flags: {Folder Unrecognized AppDesignerFolder BubbleUp})
 ")]
-        public void ChangePropertyValues_TreeWithMyProjectCandidateAlreadyMarkedAsAppDesigner_ReturnsUnmodifiedTree(string input)
+        public void ChangePropertyValues_TreeWithMyProjectCandidateAlreadyMarkedAsAppDesignerOrBubbleup_AddsRemainingFlags(string input, string expected)
         {
             var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => true);
             var propertiesProvider = CreateInstance(designerService);
 
-            var tree = ProjectTreeParser.Parse(input);
-            var result = propertiesProvider.ChangePropertyValuesForEntireTree(tree);
+            var inputTree = ProjectTreeParser.Parse(input);
+            var expectedTree = ProjectTreeParser.Parse(expected);
 
-            AssertAreEquivalent(tree, result);
+            var result = propertiesProvider.ChangePropertyValuesForEntireTree(inputTree);
+
+            AssertAreEquivalent(expectedTree, result);
         }
 
         [InlineData(@"
@@ -525,6 +543,8 @@ Root (flags: {ProjectRoot})
 
         private void AssertAreEquivalent(IProjectTree expected, IProjectTree actual)
         {
+            Assert.NotSame(expected, actual);
+
             string expectedAsString = ProjectTreeWriter.WriteToString(expected);
             string actualAsString = ProjectTreeWriter.WriteToString(actual);
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn-project-system/issues/163.

We already had tests for this, but due to the way we produce test "IProjectTree", we were comparing the wrong thing. Our ProjectTreeParser returns "Mutable" project tree instances - so when our properties provider was mutating the tree it was changing the original tree and we were asserting that the same tree matched the same tree.

Started to look at making these test trees fully immutable - but it's a non-trivial effort, with lots of surface area, as you basically have to fix up children and parents. Just ended up cloning the tree before passing it down to the properties provider.