### PR TITLE
Moved AppDesigner folder in own rule file.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/ProjectSystem/PropertiesFolderProjectTreePropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/ProjectSystem/PropertiesFolderProjectTreePropertiesProviderTests.cs
@@ -475,8 +475,8 @@ Root (flags: {ProjectRoot})
             var project = IUnconfiguredProjectFactory.Create();
             var projectProperties = ProjectPropertiesFactory.Create(project,
                 new PropertyPageData() {
-                    Category = nameof(ConfigurationGeneral),
-                    PropertyName = nameof(ConfigurationGeneral.AppDesignerFolder),
+                    Category = nameof(AppDesigner),
+                    PropertyName = nameof(AppDesigner.FolderName),
                     Value = appDesignerFolder,
                 });
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -50,6 +50,9 @@
     <Compile Include="ProjectSystem\AbstractAppDesignerFolderProjectTreePropertiesProvider.cs" />
     <Compile Include="ProjectSystem\ProjectTreeFlagsExtensions.cs" />
     <Compile Include="ProjectSystem\AbstractSpecialFolderProjectTreePropertiesProvider.cs" />
+    <Compile Include="ProjectSystem\Rules\AppDesigner.xaml.cs">
+      <DependentUpon>AppDesigner.xaml</DependentUpon>
+    </Compile>
     <Compile Include="ProjectSystem\Rules\CSharp.cs">
       <DependentUpon>CSharp.xaml</DependentUpon>
     </Compile>
@@ -101,6 +104,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <XamlPropertyRule Include="ProjectSystem\Rules\AppDesigner.xaml">
+      <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
+      <SubType>Designer</SubType>
+    </XamlPropertyRule>
   </ItemGroup>
   <Import Project="..\..\build\Targets\VSL.Imports.targets" />
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractAppDesignerFolderProjectTreePropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractAppDesignerFolderProjectTreePropertiesProvider.cs
@@ -59,11 +59,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
             // Returns the <AppDesignerFolder> from the project file
             return _projectServices.ThreadingService.ExecuteSynchronously(async () => {
 
-                var generalProperties = await _projectServices.ActiveConfiguredProjectProperties.GetConfigurationGeneralPropertiesAsync()
-                                                                                                .ConfigureAwait(false);
+                var properties = await _projectServices.ActiveConfiguredProjectProperties.GetAppDesignerPropertiesAsync()
+                                                                                         .ConfigureAwait(false);
 
-                return (string)await generalProperties.AppDesignerFolder.GetValueAsync()
-                                                                        .ConfigureAwait(false);
+                return (string)await properties.FolderName.GetValueAsync()
+                                                          .ConfigureAwait(false);
             });
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AppDesigner.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AppDesigner.xaml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Rule
+    Name="AppDesigner"
+    DisplayName="AppDesigner"
+    PageTemplate="generic"
+    Description="General"
+    xmlns="http://schemas.microsoft.com/build/2009/properties">
+
+    <Rule.DataSource>
+        <DataSource Persistence="ProjectFile" Label="Configuration" />
+    </Rule.DataSource>
+    
+    <StringProperty Name="FolderName" Visible="false" Default="Properties">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFile" Label="Configuration" HasConfigurationCondition="false" PersistedName="AppDesignerFolder"/>
+        </StringProperty.DataSource>
+    </StringProperty>
+  
+</Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AppDesigner.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AppDesigner.xaml.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    [ExcludeFromCodeCoverage]
+    partial class AppDesigner
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -94,10 +94,4 @@
     <StringProperty Name="OneAppCapabilities" Visible="False" />
     <StringProperty Name="SharedProjectAppliesTo" Visible="False" Description="Capability match expression that at a minimum tests for the language of the Shared Project; used to filter Add Shared Project Reference choices."/>
     <BoolProperty Name="AlwaysUseNumericalSuffixInItemNames" Visible="False" Description="Indicates if names of newly added items should always be suffixed with a number." />
-    
-    <StringProperty Name="AppDesignerFolder" Visible="false">
-        <StringProperty.DataSource>
-            <DataSource Persistence="ProjectFile" Label="Configuration" HasConfigurationCondition="false" />
-        </StringProperty.DataSource>
-    </StringProperty>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/ProjectSystem/MyProjectFolderProjectTreePropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/ProjectSystem/MyProjectFolderProjectTreePropertiesProviderTests.cs
@@ -568,8 +568,8 @@ Root (flags: {ProjectRoot})
             var project = IUnconfiguredProjectFactory.Create();
             var projectProperties = ProjectPropertiesFactory.Create(project, 
                 new PropertyPageData() {
-                    Category = nameof(ConfigurationGeneral),
-                    PropertyName = nameof(ConfigurationGeneral.AppDesignerFolder),
+                    Category = nameof(AppDesigner),
+                    PropertyName = nameof(AppDesigner.FolderName),
                     Value = appDesignerFolder
                 });
 


### PR DESCRIPTION
This was going to be a large change, but decided to split it up into a more manageable chuck. This moves the AppDesigner Folder property into it's own rule file so that it can be consumed outside of the other properties (for when AppDesigner becomes it's own capability). There will be a few another properties that will be added to this in a future change.