### PR TITLE
Add Item now shows correct C#/VB templates

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/GlobalSuppressions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/GlobalSuppressions.cs
@@ -11,4 +11,5 @@
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "RS0006:Do not mix attributes from different versions of MEF", Justification = "<Pending>", Scope = "type", Target = "~T:Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices.CSharpLanguageServiceHost")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "RS0006:Do not mix attributes from different versions of MEF", Justification = "<Pending>", Scope = "type", Target = "~T:Microsoft.VisualStudio.ProjectSystem.VS.Properties.CSharpProjectDesignerPageProvider")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "RS0006:Do not mix attributes from different versions of MEF", Justification = "<Pending>", Scope = "type", Target = "~T:Microsoft.VisualStudio.ProjectSystem.VS.CSharpProjectCompatibilityProvider")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "RS0006:Do not mix attributes from different versions of MEF", Justification = "<Pending>", Scope = "type", Target = "~T:Microsoft.VisualStudio.ProjectSystem.VS.CSharpProjectGuidProvider")]
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/CSharpProjectGuidProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/CSharpProjectGuidProvider.cs
@@ -2,18 +2,19 @@
 
 using System;
 using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Packaging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     /// <summary>
     ///     Provides the C# implementation of <see cref="IItemTypeGuidProvider"/> and <see cref="IAddItemTemplatesGuidProvider"/>.
     /// </summary>
-    //[Export(typeof(IItemTypeGuidProvider))]
-    //[Export(typeof(IAddItemTemplatesGuidProvider))]
+    [Export(typeof(IItemTypeGuidProvider))]
+    [Export(typeof(IAddItemTemplatesGuidProvider))]
     [AppliesTo(ProjectCapabilities.CSharp)]
     internal class CSharpProjectGuidProvider : IItemTypeGuidProvider, IAddItemTemplatesGuidProvider
     {
-        private static readonly Guid s_csharpProjectType = new Guid("{FAE04EC0-301F-11d3-BF4B-00C04F79EFBC}");
+        private static readonly Guid s_csharpProjectType = new Guid(CSharpProjectSystemPackage.LegacyProjectTypeGuid);
 
         [ImportingConstructor]
         public CSharpProjectGuidProvider(UnconfiguredProject unconfiguredProject)

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/GlobalSuppressions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/GlobalSuppressions.cs
@@ -10,4 +10,5 @@
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "RS0006:Do not mix attributes from different versions of MEF", Justification = "<Pending>", Scope = "type", Target = "~T:Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices.VisualBasicLanguageServiceHost")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "RS0006:Do not mix attributes from different versions of MEF", Justification = "<Pending>", Scope = "type", Target = "~T:Microsoft.VisualStudio.ProjectSystem.VS.Properties.VisualBasicProjectDesignerPageProvider")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "RS0006:Do not mix attributes from different versions of MEF", Justification = "<Pending>", Scope = "type", Target = "~T:Microsoft.VisualStudio.ProjectSystem.VS.VisualBasicProjectCompatibilityProvider")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "RS0006:Do not mix attributes from different versions of MEF", Justification = "<Pending>", Scope = "type", Target = "~T:Microsoft.VisualStudio.ProjectSystem.VS.VisualBasicProjectGuidProvider")]
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/VisualBasicProjectGuidProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/VisualBasicProjectGuidProvider.cs
@@ -2,18 +2,19 @@
 
 using System;
 using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Packaging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     /// <summary>
     ///     Provides the Visual Basic implementation of <see cref="IItemTypeGuidProvider"/> and <see cref="IAddItemTemplatesGuidProvider"/>.
     /// </summary>
-    //[Export(typeof(IItemTypeGuidProvider))]
-    //[Export(typeof(IAddItemTemplatesGuidProvider))]
+    [Export(typeof(IItemTypeGuidProvider))]
+    [Export(typeof(IAddItemTemplatesGuidProvider))]
     [AppliesTo(ProjectCapabilities.VB)]
     internal class VisualBasicProjectGuidProvider : IItemTypeGuidProvider, IAddItemTemplatesGuidProvider
     {
-        private static readonly Guid s_visualBasicProjectType = new Guid("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}");
+        private static readonly Guid s_visualBasicProjectType = new Guid(VisualBasicProjectSystemPackage.LegacyProjectTypeGuid);
 
         [ImportingConstructor]
         public VisualBasicProjectGuidProvider(UnconfiguredProject unconfiguredProject)


### PR DESCRIPTION
Opt'd C# and VB into legacy project's Add Item template guid and project type guid, so that correct C#/VB templates show up. Also opt'd them into returning their legacy equivalent of project type guid, so that other features start showing up because they think we're legacy C#/VB projects.