### PR TITLE
Link labels to follow theme colors

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/SpecialFileCustomView.Designer.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/SpecialFileCustomView.Designer.vb
@@ -24,47 +24,41 @@
         'Required by the Control Designer
         Private components As System.ComponentModel.IContainer
 
-        Public WithEvents LinkLabel As VsThemedLinkLabel
+        Public WithEvents LinkLabel As VSThemedLinkLabel
 
         ' NOTE: The following procedure is required by the Component Designer
         ' It can be modified using the Component Designer.  Do not modify it
         ' using the code editor.
-        <System.Diagnostics.DebuggerStepThrough()> _
-            Private Sub InitializeComponent()
+        <System.Diagnostics.DebuggerStepThrough()>
+        Private Sub InitializeComponent()
+            Dim CenterPanel As System.Windows.Forms.TableLayoutPanel
             Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(SpecialFileCustomView))
-            Me.LinkLabel = New FocusableLinkLabel
+            Me.LinkLabel = New VSThemedLinkLabel()
+            CenterPanel = New System.Windows.Forms.TableLayoutPanel()
+            CenterPanel.SuspendLayout()
             Me.SuspendLayout()
+            '
+            'CenterPanel
+            '
+            resources.ApplyResources(CenterPanel, "CenterPanel")
+            CenterPanel.Controls.Add(Me.LinkLabel, 1, 0)
+            CenterPanel.Name = "CenterPanel"
             '
             'LinkLabel
             '
             resources.ApplyResources(Me.LinkLabel, "LinkLabel")
             Me.LinkLabel.Name = "LinkLabel"
-            Me.LinkLabel.TabStop = True
             '
             'SpecialFileCustomView
             '
-            Me.Controls.Add(Me.LinkLabel)
+            Me.Controls.Add(CenterPanel)
             Me.Name = "SpecialFileCustomView"
             resources.ApplyResources(Me, "$this")
+            CenterPanel.ResumeLayout(False)
+            CenterPanel.PerformLayout()
             Me.ResumeLayout(False)
 
         End Sub
-
-        ''' <summary>
-        ''' Overrides the default behavior of the LinkLabel to show focus
-        ''' </summary>
-        Private Class FocusableLinkLabel
-            Inherits VsThemedLinkLabel
-
-            ''' <summary>
-            ''' Overrides the default behavior of the LinkLabel to show focus
-            ''' </summary>
-            Protected Overrides ReadOnly Property ShowFocusCues() As Boolean
-                Get
-                    Return True
-                End Get
-            End Property
-        End Class
 
     End Class
 

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/SpecialFileCustomView.resx
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/SpecialFileCustomView.resx
@@ -46,7 +46,7 @@
     
     mimetype: application/x-microsoft.net.object.binary.base64
     value   : The object must be serialized with 
-            : System.Serialization.Formatters.Binary.BinaryFormatter
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
@@ -60,6 +60,7 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
@@ -71,6 +72,7 @@
               <xsd:attribute name="name" use="required" type="xsd:string" />
               <xsd:attribute name="type" type="xsd:string" />
               <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
@@ -88,6 +90,7 @@
               <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
               <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
               <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
@@ -109,54 +112,90 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="LinkLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
+  <metadata name="CenterPanel.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="CenterPanel.ColumnCount" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="LinkLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="LinkLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="LinkLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
+    <value>102, 49</value>
   </data>
   <data name="LinkLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>205, 112</value>
+    <value>0, 13</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="LinkLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
-  </data>
-  <data name="LinkLabel.Text">
-    <value xml:space="preserve"></value>
   </data>
   <data name="LinkLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleCenter</value>
   </data>
-  <data name="&gt;&gt;LinkLabel.Name">
-    <value xml:space="preserve">LinkLabel</value>
+  <data name="&gt;&gt;LinkLabel.Name" xml:space="preserve">
+    <value>LinkLabel</value>
   </data>
-  <data name="&gt;&gt;LinkLabel.Type">
-    <value xml:space="preserve">System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;LinkLabel.Type" xml:space="preserve">
+    <value>VSThemedLinkLabel, Microsoft.VisualStudio.AppDesigner, Version=42.42.42.42, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="&gt;&gt;LinkLabel.Parent">
-    <value xml:space="preserve">$this</value>
+  <data name="&gt;&gt;LinkLabel.Parent" xml:space="preserve">
+    <value>CenterPanel</value>
   </data>
-  <data name="&gt;&gt;LinkLabel.ZOrder">
-    <value xml:space="preserve">0</value>
+  <data name="&gt;&gt;LinkLabel.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <data name="CenterPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="CenterPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="CenterPanel.RowCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="CenterPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>205, 112</value>
+  </data>
+  <data name="CenterPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;CenterPanel.Name" xml:space="preserve">
+    <value>CenterPanel</value>
+  </data>
+  <data name="&gt;&gt;CenterPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CenterPanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CenterPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="CenterPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="LinkLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,50,AutoSize,0,Percent,50" /&gt;&lt;Rows Styles="Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
     <value>205, 112</value>
   </data>
-  <data name="&gt;&gt;$this.Name">
-    <value xml:space="preserve">SpecialFileCustomView</value>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>SpecialFileCustomView</value>
   </data>
-  <data name="&gt;&gt;$this.Type">
-    <value xml:space="preserve">System.Windows.Forms.UserControl, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/VSThemedLinkLabel.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/VSThemedLinkLabel.vb
@@ -3,9 +3,13 @@
 Imports System.Drawing
 Imports Microsoft.VisualStudio.Shell.Interop
 Imports Microsoft.VisualStudio.Editors.AppDesCommon
+Imports System.Windows.Forms
 
 Public Class VSThemedLinkLabel
-    Inherits System.Windows.Forms.LinkLabel
+    Inherits LinkLabel
+
+    Private _vsThemedLinkColor As Color
+    Private _vsThemedLinkColorHover As Color
 
     Public Sub New()
         MyBase.New()
@@ -15,28 +19,24 @@ Public Class VSThemedLinkLabel
 
     End Sub
 
-    Private _vsThemedLinkColor As System.Drawing.Color
-    Private _vsThemedLinkColorHover As System.Drawing.Color
-
     Public Sub SetThemedColor(ByVal vsUIShell5 As IVsUIShell5)
 
         Dim environmentThemeCategory As Guid = New Guid("624ed9c3-bdfd-41fa-96c3-7c824ea32e3d")
 
         ' The default value is the actual value of DiagReportLinkTextHover and DiagReportLinkText defined by Dev11
-        _vsThemedLinkColorHover = ShellUtil.GetDesignerThemeColor(vsUIShell5, environmentThemeCategory, "DiagReportLinkTextHover", __THEMEDCOLORTYPE.TCT_Background, Color.FromArgb(&HFF1382CE))
-        _vsThemedLinkColor = ShellUtil.GetDesignerThemeColor(vsUIShell5, environmentThemeCategory, "DiagReportLinkText", __THEMEDCOLORTYPE.TCT_Background, Color.FromArgb(&HFF1382CE))
+        _vsThemedLinkColorHover = ShellUtil.GetDesignerThemeColor(vsUIShell5, environmentThemeCategory, "PanelHyperlinkHover", __THEMEDCOLORTYPE.TCT_Background, Color.FromArgb(&HFF1382CE))
+        _vsThemedLinkColor = ShellUtil.GetDesignerThemeColor(vsUIShell5, environmentThemeCategory, "PanelHyperlink", __THEMEDCOLORTYPE.TCT_Background, Color.FromArgb(&HFF1382CE))
 
-        ' By design, active link color also maps to DiagReportLinkTextHover
-        MyBase.ActiveLinkColor = _vsThemedLinkColorHover
-        MyBase.LinkColor = _vsThemedLinkColor
-
+        ActiveLinkColor = ShellUtil.GetDesignerThemeColor(vsUIShell5, environmentThemeCategory, "PanelHyperlinkPressed", __THEMEDCOLORTYPE.TCT_Background, Color.FromArgb(&HFF1382CE))
+        LinkColor = _vsThemedLinkColor
+        LinkBehavior = LinkBehavior.HoverUnderline
     End Sub
 
     Private Sub VsThemedLinkLabel_MouseEnter(sender As Object, e As System.EventArgs) Handles MyBase.MouseEnter
-        MyBase.LinkColor = _vsThemedLinkColorHover
+        LinkColor = _vsThemedLinkColorHover
     End Sub
 
     Private Sub VsThemedLinkLabel_MouseLeave(sender As Object, e As System.EventArgs) Handles MyBase.MouseLeave
-        MyBase.LinkColor = _vsThemedLinkColor
+        LinkColor = _vsThemedLinkColor
     End Sub
 End Class


### PR DESCRIPTION
- Changed Link labels in AppDesigner to follow correct theme colors
- Stop fullscreening link label for resources/settings (this prevents mouse over on the link label from occurring as soon as it enters the property page)
- Stop always showing focus cues unless it's actually got focus via the keyboard

###  Before
#### Normal, Mouse Over, Active ("clicked"), Focus:
![image](https://cloud.githubusercontent.com/assets/1103906/15528216/ab5e18d8-21f6-11e6-9fc9-24310d236eae.png)

### After:
#### Normal:
![image](https://cloud.githubusercontent.com/assets/1103906/15528257/050601b6-21f7-11e6-834b-d3582ef13f0c.png)

#### Mouse Over:
![image](https://cloud.githubusercontent.com/assets/1103906/15528270/17241252-21f7-11e6-9f01-3862f4c7d5cf.png)

#### Active:
![image](https://cloud.githubusercontent.com/assets/1103906/15528288/4a12cf82-21f7-11e6-8a43-f6f724f7b599.png)

#### Focus:
![image](https://cloud.githubusercontent.com/assets/1103906/15528276/2eebdd20-21f7-11e6-8cd3-b78bfd1bc761.png)
