### PR TITLE
Added check for VSSDK to build.cmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -29,6 +29,11 @@ if not exist "%DeveloperCommandPrompt%" (
   exit /b 1
 )
 
+if not exist "%VSSDK150Install%" (
+  echo In order to build this repository, you need to modify your Visual Studio installation to include "Visual Studio Extensibility Tools".
+  exit /b 1
+)
+
 call "%DeveloperCommandPrompt%" || goto :BuildFailed
 
 set BinariesDirectory=%Root%bin\%BuildConfiguration%\


### PR DESCRIPTION
Added a check for the VSSDK to build.cmd. This avoids a bunch of meaningless errors in the build.