### PR TITLE
Add IUnconfiguredProjectCommonServices.Project

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/ProjectSystem/PropertiesFolderProjectTreePropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/ProjectSystem/PropertiesFolderProjectTreePropertiesProviderTests.cs
@@ -472,15 +472,15 @@ Root (flags: {ProjectRoot})
         {
             designerService = designerService ?? IProjectDesignerServiceFactory.Create();
             var threadingService = IProjectThreadingServiceFactory.Create();
-            var unconfiguredProject = IUnconfiguredProjectFactory.Create();
-            var projectProperties = ProjectPropertiesFactory.Create(unconfiguredProject,
+            var project = IUnconfiguredProjectFactory.Create();
+            var projectProperties = ProjectPropertiesFactory.Create(project,
                 new PropertyPageData() {
                     Category = nameof(ConfigurationGeneral),
                     PropertyName = nameof(ConfigurationGeneral.AppDesignerFolder),
                     Value = appDesignerFolder,
                 });
 
-            var services = IUnconfiguredProjectCommonServicesFactory.Create(threadingService, projectProperties.ConfiguredProject, projectProperties);
+            var services = IUnconfiguredProjectCommonServicesFactory.Create(project, threadingService, projectProperties.ConfiguredProject, projectProperties);
 
             return new PropertiesFolderProjectTreePropertiesProvider(imageProvider ?? IProjectImageProviderFactory.Create(), services, designerService);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IUnconfiguredProjectCommonServicesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IUnconfiguredProjectCommonServicesFactory.cs
@@ -13,9 +13,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return mock.Object;
         }
 
-        public static IUnconfiguredProjectCommonServices Create(IProjectThreadingService threadingService = null, ConfiguredProject configuredProject = null, ProjectProperties projectProperties = null)
+        public static IUnconfiguredProjectCommonServices Create(UnconfiguredProject project = null, IProjectThreadingService threadingService = null, ConfiguredProject configuredProject = null, ProjectProperties projectProperties = null)
         {
             var mock = new Mock<IUnconfiguredProjectCommonServices>();
+
+            if (project != null)
+                mock.Setup(s => s.Project)
+                    .Returns(project);
 
             if (threadingService != null)
                 mock.Setup(s => s.ThreadingService)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UnconfiguredProjectCommonServicesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UnconfiguredProjectCommonServicesTests.cs
@@ -9,15 +9,29 @@ namespace Microsoft.VisualStudio.ProjectSystem
     public class UnconfiguredProjectCommonServicesTests
     {
         [Fact]
-        public void Constructor_NullAsThreadingService_ThrowsArgumentNull()
+        public void Constructor_NullAsProject_ThrowsArgumentNull()
         {
+            var threadingService = new Lazy<IProjectThreadingService>(() => IProjectThreadingServiceFactory.Create());
             var unconfiguredProject = IUnconfiguredProjectFactory.Create();
             var projectProperties = ProjectPropertiesFactory.Create(unconfiguredProject);
             var activeConfiguredProject = IActiveConfiguredProjectFactory.ImplementValue(() => projectProperties.ConfiguredProject);
             var activeConfiguredProjectProperties = IActiveConfiguredProjectFactory.ImplementValue(() => projectProperties);
 
+            Assert.Throws<ArgumentNullException>("project", () => {
+                new UnconfiguredProjectCommonServices((UnconfiguredProject)null, threadingService, activeConfiguredProject, activeConfiguredProjectProperties);
+            });
+        }
+
+        [Fact]
+        public void Constructor_NullAsThreadingService_ThrowsArgumentNull()
+        {
+            var project = IUnconfiguredProjectFactory.Create();
+            var projectProperties = ProjectPropertiesFactory.Create(project);
+            var activeConfiguredProject = IActiveConfiguredProjectFactory.ImplementValue(() => projectProperties.ConfiguredProject);
+            var activeConfiguredProjectProperties = IActiveConfiguredProjectFactory.ImplementValue(() => projectProperties);
+
             Assert.Throws<ArgumentNullException>("threadingService", () => {
-                new UnconfiguredProjectCommonServices((Lazy<IProjectThreadingService>)null, activeConfiguredProject, activeConfiguredProjectProperties);
+                new UnconfiguredProjectCommonServices(project, (Lazy<IProjectThreadingService>)null, activeConfiguredProject, activeConfiguredProjectProperties);
             });
         }
 
@@ -25,12 +39,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public void Constructor_NullAsActiveConfiguredProject_ThrowsArgumentNull()
         {
             var threadingService = new Lazy<IProjectThreadingService>(() => IProjectThreadingServiceFactory.Create());
-            var unconfiguredProject = IUnconfiguredProjectFactory.Create();
-            var projectProperties = ProjectPropertiesFactory.Create(unconfiguredProject);
+            var project = IUnconfiguredProjectFactory.Create();
+            var projectProperties = ProjectPropertiesFactory.Create(project);
             var activeConfiguredProjectProperties = IActiveConfiguredProjectFactory.ImplementValue(() => projectProperties);
 
             Assert.Throws<ArgumentNullException>("activeConfiguredProject", () => {
-                new UnconfiguredProjectCommonServices(threadingService, (ActiveConfiguredProject<ConfiguredProject>)null, activeConfiguredProjectProperties);
+                new UnconfiguredProjectCommonServices(project, threadingService, (ActiveConfiguredProject<ConfiguredProject>)null, activeConfiguredProjectProperties);
             });
         }
 
@@ -38,25 +52,39 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public void Constructor_NullAsActiveConfguredProjectProperties_ThrowsArgumentNull()
         {
             var threadingService = new Lazy<IProjectThreadingService>(() => IProjectThreadingServiceFactory.Create());
-            var unconfiguredProject = IUnconfiguredProjectFactory.Create();
-            var projectProperties = ProjectPropertiesFactory.Create(unconfiguredProject);
+            var project = IUnconfiguredProjectFactory.Create();
+            var projectProperties = ProjectPropertiesFactory.Create(project);
             var activeConfiguredProject = IActiveConfiguredProjectFactory.ImplementValue(() => projectProperties.ConfiguredProject);
 
             Assert.Throws<ArgumentNullException>("activeConfiguredProjectProperties", () => {
-                new UnconfiguredProjectCommonServices(threadingService, activeConfiguredProject, (ActiveConfiguredProject<ProjectProperties>)null);
+                new UnconfiguredProjectCommonServices(project, threadingService, activeConfiguredProject, (ActiveConfiguredProject<ProjectProperties>)null);
             });
+        }
+
+        [Fact]
+        public void Constructor_ValueAsProjecte_SetsProjectProperty()
+        {
+            var threadingService = new Lazy<IProjectThreadingService>(() => IProjectThreadingServiceFactory.Create());
+            var project = IUnconfiguredProjectFactory.Create();
+            var projectProperties = ProjectPropertiesFactory.Create(project);
+            var activeConfiguredProject = IActiveConfiguredProjectFactory.ImplementValue(() => projectProperties.ConfiguredProject);
+            var activeConfiguredProjectProperties = IActiveConfiguredProjectFactory.ImplementValue(() => projectProperties);
+
+            var services = new UnconfiguredProjectCommonServices(project, threadingService, activeConfiguredProject, activeConfiguredProjectProperties);
+
+            Assert.Same(project, services.Project);
         }
 
         [Fact]
         public void Constructor_ValueAsThreadingService_SetsThreadingServiceProperty()
         {
             var threadingService = new Lazy<IProjectThreadingService>(() => IProjectThreadingServiceFactory.Create());
-            var unconfiguredProject = IUnconfiguredProjectFactory.Create();
-            var projectProperties = ProjectPropertiesFactory.Create(unconfiguredProject);
+            var project = IUnconfiguredProjectFactory.Create();
+            var projectProperties = ProjectPropertiesFactory.Create(project);
             var activeConfiguredProject = IActiveConfiguredProjectFactory.ImplementValue(() => projectProperties.ConfiguredProject);
             var activeConfiguredProjectProperties = IActiveConfiguredProjectFactory.ImplementValue(() => projectProperties);
 
-            var services = new UnconfiguredProjectCommonServices(threadingService, activeConfiguredProject, activeConfiguredProjectProperties);
+            var services = new UnconfiguredProjectCommonServices(project, threadingService, activeConfiguredProject, activeConfiguredProjectProperties);
 
             Assert.Same(threadingService.Value, services.ThreadingService);
         }
@@ -65,12 +93,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public void Constructor_ValueAsActiveConfiguredProject_SetsActiveConfiguredProjectProperty()
         {
             var threadingService = new Lazy<IProjectThreadingService>(() => IProjectThreadingServiceFactory.Create());
-            var unconfiguredProject = IUnconfiguredProjectFactory.Create();
-            var projectProperties = ProjectPropertiesFactory.Create(unconfiguredProject);
+            var project = IUnconfiguredProjectFactory.Create();
+            var projectProperties = ProjectPropertiesFactory.Create(project);
             var activeConfiguredProject = IActiveConfiguredProjectFactory.ImplementValue(() => projectProperties.ConfiguredProject);
             var activeConfiguredProjectProperties = IActiveConfiguredProjectFactory.ImplementValue(() => projectProperties);
 
-            var services = new UnconfiguredProjectCommonServices(threadingService, activeConfiguredProject, activeConfiguredProjectProperties);
+            var services = new UnconfiguredProjectCommonServices(project, threadingService, activeConfiguredProject, activeConfiguredProjectProperties);
 
             Assert.Same(projectProperties.ConfiguredProject, services.ActiveConfiguredProject);
         }
@@ -79,12 +107,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public void Constructor_ValueAsActiveConfiguredProjectProperties_SetsActiveConfiguredProjectPropertiesProperty()
         {
             var threadingService = new Lazy<IProjectThreadingService>(() => IProjectThreadingServiceFactory.Create());
-            var unconfiguredProject = IUnconfiguredProjectFactory.Create();
-            var projectProperties = ProjectPropertiesFactory.Create(unconfiguredProject);
+            var project = IUnconfiguredProjectFactory.Create();
+            var projectProperties = ProjectPropertiesFactory.Create(project);
             var activeConfiguredProject = IActiveConfiguredProjectFactory.ImplementValue(() => projectProperties.ConfiguredProject);
             var activeConfiguredProjectProperties = IActiveConfiguredProjectFactory.ImplementValue(() => projectProperties);
 
-            var services = new UnconfiguredProjectCommonServices(threadingService, activeConfiguredProject, activeConfiguredProjectProperties);
+            var services = new UnconfiguredProjectCommonServices(project, threadingService, activeConfiguredProject, activeConfiguredProjectProperties);
 
             Assert.Same(projectProperties, services.ActiveConfiguredProjectProperties);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IUnconfiguredProjectVsServicesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IUnconfiguredProjectVsServicesFactory.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         public static IUnconfiguredProjectVsServices Implement(Func<IVsHierarchy> hierarchyCreator, Func<IVsProject4> projectCreator = null)
         {
             var mock = new Mock<IUnconfiguredProjectVsServices>();
-            mock.SetupGet(h => h.Hierarchy)
+            mock.SetupGet(h => h.VsHierarchy)
                 .Returns(hierarchyCreator);
 
             mock.SetupGet(h => h.ThreadingService)
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             if (projectCreator != null)
             {
-                mock.SetupGet(h => h.Project)
+                mock.SetupGet(h => h.VsProject)
                     .Returns(projectCreator());
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UnconfiguredProjectVsServicesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UnconfiguredProjectVsServicesTests.cs
@@ -10,57 +10,59 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     public class UnconfiguredProjectVsServicesTests
     {
         [Fact]
-        public void Constructor_NullAsUnconfiguedProject_ThrowsArgumentNull()
-        {
-            var commonServices = IUnconfiguredProjectCommonServicesFactory.Create();
-
-            Assert.Throws<ArgumentNullException>("unconfiguredProject", () => {
-                new UnconfiguredProjectVsServices((UnconfiguredProject)null, commonServices);
-            });
-        }
-
-        [Fact]
         public void Constructor_NullAsCommonSevices_ThrowsArgumentNull()
         {
-            var unconfiguredProject = IUnconfiguredProjectFactory.Create();
+            var project = IUnconfiguredProjectFactory.Create();
 
             Assert.Throws<ArgumentNullException>("commonServices", () => {
-                new UnconfiguredProjectVsServices(unconfiguredProject, (IUnconfiguredProjectCommonServices)null);
+                new UnconfiguredProjectVsServices((IUnconfiguredProjectCommonServices)null);
             });
         }
 
         [Fact]
-        public void Constructor_ValueAsUnconfiguedProject_SetsHierarchyToHostObject()
+        public void Constructor_ValueAsUnconfiguedProject_SetsVsHierarchyToHostObject()
         {
             var hierarchy = IVsHierarchyFactory.Create();
-            var unconfiguredProject = IUnconfiguredProjectFactory.Create(hostObject:hierarchy);
-            var commonServices = IUnconfiguredProjectCommonServicesFactory.Create();
+            var project = IUnconfiguredProjectFactory.Create(hostObject:hierarchy);
+            var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(project: project);
 
-            var vsServices = CreateInstance(unconfiguredProject, commonServices);
+            var vsServices = CreateInstance(commonServices);
 
-            Assert.Same(hierarchy, vsServices.Hierarchy);
+            Assert.Same(hierarchy, vsServices.VsHierarchy);
         }
 
         [Fact]
-        public void Constructor_ValueAsUnconfiguedProject_SetsProjectToHostObject()
+        public void Constructor_ValueAsUnconfiguedProject_SetsVsProjectToHostObject()
         {
             var hierarchy = IVsHierarchyFactory.Create();
-            var unconfiguredProject = IUnconfiguredProjectFactory.Create(hostObject: hierarchy);
-            var commonServices = IUnconfiguredProjectCommonServicesFactory.Create();
+            var project = IUnconfiguredProjectFactory.Create(hostObject: hierarchy);
+            var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(project: project);
 
-            var vsServices = CreateInstance(unconfiguredProject, commonServices);
+            var vsServices = CreateInstance(commonServices);
 
-            Assert.Same(hierarchy, vsServices.Project);
+            Assert.Same(hierarchy, vsServices.VsProject);
+        }
+
+        [Fact]
+        public void Constructor_ValueAsCommonServices_SetsProjectToCommonServicesProject()
+        {
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var project = IUnconfiguredProjectFactory.Create();
+            var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(project: project);
+
+            var vsServices = CreateInstance(commonServices);
+
+            Assert.Same(project, vsServices.Project);
         }
 
         [Fact]
         public void Constructor_ValueAsCommonServices_SetsThreadingServiceToCommonServicesThreadingService()
         {
             var threadingService = IProjectThreadingServiceFactory.Create();
-            var unconfiguredProject = IUnconfiguredProjectFactory.Create();
+            var project = IUnconfiguredProjectFactory.Create();
             var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(threadingService: threadingService);
 
-            var vsServices = CreateInstance(unconfiguredProject, commonServices);
+            var vsServices = CreateInstance(commonServices);
 
             Assert.Same(threadingService, vsServices.ThreadingService);
         }
@@ -68,11 +70,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         [Fact]
         public void Constructor_ValueAsCommonServices_SetsActiveConfiguredProjectProjectToCommonServicesActiveConfiguredProject()
         {
-            var unconfiguredProject = IUnconfiguredProjectFactory.Create();
-            var projectProperties = ProjectPropertiesFactory.Create(unconfiguredProject);
+            var project = IUnconfiguredProjectFactory.Create();
+            var projectProperties = ProjectPropertiesFactory.Create(project);
             var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(configuredProject: projectProperties.ConfiguredProject);
 
-            var vsServices = CreateInstance(unconfiguredProject, commonServices);
+            var vsServices = CreateInstance(commonServices);
 
             Assert.Same(projectProperties.ConfiguredProject, vsServices.ActiveConfiguredProject);
         }
@@ -80,18 +82,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         [Fact]
         public void Constructor_ValueAsCommonServices_SetsActiveConfiguredProjectPropertiesToCommonServicesActiveConfiguredProjectProperties()
         {
-            var unconfiguredProject = IUnconfiguredProjectFactory.Create();
-            var projectProperties = ProjectPropertiesFactory.Create(unconfiguredProject);
+            var project = IUnconfiguredProjectFactory.Create();
+            var projectProperties = ProjectPropertiesFactory.Create(project);
             var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(projectProperties: projectProperties);
 
-            var vsServices = CreateInstance(unconfiguredProject, commonServices);
+            var vsServices = CreateInstance(commonServices);
 
             Assert.Same(projectProperties, vsServices.ActiveConfiguredProjectProperties);
         }
 
-        private static UnconfiguredProjectVsServices CreateInstance(UnconfiguredProject unconfiguredProject, IUnconfiguredProjectCommonServices commonServices)
+        private static UnconfiguredProjectVsServices CreateInstance(IUnconfiguredProjectCommonServices commonServices)
         {
-            return new UnconfiguredProjectVsServices(unconfiguredProject, commonServices);
+            return new UnconfiguredProjectVsServices(commonServices);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IUnconfiguredProjectVsServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IUnconfiguredProjectVsServices.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// <summary>
         ///     Gets <see cref="IVsHierarchy"/> provided by the <see cref="UnconfiguredProject"/>.
         /// </summary>
-        IVsHierarchy Hierarchy
+        IVsHierarchy VsHierarchy
         {
             get;
         }
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// <summary>
         ///     Gets <see cref="IVsProject4"/> provided by the <see cref="UnconfiguredProject"/>.
         /// </summary>
-        IVsProject4 Project
+        IVsProject4 VsProject
         {
             get;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/AbstractLanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/AbstractLanguageServiceHost.cs
@@ -82,11 +82,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         /// <summary>
         /// Gets the unconfigured project.
         /// </summary>
-        [Import]
         public UnconfiguredProject UnconfiguredProject
         {
-            get;
-            private set;
+            get { return _projectVsServices.Project; }
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/AbstractLanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/AbstractLanguageServiceHost.cs
@@ -315,7 +315,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
                 switch (dwPropID)
                 {
                     case (uint)HOSTPROPID.HOSTPROPID_HIERARCHY:
-                        pvar = _projectVsServices.Hierarchy;
+                        pvar = _projectVsServices.VsHierarchy;
                         break;
                     case (uint)HOSTPROPID.HOSTPROPID_PROJECTNAME:
                         pvar = UnconfiguredProject.FullPath;
@@ -388,7 +388,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         FileCodeModel ICodeModelProvider.GetFileCodeModel(ProjectItem fileItem)
         {
             object result;
-            Marshal.ThrowExceptionForHR(_intellisenseEngine.GetFileCodeModel(_projectVsServices.Hierarchy, fileItem, out result));
+            Marshal.ThrowExceptionForHR(_intellisenseEngine.GetFileCodeModel(_projectVsServices.VsHierarchy, fileItem, out result));
             return (FileCodeModel)result;
         }
 
@@ -495,11 +495,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         {
             ThreadingService.VerifyOnUIThread();
 
-            HierarchyId id = _projectVsServices.Project.GetHierarchyId(documentMoniker);
+            HierarchyId id = _projectVsServices.VsProject.GetHierarchyId(documentMoniker);
             if (id.IsNil || id.IsRoot)
                 return null;
 
-            return _projectVsServices.Hierarchy.GetProperty(id, VsHierarchyPropID.ExtObject, (ProjectItem)null);
+            return _projectVsServices.VsHierarchy.GetProperty(id, VsHierarchyPropID.ExtObject, (ProjectItem)null);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/ProjectDesignerService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/ProjectDesignerService.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
         public bool SupportsProjectDesigner
         {
-            get { return _projectVsServices.Hierarchy.GetProperty(VsHierarchyPropID.SupportsProjectDesigner, defaultValue: false); }
+            get { return _projectVsServices.VsHierarchy.GetProperty(VsHierarchyPropID.SupportsProjectDesigner, defaultValue: false); }
         }
 
         public Task ShowProjectDesignerAsync()
@@ -42,9 +42,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
         private async Task OpenProjectDesignerAsyncCore()
         {
-            Guid projectDesignerGuid = _projectVsServices.Hierarchy.GetGuidProperty(VsHierarchyPropID.ProjectDesignerEditor);
+            Guid projectDesignerGuid = _projectVsServices.VsHierarchy.GetGuidProperty(VsHierarchyPropID.ProjectDesignerEditor);
 
-            IVsWindowFrame frame = _projectVsServices.Project.OpenItemWithSpecific(HierarchyId.Root, projectDesignerGuid);
+            IVsWindowFrame frame = _projectVsServices.VsProject.OpenItemWithSpecific(HierarchyId.Root, projectDesignerGuid);
             if (frame != null)
             {   // Opened within Visual Studio
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UnconfiguredProjectVsServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UnconfiguredProjectVsServices.cs
@@ -13,32 +13,34 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     [Export(typeof(IUnconfiguredProjectVsServices))]
     internal class UnconfiguredProjectVsServices : IUnconfiguredProjectVsServices
     {
-        private readonly UnconfiguredProject _unconfiguredProject;
         private readonly IUnconfiguredProjectCommonServices _commonServices;
 
         [ImportingConstructor]
-        public UnconfiguredProjectVsServices(UnconfiguredProject unconfiguredProject, IUnconfiguredProjectCommonServices commonServices)
+        public UnconfiguredProjectVsServices(IUnconfiguredProjectCommonServices commonServices)
         {
-            Requires.NotNull(unconfiguredProject, nameof(unconfiguredProject));
             Requires.NotNull(commonServices, nameof(commonServices));
 
-            _unconfiguredProject = unconfiguredProject;
             _commonServices = commonServices;
         }
 
-        public IVsHierarchy Hierarchy
+        public IVsHierarchy VsHierarchy
         {
-            get { return (IVsHierarchy)_unconfiguredProject.Services.HostObject; }
+            get { return (IVsHierarchy)_commonServices.Project.Services.HostObject; }
         }
 
-        public IVsProject4 Project
+        public IVsProject4 VsProject
         {
-            get { return (IVsProject4)_unconfiguredProject.Services.HostObject; }
+            get { return (IVsProject4)_commonServices.Project.Services.HostObject; }
         }
 
         public IProjectThreadingService ThreadingService
         {
             get { return _commonServices.ThreadingService; }
+        }
+
+        public UnconfiguredProject Project
+        {
+            get { return _commonServices.Project; }
         }
 
         public ConfiguredProject ActiveConfiguredProject

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IUnconfiguredProjectCommonServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IUnconfiguredProjectCommonServices.cs
@@ -16,6 +16,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         /// <summary>
+        ///     Gets the current <see cref="UnconfiguredProject"/>.
+        /// </summary>
+        UnconfiguredProject Project
+        {
+            get;
+        }
+
+        /// <summary>
         ///     Gets the current active <see cref="ConfiguredProject"/>.
         /// </summary>
         ConfiguredProject ActiveConfiguredProject

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectCommonServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectCommonServices.cs
@@ -11,17 +11,20 @@ namespace Microsoft.VisualStudio.ProjectSystem
     [Export(typeof(IUnconfiguredProjectCommonServices))]
     internal class UnconfiguredProjectCommonServices : IUnconfiguredProjectCommonServices
     {
+        private readonly UnconfiguredProject _project;
         private readonly Lazy<IProjectThreadingService> _threadingService;
         private readonly ActiveConfiguredProject<ConfiguredProject> _activeConfiguredProject;
         private readonly ActiveConfiguredProject<ProjectProperties> _activeConfiguredProjectProperties;
 
         [ImportingConstructor]
-        public UnconfiguredProjectCommonServices(Lazy<IProjectThreadingService> threadingService, ActiveConfiguredProject<ConfiguredProject> activeConfiguredProject, ActiveConfiguredProject<ProjectProperties> activeConfiguredProjectProperties)
+        public UnconfiguredProjectCommonServices(UnconfiguredProject project, Lazy<IProjectThreadingService> threadingService, ActiveConfiguredProject<ConfiguredProject> activeConfiguredProject, ActiveConfiguredProject<ProjectProperties> activeConfiguredProjectProperties)
         {
+            Requires.NotNull(project, nameof(project));
             Requires.NotNull(threadingService, nameof(threadingService));
             Requires.NotNull(activeConfiguredProject, nameof(activeConfiguredProject));
             Requires.NotNull(activeConfiguredProjectProperties, nameof(activeConfiguredProjectProperties));
 
+            _project = project;
             _threadingService = threadingService;
             _activeConfiguredProject = activeConfiguredProject;
             _activeConfiguredProjectProperties = activeConfiguredProjectProperties;
@@ -30,6 +33,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public IProjectThreadingService ThreadingService
         {
             get { return _threadingService.Value; }
+        }
+
+        public UnconfiguredProject Project
+        {
+            get { return _project;  }
         }
 
         public ConfiguredProject ActiveConfiguredProject

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/ProjectSystem/MyProjectFolderProjectTreePropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/ProjectSystem/MyProjectFolderProjectTreePropertiesProviderTests.cs
@@ -565,15 +565,15 @@ Root (flags: {ProjectRoot})
         {
             designerService = designerService ?? IProjectDesignerServiceFactory.Create();
             var threadingService = IProjectThreadingServiceFactory.Create();
-            var unconfiguredProject = IUnconfiguredProjectFactory.Create();
-            var projectProperties = ProjectPropertiesFactory.Create(unconfiguredProject, 
+            var project = IUnconfiguredProjectFactory.Create();
+            var projectProperties = ProjectPropertiesFactory.Create(project, 
                 new PropertyPageData() {
                     Category = nameof(ConfigurationGeneral),
                     PropertyName = nameof(ConfigurationGeneral.AppDesignerFolder),
                     Value = appDesignerFolder
                 });
 
-            var projectServices = IUnconfiguredProjectCommonServicesFactory.Create(threadingService, projectProperties.ConfiguredProject, projectProperties);
+            var projectServices = IUnconfiguredProjectCommonServicesFactory.Create(project, threadingService, projectProperties.ConfiguredProject, projectProperties);
 
             return new MyProjectFolderProjectTreePropertiesProvider(imageProvider ?? IProjectImageProviderFactory.Create(), projectServices, designerService);
         }


### PR DESCRIPTION
This gives access to the current project, so you don't need to import it and this service.
I also added "Vs" to the IVsUnconfiguredProjectVsService properties to distinguish them.