### PR TITLE
Add implicit pause to console window on CTRL+F5

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Mocks\IProjectDesignerServiceFactory.cs" />
     <Compile Include="OrderPrecedenceImportCollectionExtensions.cs" />
     <Compile Include="ProjectSystem\AppDesignerFolderProjectTreePropertiesProviderTests.cs" />
+    <Compile Include="ProjectSystem\Debug\ManagedDebuggerImageTypeServiceTests.cs" />
     <Compile Include="ProjectSystem\Imaging\ProjectImageProviderAggregatorTests.cs" />
     <Compile Include="ProjectSystem\ProjectRootImageProjectTreeModifierTests.cs" />
     <Compile Include="ProjectSystem\UnconfiguredProjectCommonServicesTests.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/ManagedDebuggerImageTypeServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/ManagedDebuggerImageTypeServiceTests.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Imaging;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    [ProjectSystemTrait]
+    public class ManagedDebuggerImageTypeServiceTests
+    {
+        [Fact]
+        public void Constructor_NullAsProperties_ThrowsArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>("properties", () => {
+                new ManagedDebuggerImageTypeService((ProjectProperties)null);
+            });
+        }
+
+        [Fact]
+        public void AppUserModelID_ThrowsNotSupported()
+        {
+            var service = CreateInstance();
+
+            Assert.Throws<NotSupportedException>(() => {
+
+                var ignored = service.AppUserModelID;
+            });
+        }
+
+        [Fact]
+        public void TargetImageClrType_ReturnsManaged()
+        {
+            var service = CreateInstance();
+
+            var result = service.TargetImageClrType;
+
+            Assert.Equal(ImageClrType.Managed, result);
+        }
+
+        [Fact]
+        public void PackageMoniker_ThrowsNotSupported()
+        {
+            var service = CreateInstance();
+
+            Assert.Throws<NotSupportedException>(() => {
+
+                var ignored = service.PackageMoniker;
+            });
+        }
+
+        [Fact]
+        public void GetIs64BitAsync_ThrowsNotSupported()
+        {
+            var service = CreateInstance();
+
+            Assert.Throws<NotSupportedException>(() => {
+                service.GetIs64BitAsync();
+            });
+        }
+
+        [Theory]
+        [InlineData("AppContainerExe")]
+        [InlineData("Library")]
+        [InlineData("winexe")]
+        [InlineData("WinMDObj")]
+        [InlineData("Foo")]
+        public async Task GetIsConsoleAppAsync_WhenOutputTypeNotExe_ReturnsFalse(string outputType)
+        {
+            var service = CreateInstance(outputType);
+
+            var result = await service.GetIsConsoleAppAsync();
+
+            Assert.False(result);
+        }
+
+        [Theory]
+        [InlineData("exe")]
+        [InlineData("EXE")]
+        [InlineData("Exe")]
+        public async Task GetIsConsoleAppAsync_WhenOutputTypeExe_ReturnsTrue(string outputType)
+        {
+            var service = CreateInstance(outputType);
+
+            var result = await service.GetIsConsoleAppAsync();
+
+            Assert.True(result);
+        }
+
+        private ManagedDebuggerImageTypeService CreateInstance()
+        {
+            var project = IUnconfiguredProjectFactory.Create();
+            var properties = ProjectPropertiesFactory.Create(project);
+
+            return new ManagedDebuggerImageTypeService(properties);
+        }
+
+        private ManagedDebuggerImageTypeService CreateInstance(string outputType)
+        {
+            var data = new PropertyPageData() {
+                Category = ConfigurationGeneral.SchemaName,
+                PropertyName = ConfigurationGeneral.OutputTypeProperty,
+                Value = outputType
+            };
+
+            var project = IUnconfiguredProjectFactory.Create();
+            var properties = ProjectPropertiesFactory.Create(project, data);
+
+            return new ManagedDebuggerImageTypeService(properties);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/GlobalSuppressions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/GlobalSuppressions.cs
@@ -9,4 +9,5 @@
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "RS0006:Do not mix attributes from different versions of MEF", Justification = "<Pending>", Scope = "type", Target = "~T:Microsoft.VisualStudio.ProjectSystem.ProjectRootImageProjectTreePropertiesProvider")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "RS0006:Do not mix attributes from different versions of MEF", Justification = "<Pending>", Scope = "type", Target = "~T:Microsoft.VisualStudio.ProjectSystem.DisableInboxComponentsProjectCapabilityProvider")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "RS0006:Do not mix attributes from different versions of MEF", Justification = "<Pending>", Scope = "type", Target = "~T:Microsoft.VisualStudio.ProjectSystem.AppDesignerFolderProjectTreePropertiesProvider")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "RS0006:Do not mix attributes from different versions of MEF", Justification = "<Pending>", Scope = "type", Target = "~T:Microsoft.VisualStudio.ProjectSystem.Debug.ManagedDebuggerImageTypeService")]
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -33,6 +33,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="ProjectSystem\Debug\ManagedDebuggerImageTypeService.cs" />
     <Compile Include="ProjectSystem\DisableInboxComponentsProjectCapabilityProvider.cs" />
     <Compile Include="ProjectSystem\Imaging\IProjectImageProvider.cs" />
     <Compile Include="ProjectSystem\Imaging\ProjectImageKey.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ManagedDebuggerImageTypeService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ManagedDebuggerImageTypeService.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    /// <summary>
+    ///     Provides debuggers with information agbout the target output that the project generates.
+    /// </summary>
+    [Export(typeof(IDebuggerImageTypeService))]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
+    internal class ManagedDebuggerImageTypeService : IDebuggerImageTypeService
+    {
+        private readonly ProjectProperties _properties;
+
+        [ImportingConstructor]
+        public ManagedDebuggerImageTypeService(ProjectProperties properties)
+        {
+            Requires.NotNull(properties, nameof(properties));
+
+            _properties = properties;
+        }
+
+        public ImageClrType TargetImageClrType
+        {
+            get { return ImageClrType.Managed; }            // Used by "attach" when engine is set to auto-detect
+        }
+
+        public async Task<bool> GetIsConsoleAppAsync()
+        {
+            // Used by default Windows debugger to figure out whether to add an extra
+            // pause to end of window when CTRL+F5'ing a console application
+            var configuration = await _properties.GetConfigurationGeneralPropertiesAsync()
+                                                 .ConfigureAwait(false);
+
+            string outputType = (string)await configuration.OutputType.GetValueAsync()
+                                                                      .ConfigureAwait(false);
+
+            return StringComparers.PropertyValues.Equals(outputType, ConfigurationGeneral.OutputTypeValues.exe);
+        }
+
+        
+        public Task<bool> GetIs64BitAsync()
+        {
+            throw new NotSupportedException();              // GetIs64BitAsync isn't used *at all*
+        }
+        
+        public string AppUserModelID
+        {
+            get { throw new NotSupportedException(); }      // AppUserModelID and PackageMoniker are used only by AppContainer-based debuggers
+        }
+
+        public string PackageMoniker
+        {
+            get { throw new NotSupportedException(); }
+        }
+    }
+}


### PR DESCRIPTION
CPS already adds the pause if it knows you are a console application, implement the required interface to tell them we are.

This brings in line the project system with vslangproj.

![image](https://cloud.githubusercontent.com/assets/1103906/15762578/63b2f48e-28d3-11e6-9eb3-7af920226ae6.png)

Fixes #138