### PR TITLE
Set shared project icons

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Imaging/CSharpProjectImageProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Imaging/CSharpProjectImageProviderTests.cs
@@ -50,6 +50,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Imaging
 
         [Theory]
         [InlineData(ProjectImageKey.ProjectRoot)]
+        [InlineData(ProjectImageKey.SharedProjectRoot)]
+        [InlineData(ProjectImageKey.SharedItemsImportFile)]
         [InlineData(ProjectImageKey.AppDesignerFolder)]
         public void GetProjectImage_RecognizedKeyAsKey_ReturnsNonNull(string key)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Imaging/CSharpProjectImageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Imaging/CSharpProjectImageProvider.cs
@@ -27,6 +27,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Imaging
                 case ProjectImageKey.ProjectRoot:
                     return KnownMonikers.CSProjectNode.ToProjectSystemType();
 
+                case ProjectImageKey.SharedItemsImportFile:
+                case ProjectImageKey.SharedProjectRoot:
+                    return KnownMonikers.CSSharedProject.ToProjectSystemType();
+
                 case ProjectImageKey.AppDesignerFolder:
                     return KnownMonikers.Property.ToProjectSystemType();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
@@ -43,6 +43,7 @@
   <ItemGroup>
     <Compile Include="Mocks\IActiveConfiguredProjectFactory.cs" />
     <Compile Include="Mocks\IOrderPrecedenceMetadataViewFactory.cs" />
+    <Compile Include="Mocks\IProjectCapabilitiesServiceFactory.cs" />
     <Compile Include="Mocks\IProjectThreadingServiceFactory.cs" />
     <Compile Include="Mocks\IProjectTreeCustomizablePropertyContextFactory.cs" />
     <Compile Include="Mocks\IProjectTreeCustomizablePropertyValuesFactory.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectCapabilitiesServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectCapabilitiesServiceFactory.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IProjectCapabilitiesServiceFactory
+    {
+        public static IProjectCapabilitiesService Create()
+        {
+            return Mock.Of<IProjectCapabilitiesService>();
+        }
+
+        public static IProjectCapabilitiesService ImplementsContains(Func<string, bool> action)
+        {
+            var mock = new Mock<IProjectCapabilitiesService>();
+
+            mock.Setup(s => s.Contains(It.IsAny<string>()))
+                .Returns(action);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -37,6 +37,8 @@
     <Compile Include="ProjectSystem\Imaging\IProjectImageProvider.cs" />
     <Compile Include="ProjectSystem\Imaging\ProjectImageKey.cs" />
     <Compile Include="ProjectSystem\Imaging\ProjectImageProviderAggregator.cs" />
+    <Compile Include="ProjectSystem\ProjectCapabilitiesService.cs" />
+    <Compile Include="ProjectSystem\IProjectCapabilitiesService.cs" />
     <Compile Include="ProjectSystem\ProjectRootImageProjectTreePropertiesProvider.cs" />
     <Compile Include="ProjectSystem\Input\GetCommandStatusResult.cs" />
     <Compile Include="ProjectSystem\Input\AbstractSingleNodeProjectCommand.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectCapabilitiesService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectCapabilitiesService.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    /// <summary>
+    ///     Provides methods for querying and testing the current project's capabilities.
+    /// </summary>
+    internal interface IProjectCapabilitiesService
+    {   // This interface introduced just so that we can mock checks for capabilities, 
+        // to avoid static state and call context data that we cannot influence
+
+        /// <summary>
+        ///     Returns a value indicating whether the current project has the specified capability
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="capability"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="capability"/> is an empty string ("").
+        /// </exception>
+        bool Contains(string capability);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/ProjectImageKey.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/ProjectImageKey.cs
@@ -13,6 +13,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Imaging
         public const string ProjectRoot = nameof(ProjectRoot);
 
         /// <summary>
+        ///     Represents the image key for the root of a shared project hierarchy.
+        /// </summary>
+        public const string SharedProjectRoot = nameof(SharedProjectRoot);
+
+        /// <summary>
+        ///     Represents the image key for the Shared.items file that is imported into this project in order to add a shared folder.
+        /// </summary>
+        public const string SharedItemsImportFile = nameof(SharedItemsImportFile);
+
+        /// <summary>
         ///     Represents the image key for the AppDesigner folder (called "Properties" in C# and "My Project" in VB).
         /// </summary>
         public const string AppDesignerFolder = nameof(AppDesignerFolder);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapabilitiesService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapabilitiesService.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    /// <summary>
+    ///     Provides an implementation of <see cref="IProjectCapabilitiesService"/> that simply delegates 
+    ///     onto the <see cref="CapabilitiesExtensions.Contains(IProjectCapabilitiesScope, string)"/> method.
+    /// </summary>
+    [Export(typeof(IProjectCapabilitiesService))]
+    internal class ProjectCapabilitiesService : IProjectCapabilitiesService
+    {
+        private readonly UnconfiguredProject _project;
+
+        [ImportingConstructor]
+        public ProjectCapabilitiesService(UnconfiguredProject project)
+        {
+            Requires.NotNull(project, nameof(project));
+
+            _project = project;
+        }
+
+        public bool Contains(string capability)
+        {
+            Requires.NotNullOrEmpty(capability, nameof(capability));
+
+            // Just to check capabilities, requires static state and call context that we cannot influence
+            return _project.Capabilities.Contains(capability);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Imaging/VisualBasicProjectImageProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Imaging/VisualBasicProjectImageProviderTests.cs
@@ -50,6 +50,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Imaging
 
         [Theory]
         [InlineData(ProjectImageKey.ProjectRoot)]
+        [InlineData(ProjectImageKey.SharedProjectRoot)]
+        [InlineData(ProjectImageKey.SharedItemsImportFile)]
         [InlineData(ProjectImageKey.AppDesignerFolder)]
         public void GetProjectImage_RecognizedKeyAsKey_ReturnsNonNull(string key)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Imaging/VisualBasicProjectImageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Imaging/VisualBasicProjectImageProvider.cs
@@ -27,6 +27,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Imaging
                 case ProjectImageKey.ProjectRoot:
                     return KnownMonikers.VBProjectNode.ToProjectSystemType();
 
+                case ProjectImageKey.SharedItemsImportFile:
+                case ProjectImageKey.SharedProjectRoot:
+                    return KnownMonikers.VBSharedProject.ToProjectSystemType();
+
                 case ProjectImageKey.AppDesignerFolder:
                     return KnownMonikers.Property.ToProjectSystemType();
 


### PR DESCRIPTION
We were setting shared project icons to C#/VB project icons, instead of the shared project icons - only to be overridden again by CPS. Moved CPS's logic for setting the C#/VB icons to us and will remove theirs in #170. 