### PR TITLE
Make NuGet packaging play nicely with build

### DIFF
--- a/build/Nuget/Microsoft.VisualStudio.ProjectSystem.VSInsertionNuget.proj
+++ b/build/Nuget/Microsoft.VisualStudio.ProjectSystem.VSInsertionNuget.proj
@@ -33,6 +33,8 @@
     <Delete Files="%(NuSpec.NuPkgOutput)" />
   </Target>
 
+  <Target Name="Rebuild" DependsOnTargets="Clean;Build" />
+
   <Target Name="LogOutput">
     <Message Importance="High" Text="%(NuSpec.Identity) -> %(NuSpec.NuPkgOutput)'" />
   </Target>

--- a/build/Nuget/Microsoft.VisualStudio.ProjectSystem.VSInsertionNuget.proj
+++ b/build/Nuget/Microsoft.VisualStudio.ProjectSystem.VSInsertionNuget.proj
@@ -12,13 +12,16 @@
     <NuSpec Include="Microsoft.VisualStudio.ProjectSystem.VSInsertion.nuspec">
       <NuPkgOutput>$(NuGetOutDir)%(FileName).$(NuGetVersion).nupkg</NuPkgOutput>
     </NuSpec>
-  </ItemGroup>
 
-  <ItemGroup>
-    <NuPkgOutput Include="@(NuSpec -> '%(Filename).nupkg'" />
+    <!-- Make note, without actually knowing what's included in the NuSpec, 
+         we just assume that everything in the output dir is, and treat them
+         as inputs so that we rerun packaging if they change. 
+         Long term we'll want to use a packaging project, such as NuProj where 
+         the NuSpec is auto-generated based on the inputs. -->
+    <PackageAssets Include="$(OutDir)\*.*" Exclude="*.log" />
   </ItemGroup>
-  
-  <Target Name="Build" Inputs="@(NuSpec)" Outputs="@(NuSpec->'%(NuPkgOutput)')" DependsOnTargets="LogOutput">
+ 
+  <Target Name="Build" Inputs="@(NuSpec);@(PackageAssets)" Outputs="@(NuSpec->'%(NuPkgOutput)')" DependsOnTargets="LogOutput">
     
     <PropertyGroup>
       <NuGetArguments>-prop currentVersion="$(NuGetVersion)"</NuGetArguments>

--- a/build/Nuget/Microsoft.VisualStudio.ProjectSystem.VSInsertionNuget.proj
+++ b/build/Nuget/Microsoft.VisualStudio.ProjectSystem.VSInsertionNuget.proj
@@ -1,26 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ImportGroup Label="Settings">
-    <Import Project="..\Targets\Settings.targets" />
-  </ImportGroup>
+  <Import Project="..\Targets\Settings.targets" />
+  
   <PropertyGroup>
     <NuGetVersion>1.0.0.0</NuGetVersion>
     <NuGetVersionType>InsertionPurposeOnly</NuGetVersionType>
+    <NuGetOutDir>$(OutDir)NuGet\$(NuGetVersionType)\</NuGetOutDir>
   </PropertyGroup>
-  <ItemGroup Label="Redist">
-    <NuSpec Include="Microsoft.VisualStudio.ProjectSystem.VSInsertion.nuspec" />
+  
+  <ItemGroup>
+    <NuSpec Include="Microsoft.VisualStudio.ProjectSystem.VSInsertion.nuspec">
+      <NuPkgOutput>$(NuGetOutDir)%(FileName).$(NuGetVersion).nupkg</NuPkgOutput>
+    </NuSpec>
   </ItemGroup>
-  <Target Name="Build" Inputs="@(NuSpec)" Outputs="@(NuSpec-&gt;NuGet\$(NuGetVersionType)\%(Identity).$(NuGetVersion).nupkg">
+
+  <ItemGroup>
+    <NuPkgOutput Include="@(NuSpec -> '%(Filename).nupkg'" />
+  </ItemGroup>
+  
+  <Target Name="Build" Inputs="@(NuSpec)" Outputs="@(NuSpec->'%(NuPkgOutput)')" DependsOnTargets="LogOutput">
+    
     <PropertyGroup>
       <NuGetArguments>-prop currentVersion="$(NuGetVersion)"</NuGetArguments>
-      <NuGetOutDir>$(OutDir)NuGet\$(NuGetVersionType)</NuGetOutDir>
     </PropertyGroup>
-    <!-- clean our output directory -->
-    <MakeDir Directories="$(NuGetOutDir)" Condition="!Exists('$(NuGetOutDir)')" />
-    <!-- package! -->
-    <Exec Command="$(NuGetToolPath) Pack &quot;$(MSBuildProjectDirectory)\%(NuSpec.Identity)&quot; -BasePath &quot;$(OutDir.TrimEnd('\'))&quot; -OutputDirectory &quot;$(NuGetOutDir)&quot; $(NuGetArguments)" />
+    
+    <MakeDir Directories="$(NuGetOutDir)" />
+    
+    <Exec Command="$(NuGetToolPath) Pack &quot;$(MSBuildProjectDirectory)\%(NuSpec.Identity)&quot; -verbosity quiet -BasePath &quot;$(OutDir.TrimEnd('\'))&quot; -OutputDirectory &quot;$(NuGetOutDir.TrimEnd('\'))&quot; $(NuGetArguments)" />
   </Target>
+  
   <Target Name="Clean">
-    <RemoveDir Directories="$(OutDir)NuGet" />
+    <Delete Files="%(NuSpec.NuPkgOutput)" />
   </Target>
+
+  <Target Name="LogOutput">
+    <Message Importance="High" Text="%(NuSpec.Identity) -> %(NuSpec.NuPkgOutput)'" />
+  </Target>
+  
 </Project>

--- a/build/build.proj
+++ b/build/build.proj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <SolutionFile Include="$(RepositoryRootDirectory)src\ProjectSystem.sln" />
-    <NugetPackageFile Include="$(RepositoryRootDirectory)build\Nuget\Microsoft.VisualStudio.ProjectSystem.VSInsertionNuget.proj" />
+    <NuGetProjectFile Include="$(RepositoryRootDirectory)build\Nuget\Microsoft.VisualStudio.ProjectSystem.VSInsertionNuget.proj" />
   </ItemGroup>
 
   <Target Name="RestorePackages">
@@ -50,13 +50,20 @@
              />
   </Target>
   
-  <Target Name="BuildVsInsertionNuget">
-
-    <Message Text="Building %(NugetPackageFile.Filename)" Importance="high" />
+  <Target Name="BuildNuGetPackages">
 
     <MSBuild BuildInParallel="true"
-             Projects="@(NugetPackageFile)"
+             Projects="@(NuGetProjectFile)"
              Targets="Build"
+             Properties="$(CommonMSBuildGlobalProperties)"
+             />
+  </Target>
+
+  <Target Name="RebuildNuGetPackages">
+
+    <MSBuild BuildInParallel="true"
+             Projects="@(NuGetProjectFile)"
+             Targets="Rebuild"
              Properties="$(CommonMSBuildGlobalProperties)"
              />
   </Target>
@@ -82,7 +89,7 @@
 
   </Target>
 
-  <Target Name="Build" DependsOnTargets="RestorePackages;BuildSolution;BuildVsInsertionNuget;Test" />
-  <Target Name="Rebuild" DependsOnTargets="RestorePackages;RebuildSolution;BuildVsInsertionNuget;Test" />
+  <Target Name="Build" DependsOnTargets="RestorePackages;BuildSolution;BuildNuGetPackages;Test" />
+  <Target Name="Rebuild" DependsOnTargets="RestorePackages;RebuildSolution;RebuildNuGetPackages;Test" />
 
 </Project>


### PR DESCRIPTION
- Stopped logging so much during build, now we only output the actual output, similar to other projects
- Fixed NuGet up-to-date check so that it actually works and stops rebuilding the package even though nothing has changed. Make note - we added all the assembloes, pdb, xml, etc outputs as a input so that we rebuild in that case.
- Fixed clean so that it only deletes what it actually created