### PR TITLE
Add telemetry logging for unexpected exceptions in Microsoft.VisualSt…

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/AttributeEditor/PermissionSetService.vb
+++ b/src/Microsoft.VisualStudio.Editors/AttributeEditor/PermissionSetService.vb
@@ -7,6 +7,7 @@ Imports System.Security.Permissions
 Imports System.Xml
 Imports System.IO
 Imports Microsoft.Build.Tasks.Deployment.ManifestUtilities
+Imports Microsoft.VisualStudio.Editors.Common.Utils
 Imports Microsoft.VisualStudio.Shell.Design.Serialization
 
 Imports NativeMethods = Microsoft.VisualStudio.Editors.Interop.NativeMethods
@@ -84,10 +85,10 @@ Namespace Microsoft.VisualStudio.Editors.VBAttributeEditor
                 If (strManifestFileName IsNot Nothing) AndAlso (strManifestFileName.Length > 0) Then
 
                     Dim manifestInfo As New TrustInfo
-                    manifestInfo.PreserveFullTrustPermissionSet = true
+                    manifestInfo.PreserveFullTrustPermissionSet = True
 
                     Try
-                        Using appManifestDocData as New DocData(_serviceProvider, strManifestFileName)
+                        Using appManifestDocData As New DocData(_serviceProvider, strManifestFileName)
 
                             manifestInfo.ReadManifest(DocDataToStream(appManifestDocData))
 
@@ -113,12 +114,12 @@ Namespace Microsoft.VisualStudio.Editors.VBAttributeEditor
                     identityList = StringToIdentityList(strExcludedPermissions)
                 End If
 
-                Return SecurityUtilities.ComputeZonePermissionSet( _
-                    strTargetZone, _
-                    projectPermissionSet, _
+                Return SecurityUtilities.ComputeZonePermissionSet(
+                    strTargetZone,
+                    projectPermissionSet,
                     identityList)
 
-            Catch ex As Exception
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ComputeZonePermissionSet), NameOf(PermissionSetService), considerExceptionAsRecoverable:=True)
             End Try
 
             Return Nothing
@@ -145,7 +146,7 @@ Namespace Microsoft.VisualStudio.Editors.VBAttributeEditor
 
                 End If
 
-            Catch ex As Exception
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(IsAvailableInProject), NameOf(PermissionSetService), considerExceptionAsRecoverable:=True)
             End Try
 
             Return NativeMethods.S_OK
@@ -189,7 +190,7 @@ Namespace Microsoft.VisualStudio.Editors.VBAttributeEditor
 
                 End If
 
-            Catch ex As Exception
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(IsAvailableInProject), NameOf(PermissionSetService), considerExceptionAsRecoverable:=True)
             End Try
 
             If hasTip Then

--- a/src/Microsoft.VisualStudio.Editors/AttributeEditor/PermissionSetService.vb
+++ b/src/Microsoft.VisualStudio.Editors/AttributeEditor/PermissionSetService.vb
@@ -119,7 +119,7 @@ Namespace Microsoft.VisualStudio.Editors.VBAttributeEditor
                     projectPermissionSet,
                     identityList)
 
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ComputeZonePermissionSet), NameOf(PermissionSetService), considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ComputeZonePermissionSet), NameOf(PermissionSetService))
             End Try
 
             Return Nothing
@@ -146,7 +146,7 @@ Namespace Microsoft.VisualStudio.Editors.VBAttributeEditor
 
                 End If
 
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(IsAvailableInProject), NameOf(PermissionSetService), considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(IsAvailableInProject), NameOf(PermissionSetService))
             End Try
 
             Return NativeMethods.S_OK
@@ -190,7 +190,7 @@ Namespace Microsoft.VisualStudio.Editors.VBAttributeEditor
 
                 End If
 
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(IsAvailableInProject), NameOf(PermissionSetService), considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(IsAvailableInProject), NameOf(PermissionSetService))
             End Try
 
             If hasTip Then

--- a/src/Microsoft.VisualStudio.Editors/Common/CodeModelUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/CodeModelUtils.vb
@@ -143,7 +143,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
 
                 'And navigate...
                 TextPoint.Parent.Selection.MoveToPoint(TextPoint)
-            Catch ex As Exception When Common.ReportWithoutCrash(ex, $"Navigate to function '{Func.Name}' failed", NameOf(CodeModelUtils), debugFail:=True)
+            Catch ex As Exception When Common.ReportWithoutCrash(ex, $"Navigate to function '{Func.Name}' failed", NameOf(CodeModelUtils))
             End Try
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/Common/CodeModelUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/CodeModelUtils.vb
@@ -143,9 +143,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
 
                 'And navigate...
                 TextPoint.Parent.Selection.MoveToPoint(TextPoint)
-            Catch ex As Exception
-                RethrowIfUnrecoverable(ex)
-                Debug.Fail("Navigate to function '" & Func.Name & "' failed: " & ex.ToString)
+            Catch ex As Exception When Common.ReportWithoutCrash(ex, $"Navigate to function '{Func.Name}' failed", NameOf(CodeModelUtils), debugFail:=True)
             End Try
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/Common/DTEUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/DTEUtils.vb
@@ -226,7 +226,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                 'If there are no configurations defined in the project, this call can fail.  In that case, just return
                 '  the first config (there should be a single Debug configuration automatically defined and available).
                 Return Project.ConfigurationManager.Item(1) '1-indexed
-            Catch ex As Exception When Utils.ReportWithoutCrash(ex, "Unexpected exception trying to get the active configuration", NameOf(DTEUtils), debugFail:=True)
+            Catch ex As Exception When Utils.ReportWithoutCrash(ex, "Unexpected exception trying to get the active configuration", NameOf(DTEUtils))
                 Return Project.ConfigurationManager.Item(1) '1-indexed
             End Try
         End Function

--- a/src/Microsoft.VisualStudio.Editors/Common/DTEUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/DTEUtils.vb
@@ -226,10 +226,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                 'If there are no configurations defined in the project, this call can fail.  In that case, just return
                 '  the first config (there should be a single Debug configuration automatically defined and available).
                 Return Project.ConfigurationManager.Item(1) '1-indexed
-            Catch ex As Exception
-                Common.RethrowIfUnrecoverable(ex)
-                Debug.Fail("Unexpected exception trying to get the active configuration")
-
+            Catch ex As Exception When Utils.ReportWithoutCrash(ex, "Unexpected exception trying to get the active configuration", NameOf(DTEUtils), debugFail:=True)
                 Return Project.ConfigurationManager.Item(1) '1-indexed
             End Try
         End Function

--- a/src/Microsoft.VisualStudio.Editors/Common/ShellUtil.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/ShellUtil.vb
@@ -128,7 +128,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                         Return CanHideConfigurationsForProject(ProjectHierarchy) AndAlso Not ToolsOptionsShowAdvancedBuildConfigurations(Project.DTE)
                     End If
                 End If
-            Catch ex As Exception When Common.ReportWithoutCrash(ex, "Exception determining if we're in simplified configuration mode - default to advanced configs mode", NameOf(ShellUtil), debugFail:=True)
+            Catch ex As Exception When Common.ReportWithoutCrash(ex, "Exception determining if we're in simplified configuration mode - default to advanced configs mode", NameOf(ShellUtil))
             End Try
 
             Return False 'Default to advanced configs
@@ -192,7 +192,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                     Debug.Fail("Couldn't get ProjAndSolutionProperties property from DTE.Properties")
                     ShowValue = True 'If can't get to the property, assume advanced mode
                 End If
-            Catch ex As Exception When Common.ReportWithoutCrash(ex, "Couldn't get ShowAdvancedBuildConfigurations property from tools.options", NameOf(ShellUtil), debugFail:=True)
+            Catch ex As Exception When Common.ReportWithoutCrash(ex, "Couldn't get ShowAdvancedBuildConfigurations property from tools.options", NameOf(ShellUtil))
                 Return True 'default to showing advanced
             End Try
 
@@ -306,7 +306,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                 If String.Equals(project.Kind, VsWebSite.PrjKind.prjKindVenusProject, System.StringComparison.OrdinalIgnoreCase) Then
                     Return True
                 End If
-            Catch ex As Exception When Utils.ReportWithoutCrash(ex, NameOf(IsVenusProject), NameOf(ShellUtil), considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Utils.ReportWithoutCrash(ex, NameOf(IsVenusProject), NameOf(ShellUtil))
                 ' We failed. Assume that this isn't a web project...
             End Try
             Return False
@@ -348,7 +348,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                                 If SLPGuid.Equals(flavorGuid) Then
                                     Return True
                                 End If
-                            Catch ex As Exception When Utils.ReportWithoutCrash(ex, $"We received a broken guid string from IVsAggregatableProject '{guidStrings}'", NameOf(ShellUtil), debugFail:=True, considerExceptionAsRecoverable:=True)
+                            Catch ex As Exception When Utils.ReportWithoutCrash(ex, $"We received a broken guid string from IVsAggregatableProject '{guidStrings}'", NameOf(ShellUtil))
                             End Try
                         End If
                     Next
@@ -360,7 +360,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                         Return True
                     End If
                 End If
-            Catch ex As Exception When Utils.ReportWithoutCrash(ex, NameOf(IsSilverLightProject), NameOf(ShellUtil), considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Utils.ReportWithoutCrash(ex, NameOf(IsSilverLightProject), NameOf(ShellUtil))
                 ' We failed. Assume that this isn't a web project...
             End Try
             Return False
@@ -405,7 +405,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                                 If WAPGuid.Equals(flavorGuid) Then
                                     Return True
                                 End If
-                            Catch ex As Exception When Utils.ReportWithoutCrash(ex, $"We received a broken guid string from IVsAggregatableProject '{guidStrings}'", NameOf(ShellUtil), debugFail:=True, considerExceptionAsRecoverable:=True)
+                            Catch ex As Exception When Utils.ReportWithoutCrash(ex, $"We received a broken guid string from IVsAggregatableProject '{guidStrings}'", NameOf(ShellUtil))
                             End Try
                         End If
                     Next
@@ -417,7 +417,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                         Return True
                     End If
                 End If
-            Catch ex As Exception When Utils.ReportWithoutCrash(ex, NameOf(IsWebProject), NameOf(ShellUtil), considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Utils.ReportWithoutCrash(ex, NameOf(IsWebProject), NameOf(ShellUtil))
                 ' We failed. Assume that this isn't a web project...
             End Try
             Return False

--- a/src/Microsoft.VisualStudio.Editors/Common/ShellUtil.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/ShellUtil.vb
@@ -128,9 +128,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                         Return CanHideConfigurationsForProject(ProjectHierarchy) AndAlso Not ToolsOptionsShowAdvancedBuildConfigurations(Project.DTE)
                     End If
                 End If
-            Catch ex As Exception
-                Common.RethrowIfUnrecoverable(ex)
-                Debug.Fail("Exception determining if we're in simplified configuration mode - default to advanced configs mode")
+            Catch ex As Exception When Common.ReportWithoutCrash(ex, "Exception determining if we're in simplified configuration mode - default to advanced configs mode", NameOf(ShellUtil), debugFail:=True)
             End Try
 
             Return False 'Default to advanced configs
@@ -194,9 +192,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                     Debug.Fail("Couldn't get ProjAndSolutionProperties property from DTE.Properties")
                     ShowValue = True 'If can't get to the property, assume advanced mode
                 End If
-            Catch ex As Exception
-                Common.RethrowIfUnrecoverable(ex)
-                Debug.Fail("Couldn't get ShowAdvancedBuildConfigurations property from tools.options")
+            Catch ex As Exception When Common.ReportWithoutCrash(ex, "Couldn't get ShowAdvancedBuildConfigurations property from tools.options", NameOf(ShellUtil), debugFail:=True)
                 Return True 'default to showing advanced
             End Try
 
@@ -310,7 +306,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                 If String.Equals(project.Kind, VsWebSite.PrjKind.prjKindVenusProject, System.StringComparison.OrdinalIgnoreCase) Then
                     Return True
                 End If
-            Catch ex As Exception
+            Catch ex As Exception When Utils.ReportWithoutCrash(ex, NameOf(IsVenusProject), NameOf(ShellUtil), considerExceptionAsRecoverable:=True)
                 ' We failed. Assume that this isn't a web project...
             End Try
             Return False
@@ -352,8 +348,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                                 If SLPGuid.Equals(flavorGuid) Then
                                     Return True
                                 End If
-                            Catch ex As Exception
-                                System.Diagnostics.Debug.Fail(String.Format("We received a broken guid string from IVsAggregatableProject: '{0}'", guidStrings))
+                            Catch ex As Exception When Utils.ReportWithoutCrash(ex, $"We received a broken guid string from IVsAggregatableProject '{guidStrings}'", NameOf(ShellUtil), debugFail:=True, considerExceptionAsRecoverable:=True)
                             End Try
                         End If
                     Next
@@ -365,7 +360,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                         Return True
                     End If
                 End If
-            Catch ex As Exception
+            Catch ex As Exception When Utils.ReportWithoutCrash(ex, NameOf(IsSilverLightProject), NameOf(ShellUtil), considerExceptionAsRecoverable:=True)
                 ' We failed. Assume that this isn't a web project...
             End Try
             Return False
@@ -410,8 +405,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                                 If WAPGuid.Equals(flavorGuid) Then
                                     Return True
                                 End If
-                            Catch ex As Exception
-                                System.Diagnostics.Debug.Fail(String.Format("We received a broken guid string from IVsAggregatableProject: '{0}'", guidStrings))
+                            Catch ex As Exception When Utils.ReportWithoutCrash(ex, $"We received a broken guid string from IVsAggregatableProject '{guidStrings}'", NameOf(ShellUtil), debugFail:=True, considerExceptionAsRecoverable:=True)
                             End Try
                         End If
                     Next
@@ -423,7 +417,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                         Return True
                     End If
                 End If
-            Catch ex As Exception
+            Catch ex As Exception When Utils.ReportWithoutCrash(ex, NameOf(IsWebProject), NameOf(ShellUtil), considerExceptionAsRecoverable:=True)
                 ' We failed. Assume that this isn't a web project...
             End Try
             Return False
@@ -521,9 +515,9 @@ Namespace Microsoft.VisualStudio.Editors.Common
                             Dim childItemName As String = DTEUtils.FileNameFromProjectItem(projectitem.ProjectItems.Item(childNo))
 
                             ' Make sure that the filename matches what we expect.
-                            If String.Equals( _
-                                System.IO.Path.GetFileNameWithoutExtension(childItemName), _
-                                System.IO.Path.GetFileNameWithoutExtension(DTEUtils.FileNameFromProjectItem(projectitem)) & suffix, _
+                            If String.Equals(
+                                System.IO.Path.GetFileNameWithoutExtension(childItemName),
+                                System.IO.Path.GetFileNameWithoutExtension(DTEUtils.FileNameFromProjectItem(projectitem)) & suffix,
                                 StringComparison.OrdinalIgnoreCase) _
                             Then
                                 ' If we've got a filter predicate, we remove anything that we've been

--- a/src/Microsoft.VisualStudio.Editors/Common/SplitButton.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/SplitButton.vb
@@ -200,7 +200,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                 Dim e As New ShowCustomContextMenuEventArgs
                 Try
                     RaiseEvent ShowCustomContextMenu(e)
-                Catch ex As Exception
+                Catch ex As Exception When Utils.ReportWithoutCrash(ex, NameOf(ShowContextMenuOrContextMenuStrip), NameOf(SplitButton), considerExceptionAsRecoverable:=True)
                 End Try
 
                 If e.Handled Then

--- a/src/Microsoft.VisualStudio.Editors/Common/SplitButton.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/SplitButton.vb
@@ -200,7 +200,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                 Dim e As New ShowCustomContextMenuEventArgs
                 Try
                     RaiseEvent ShowCustomContextMenu(e)
-                Catch ex As Exception When Utils.ReportWithoutCrash(ex, NameOf(ShowContextMenuOrContextMenuStrip), NameOf(SplitButton), considerExceptionAsRecoverable:=True)
+                Catch ex As Exception When Utils.ReportWithoutCrash(ex, NameOf(ShowContextMenuOrContextMenuStrip), NameOf(SplitButton))
                 End Try
 
                 If e.Handled Then

--- a/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
@@ -314,8 +314,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                 Else
                     Return Value.ToString()
                 End If
-            Catch ex As Exception
-                RethrowIfUnrecoverable(ex)
+            Catch ex As Exception When Not IsUnrecoverableException(ex)
                 Return "[" & ex.GetType.Name & "]"
             End Try
 #Else
@@ -323,26 +322,55 @@ Namespace Microsoft.VisualStudio.Editors.Common
 #End If
         End Function
 
-
-        ''' <summary>
-        ''' Given an exception, returns True if it is an "unrecoverable" exception.
-        ''' </summary>
-        ''' <param name="ex">The exception to check rethrow if it's unrecoverable</param>
-        ''' <param name="IgnoreOutOfMemory">If True, out of memory will not be considered unrecoverable.</param>
-        ''' <remarks></remarks>
-        Public Function IsUnrecoverable(ByVal ex As Exception, Optional ByVal IgnoreOutOfMemory As Boolean = False) As Boolean
-            If TypeOf ex Is NullReferenceException _
-                OrElse (Not IgnoreOutOfMemory AndAlso TypeOf ex Is OutOfMemoryException) _
+        Public Function IsUnrecoverableException(ByVal ex As Exception, Optional ByVal ignoreOutOfMemory As Boolean = False) As Boolean
+            Return TypeOf ex Is NullReferenceException _
+                OrElse (Not ignoreOutOfMemory AndAlso TypeOf ex Is OutOfMemoryException) _
                 OrElse TypeOf ex Is StackOverflowException _
                 OrElse TypeOf ex Is System.Threading.ThreadAbortException _
-                OrElse TypeOf ex Is AccessViolationException _
-            Then
-                Return True
-            End If
-
-            Return False
+                OrElse TypeOf ex Is AccessViolationException
         End Function
 
+        ''' <summary>
+        ''' Logs the given exception and returns whether or not this is a "recoverable" exception, i.e. exception can be ignored.
+        ''' </summary>
+        ''' <param name="ex">The exception to log and check if it is recoverable.</param>
+        ''' <param name="exceptionEventDescription">Additional description for the cause of the exception.</param>
+        ''' <param name="throwingComponentName">Name of the component that threw that exception, generally the containing type name.</param>
+        ''' <param name="debugFail">If True, then invoke Debug.Fail for recoverable exception.</param>
+        ''' <param name="debugWriteLine">If True, then invoke Debug.WriteLine for recoverable exception.</param>
+        ''' <param name="considerExceptionAsRecoverable">If True, then the given exception is always considered recoverable.
+        ''' Otherwise, invokes <see cref="IsUnrecoverableException(Exception, Boolean)"/> to determine if exception is recoverable or not.</param>
+        ''' <param name="ignoreOutOfMemory">If True, out of memory will be considered recoverable.</param>
+        ''' <remarks></remarks>
+        Public Function ReportWithoutCrash(ByVal ex As Exception,
+                                           ByVal exceptionEventDescription As String,
+                                           Optional ByVal throwingComponentName As String = "general",
+                                           Optional ByVal debugFail As Boolean = False,
+                                           Optional ByVal debugWriteLine As Boolean = False,
+                                           Optional ByVal considerExceptionAsRecoverable As Boolean = False,
+                                           Optional ByVal ignoreOutOfMemory As Boolean = False) As Boolean
+            Debug.Assert(ex IsNot Nothing)
+            Debug.Assert(Not String.IsNullOrEmpty(throwingComponentName))
+            Debug.Assert(Not String.IsNullOrEmpty(exceptionEventDescription))
+
+            TelemetryService.DefaultSession.PostFault(
+                eventName:="vs/projectsystem/editors/" & throwingComponentName.ToLower,
+                description:=exceptionEventDescription,
+                exceptionObject:=ex)
+
+            Dim isRecoverable = considerExceptionAsRecoverable OrElse Not IsUnrecoverableException(ex, ignoreOutOfMemory)
+            If isRecoverable Then
+                If debugFail Then
+                    Debug.Fail(exceptionEventDescription & VB.vbCrLf & $"Exception: {ex.ToString}")
+                End If
+
+                If debugWriteLine Then
+                    Debug.WriteLine(exceptionEventDescription & VB.vbCrLf & $"Exception: {ex.ToString}")
+                End If
+            End If
+
+            Return isRecoverable
+        End Function
 
         ''' <summary>
         ''' Given an exception, returns True if it is a CheckOut exception.
@@ -363,19 +391,6 @@ Namespace Microsoft.VisualStudio.Editors.Common
 
             Return False
         End Function
-
-
-        ''' <summary>
-        ''' Given an exception, rethrows it if it is an "unrecoverable" exception.  Otherwise does nothing.
-        ''' </summary>
-        ''' <param name="ex">The exception to check rethrow if it's unrecoverable</param>
-        ''' <param name="IgnoreOutOfMemory">If True, out of memory will not be considered unrecoverable.</param>
-        ''' <remarks></remarks>
-        Public Sub RethrowIfUnrecoverable(ByVal ex As Exception, Optional ByVal IgnoreOutOfMemory As Boolean = False)
-            If IsUnrecoverable(ex, IgnoreOutOfMemory) Then
-                Throw ex
-            End If
-        End Sub
 
 
         ''' <summary>
@@ -519,7 +534,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' 
         '''       returns the string 
         ''' 
-        '''       "Metafiles (*.wmf, *.emf)|*.wmf;*.emf"
+        '''       "Metafiles (*.wmf, * .emf)|*.wmf;*.emf"
         ''' 
         ''' </returns>
         ''' <remarks></remarks>
@@ -801,8 +816,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                     Try
                         'Path needs a backslash at the end, or it will be interpreted as a directory + filename
                         InitialDirectory = Path.GetFullPath(AppendBackslash(InitialDirectory))
-                    Catch ex As Exception
-                        Common.RethrowIfUnrecoverable(ex)
+                    Catch ex As Exception When Not IsUnrecoverableException(ex)
                         InitialDirectory = String.Empty
                     End Try
                 End If
@@ -1060,10 +1074,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
 
                     g.DrawImage(unmappedBitmap, r, 0, 0, size.Width, size.Height, GraphicsUnit.Pixel, imageAttributes)
                 End Using
-            Catch e As Exception
-                Debug.Fail(e.ToString())
-                Common.RethrowIfUnrecoverable(e)
-
+            Catch e As Exception When Common.ReportWithoutCrash(e, NameOf(MapBitmapColor), NameOf(Utils), debugFail:=True)
                 ' fall-back is to use the unmapped bitmap
                 Return unmappedBitmap
             End Try
@@ -1262,8 +1273,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                 End If
             Catch ex As System.ArgumentException
                 ' Venus throws when trying to access the CustomToolNamespace property...
-            Catch ex As Exception When Not Common.IsUnrecoverable(ex)
-                Debug.Fail(String.Format("Failed to get item.Properties('CustomToolNamespace') {0}", ex))
+            Catch ex As Exception When Common.ReportWithoutCrash(ex, "Failed to get item.Properties('CustomToolNamespace')", NameOf(Utils), debugFail:=True)
             End Try
 
             ' If we have a custom tool namespace, then we will return this unless we also have a root namespace (VB only)
@@ -1300,15 +1310,13 @@ Namespace Microsoft.VisualStudio.Editors.Common
                         End If
                     End If
                 Catch ex As System.ArgumentException
-                    Debug.Fail("Why did we get a System.ArgumentException when trying to get the root namespace?")
-                Catch ex As Exception
-                    Debug.Fail(String.Format("Why did we get a {0} when trying to get the root namespace?", ex))
+                Catch ex As Exception When Utils.ReportWithoutCrash(ex, "Exception when trying to get the root namespace", NameOf(Utils), debugFail:=True, considerExceptionAsRecoverable:=True)
                 End Try
             End If
             Try
                 Return DesignerFramework.DesignUtil.GenerateValidLanguageIndependentNamespace(DefaultNamespace)
             Catch ex As ArgumentException
-                Return ""
+                Return String.Empty
             End Try
         End Function
 
@@ -1386,7 +1394,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                 If Not langService = Guid.Empty Then
                     Return langService.Equals(New Guid("{E34ACDC0-BAAE-11D0-88BF-00A0C9110049}"))
                 End If
-            Catch
+            Catch ex As Exception When Utils.ReportWithoutCrash(ex, NameOf(IsVbProject), NameOf(Utils), considerExceptionAsRecoverable:=True)
             End Try
             Return False
         End Function
@@ -1445,33 +1453,33 @@ Namespace Microsoft.VisualStudio.Editors.Common
             ' in this list. All unknown entries will be reported as &hFF
             '
             ' Add more entries to the end of this list. Do *not* put any new entries in the middle of the list!
-            Private Shared s_sqmOrder() As Guid = { _
-                KnownPropertyPageGuids.GuidApplicationPage_VB, _
-                KnownPropertyPageGuids.GuidApplicationPage_CS, _
-                KnownPropertyPageGuids.GuidApplicationPage_JS, _
-                KnownPropertyPageGuids.GuidCompilePage_VB, _
-                KnownPropertyPageGuids.GuidBuildPage_CS, _
-                KnownPropertyPageGuids.GuidBuildPage_JS, _
-                KnownPropertyPageGuids.GuidBuildEventsPage, _
-                KnownPropertyPageGuids.GuidDebugPage, _
-                KnownPropertyPageGuids.GuidReferencesPage_VB, _
-                GetType(SettingsDesigner.SettingsDesignerEditorFactory).GUID, _
-                GetType(ResourceEditor.ResourceEditorFactory).GUID, _
-                KnownPropertyPageGuids.GuidReferencePathsPage, _
-                KnownPropertyPageGuids.GuidSigningPage, _
-                KnownPropertyPageGuids.GuidSecurityPage, _
-                KnownPropertyPageGuids.GuidPublishPage, _
-                KnownPropertyPageGuids.GuidDatabasePage_SQL, _
-                KnownPropertyPageGuids.GuidFxCopPage, _
-                KnownPropertyPageGuids.GuidDeployPage, _
-                KnownPropertyPageGuids.GuidDevicesPage_VSD, _
-                KnownPropertyPageGuids.GuidDebugPage_VSD, _
-                KnownPropertyPageGuids.GuidApplicationPage_VB_WPF, _
-                KnownPropertyPageGuids.GuidSecurityPage_WPF, _
-                KnownPropertyPageGuids.GuidMyExtensionsPage, _
-                KnownPropertyPageGuids.GuidOfficePublishPage, _
-                KnownPropertyPageGuids.GuidServicesPage, _
-                KnownPropertyPageGuids.GuidWAPWebPage _
+            Private Shared s_sqmOrder() As Guid = {
+                KnownPropertyPageGuids.GuidApplicationPage_VB,
+                KnownPropertyPageGuids.GuidApplicationPage_CS,
+                KnownPropertyPageGuids.GuidApplicationPage_JS,
+                KnownPropertyPageGuids.GuidCompilePage_VB,
+                KnownPropertyPageGuids.GuidBuildPage_CS,
+                KnownPropertyPageGuids.GuidBuildPage_JS,
+                KnownPropertyPageGuids.GuidBuildEventsPage,
+                KnownPropertyPageGuids.GuidDebugPage,
+                KnownPropertyPageGuids.GuidReferencesPage_VB,
+                GetType(SettingsDesigner.SettingsDesignerEditorFactory).GUID,
+                GetType(ResourceEditor.ResourceEditorFactory).GUID,
+                KnownPropertyPageGuids.GuidReferencePathsPage,
+                KnownPropertyPageGuids.GuidSigningPage,
+                KnownPropertyPageGuids.GuidSecurityPage,
+                KnownPropertyPageGuids.GuidPublishPage,
+                KnownPropertyPageGuids.GuidDatabasePage_SQL,
+                KnownPropertyPageGuids.GuidFxCopPage,
+                KnownPropertyPageGuids.GuidDeployPage,
+                KnownPropertyPageGuids.GuidDevicesPage_VSD,
+                KnownPropertyPageGuids.GuidDebugPage_VSD,
+                KnownPropertyPageGuids.GuidApplicationPage_VB_WPF,
+                KnownPropertyPageGuids.GuidSecurityPage_WPF,
+                KnownPropertyPageGuids.GuidMyExtensionsPage,
+                KnownPropertyPageGuids.GuidOfficePublishPage,
+                KnownPropertyPageGuids.GuidServicesPage,
+                KnownPropertyPageGuids.GuidWAPWebPage
             }
 
             Public Const UNKNOWN_PAGE As Byte = &HFF
@@ -1654,8 +1662,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                 If Reference3 IsNot Nothing AndAlso Reference3.AutoReferenced Then
                     Return True
                 End If
-            Catch ex As Exception When Not Common.IsUnrecoverable(ex)
-                Debug.Fail("Reference3.AutoReferenced threw an exception: " & ex.Message)
+            Catch ex As Exception When Common.ReportWithoutCrash(ex, "Reference3.AutoReferenced threw an exception", NameOf(Utils), debugFail:=True)
             End Try
 
             Return False

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/AccessModifierComboBox.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/AccessModifierComboBox.vb
@@ -496,7 +496,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                 Else
                     Debug.Fail("Couldn't find CustomTool property.  Dropdown shouldn't have been enabled.")
                 End If
-            Catch ex As Exception
+            Catch ex As Exception When Utils.ReportWithoutCrash(ex, NameOf(TrySetCustomToolValue), NameOf(AccessModifierCombobox), considerExceptionAsRecoverable:=True)
                 DesignerFramework.DesignerMessageBox.Show( _
                     _rootDesigner, _
                     SR.GetString(SR.RSE_Task_CantChangeCustomToolOrNamespace), _
@@ -524,8 +524,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             Try
                 Dim shouldBeEnabled As Boolean = Me.ShouldBeEnabled()
                 Switches.TracePDAccessModifierCombobox(TraceLevel.Verbose, "EnabledHandler: " & Me.GetType.Name & ": Enabled=" & shouldBeEnabled)
-            Catch e As Exception
-                Debug.Fail("Failed to determine if the access modifier combobox should be enabled: " & e.ToString())
+            Catch ex As Exception When Utils.ReportWithoutCrash(ex, "Failed to determine if the access modifier combobox should be enabled", NameOf(AccessModifierCombobox), debugFail:=True, considerExceptionAsRecoverable:=True)
                 Throw
             End Try
             Return shouldBeEnabled

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/AccessModifierComboBox.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/AccessModifierComboBox.vb
@@ -496,7 +496,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                 Else
                     Debug.Fail("Couldn't find CustomTool property.  Dropdown shouldn't have been enabled.")
                 End If
-            Catch ex As Exception When Utils.ReportWithoutCrash(ex, NameOf(TrySetCustomToolValue), NameOf(AccessModifierCombobox), considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Utils.ReportWithoutCrash(ex, NameOf(TrySetCustomToolValue), NameOf(AccessModifierCombobox))
                 DesignerFramework.DesignerMessageBox.Show( _
                     _rootDesigner, _
                     SR.GetString(SR.RSE_Task_CantChangeCustomToolOrNamespace), _
@@ -524,7 +524,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             Try
                 Dim shouldBeEnabled As Boolean = Me.ShouldBeEnabled()
                 Switches.TracePDAccessModifierCombobox(TraceLevel.Verbose, "EnabledHandler: " & Me.GetType.Name & ": Enabled=" & shouldBeEnabled)
-            Catch ex As Exception When Utils.ReportWithoutCrash(ex, "Failed to determine if the access modifier combobox should be enabled", NameOf(AccessModifierCombobox), debugFail:=True, considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Utils.ReportWithoutCrash(ex, "Failed to determine if the access modifier combobox should be enabled", NameOf(AccessModifierCombobox))
                 Throw
             End Try
             Return shouldBeEnabled

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
@@ -82,7 +82,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                         ProjectReloaded = View.ProjectReloadedDuringCheckout
                     End If
                 End Try
-            Catch ex As Exception
+            Catch ex As Exception When Utils.ReportWithoutCrash(ex, "Checkout failed", NameOf(BaseDesignerLoader), considerExceptionAsRecoverable:=True)
                 Switches.TraceSCC("Checkout failed: " & ex.Message)
 
                 'Check-out has failed.  We need to handle this gracefully at all places in the UI where this could happen.
@@ -639,8 +639,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                         vsProj.RunCustomTool()
                     End If
                 End If
-            Catch ex As Exception When Not Utils.IsUnrecoverable(ex)
-                Debug.Fail(String.Format("Failed to run custom tool: {0}", ex))
+            Catch ex As Exception When Utils.ReportWithoutCrash(ex, "Failed to run custom tool", NameOf(BaseDesignerLoader), debugFail:=True)
             End Try
         End Sub
 
@@ -676,8 +675,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                 Dim LostFocusProjectItem As EnvDTE.ProjectItem = Nothing
                 Try
                     LostFocusProjectItem = LostFocus.ProjectItem
-                Catch ex As Exception
-                    Common.RethrowIfUnrecoverable(ex)
+                Catch ex As Exception When Common.ReportWithoutCrash(ex, NameOf(m_WindowEvents_WindowActivated), NameOf(BaseDesignerLoader))
                 End Try
 
                 If LostFocusProjectItem Is ThisProjectItem Then
@@ -689,8 +687,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                 Dim GotFocusProjectItem As EnvDTE.ProjectItem = Nothing
                 Try
                     GotFocusProjectItem = GotFocus.ProjectItem
-                Catch ex As Exception
-                    Common.RethrowIfUnrecoverable(ex)
+                Catch ex As Exception When Common.ReportWithoutCrash(ex, NameOf(m_WindowEvents_WindowActivated), NameOf(BaseDesignerLoader))
                 End Try
 
                 If GotFocusProjectItem Is ThisProjectItem Then

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
@@ -82,7 +82,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                         ProjectReloaded = View.ProjectReloadedDuringCheckout
                     End If
                 End Try
-            Catch ex As Exception When Utils.ReportWithoutCrash(ex, "Checkout failed", NameOf(BaseDesignerLoader), considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Utils.ReportWithoutCrash(ex, "Checkout failed", NameOf(BaseDesignerLoader))
                 Switches.TraceSCC("Checkout failed: " & ex.Message)
 
                 'Check-out has failed.  We need to handle this gracefully at all places in the UI where this could happen.
@@ -639,7 +639,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                         vsProj.RunCustomTool()
                     End If
                 End If
-            Catch ex As Exception When Utils.ReportWithoutCrash(ex, "Failed to run custom tool", NameOf(BaseDesignerLoader), debugFail:=True)
+            Catch ex As Exception When Utils.ReportWithoutCrash(ex, "Failed to run custom tool", NameOf(BaseDesignerLoader))
             End Try
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerView.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerView.vb
@@ -73,9 +73,8 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                     End If
                     Debug.Assert(IsHandleCreated AndAlso Not Handle.Equals(IntPtr.Zero), "We should have a handle still.  Without it, BeginInvoke will fail.")
                     BeginInvoke(New MethodInvoker(AddressOf DelayedMyBaseDispose))
-                Catch ex As Exception
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to queue a delayed Dispose for the designer view", NameOf(BaseDesignerView), debugFail:=True, considerExceptionAsRecoverable:=True)
                     ' At this point, all we can do is to avoid crashing the shell. 
-                    Debug.Fail(String.Format("Failed to queue a delayed Dispose for the designer view: {0}", ex))
                 End Try
             End If
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerView.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerView.vb
@@ -73,7 +73,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                     End If
                     Debug.Assert(IsHandleCreated AndAlso Not Handle.Equals(IntPtr.Zero), "We should have a handle still.  Without it, BeginInvoke will fail.")
                     BeginInvoke(New MethodInvoker(AddressOf DelayedMyBaseDispose))
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to queue a delayed Dispose for the designer view", NameOf(BaseDesignerView), debugFail:=True, considerExceptionAsRecoverable:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to queue a delayed Dispose for the designer view", NameOf(BaseDesignerView))
                     ' At this point, all we can do is to avoid crashing the shell. 
                 End Try
             End If

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseEditorFactory.vb
@@ -120,7 +120,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                     Marshal.Release(ObjPtr)
                     ObjPtr = IntPtr.Zero
                 End If
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to create VSTextBuffer Class", NameOf(BaseEditorFactory), debugFail:=True, considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to create VSTextBuffer Class", NameOf(BaseEditorFactory))
                 Throw New COMException(SR.GetString(SR.DFX_UnableCreateTextBuffer), Interop.NativeMethods.E_FAIL)
             End Try
 
@@ -394,7 +394,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                         If ((New IO.FileInfo(FileName)).Attributes And FileAttributes.ReadOnly) <> 0 Then
                             CaptionReadOnlyStatus = BaseDesignerLoader.EditorCaptionState.ReadOnly
                         End If
-                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to get file read-only status", NameOf(BaseEditorFactory), debugFail:=True, considerExceptionAsRecoverable:=True)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to get file read-only status", NameOf(BaseEditorFactory))
                     End Try
                     Caption = DesignerLoader.GetEditorCaption(CaptionReadOnlyStatus)
 

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseEditorFactory.vb
@@ -120,8 +120,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                     Marshal.Release(ObjPtr)
                     ObjPtr = IntPtr.Zero
                 End If
-            Catch ex As Exception
-                Debug.Fail("Failed to create VSTextBuffer Class. You need to check the guid is right?" + ex.ToString())
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to create VSTextBuffer Class", NameOf(BaseEditorFactory), debugFail:=True, considerExceptionAsRecoverable:=True)
                 Throw New COMException(SR.GetString(SR.DFX_UnableCreateTextBuffer), Interop.NativeMethods.E_FAIL)
             End Try
 
@@ -271,7 +270,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                 Dim DocData As Object = Nothing
 
                 Dim CanceledAsBoolean As Boolean = False
-                CreateEditorInstance(vscreateeditorflags, FileName, PhysicalView, Hierarchy, Itemid, ExistingDocData, _
+                CreateEditorInstance(vscreateeditorflags, FileName, PhysicalView, Hierarchy, Itemid, ExistingDocData,
                         DocView, DocData, Caption, CmdUIGuid, CanceledAsBoolean)
 
                 If CanceledAsBoolean Then
@@ -395,8 +394,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                         If ((New IO.FileInfo(FileName)).Attributes And FileAttributes.ReadOnly) <> 0 Then
                             CaptionReadOnlyStatus = BaseDesignerLoader.EditorCaptionState.ReadOnly
                         End If
-                    Catch ex As Exception
-                        Debug.Fail("Failed to get file read-only status")
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to get file read-only status", NameOf(BaseEditorFactory), debugFail:=True, considerExceptionAsRecoverable:=True)
                     End Try
                     Caption = DesignerLoader.GetEditorCaption(CaptionReadOnlyStatus)
 

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignUtil.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignUtil.vb
@@ -333,8 +333,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                         Return System.Text.Encoding.GetEncoding(CInt(oEncoding) And TextManager.Interop.__VSTFF.VSTFF_CPMASK)
                     End If
                 End If
-            Catch ex As Exception
-                Common.RethrowIfUnrecoverable(ex)
+            Catch ex As Exception When Common.ReportWithoutCrash(ex, NameOf(GetEncoding), NameOf(DesignUtil))
             End Try
             Return System.Text.Encoding.Default
         End Function

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerMessageBox.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerMessageBox.vb
@@ -156,7 +156,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                     Return ShowInternal(CType(ServiceProvider.GetService(GetType(IUIService)), IUIService),
                         CType(ServiceProvider.GetService(GetType(IVsUIShell)), IVsUIShell),
                         Message, Caption, Buttons, Icon, DefaultButton, HelpLink)
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ShowHelper), NameOf(DesignerMessageBox), debugFail:=True, considerExceptionAsRecoverable:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ShowHelper), NameOf(DesignerMessageBox))
                 End Try
             Else
                 Debug.Fail("ServiceProvider is Nothing! Message box won't have parent!")

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerMessageBox.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerMessageBox.vb
@@ -153,11 +153,10 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
 
             If ServiceProvider IsNot Nothing Then
                 Try
-                    Return ShowInternal(CType(ServiceProvider.GetService(GetType(IUIService)), IUIService), _
-                        CType(ServiceProvider.GetService(GetType(IVsUIShell)), IVsUIShell), _
+                    Return ShowInternal(CType(ServiceProvider.GetService(GetType(IUIService)), IUIService),
+                        CType(ServiceProvider.GetService(GetType(IVsUIShell)), IVsUIShell),
                         Message, Caption, Buttons, Icon, DefaultButton, HelpLink)
-                Catch ex As Exception
-                    Debug.Fail(ex.ToString)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ShowHelper), NameOf(DesignerMessageBox), debugFail:=True, considerExceptionAsRecoverable:=True)
                 End Try
             Else
                 Debug.Fail("ServiceProvider is Nothing! Message box won't have parent!")

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
@@ -468,10 +468,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                         End If
                     End If
                 End If
-            Catch ex As Exception
-                Common.RethrowIfUnrecoverable(ex)
-                Debug.WriteLine(ex.ToString())
-                Debug.Fail("These methods should succeed...")
+            Catch ex As Exception When Common.ReportWithoutCrash(ex, NameOf(GetRootNamespace), NameOf(MyApplicationCodeGenerator), debugFail:=True)
             End Try
 
             Debug.Fail("Unable to get the project's root namespace from MyApplicationCodeGenerator")
@@ -616,8 +613,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                             End If
                         End If
                     End Using
-                Catch ex As Exception When Not Common.Utils.IsUnrecoverable(ex)
-                    Debug.Fail("Failed to save changes to myapp file")
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to save changes to myapp file", NameOf(MyApplicationCodeGenerator), debugFail:=True)
                 End Try
             End If
 

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
@@ -468,7 +468,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                         End If
                     End If
                 End If
-            Catch ex As Exception When Common.ReportWithoutCrash(ex, NameOf(GetRootNamespace), NameOf(MyApplicationCodeGenerator), debugFail:=True)
+            Catch ex As Exception When Common.ReportWithoutCrash(ex, NameOf(GetRootNamespace), NameOf(MyApplicationCodeGenerator))
             End Try
 
             Debug.Fail("Unable to get the project's root namespace from MyApplicationCodeGenerator")
@@ -613,7 +613,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                             End If
                         End If
                     End Using
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to save changes to myapp file", NameOf(MyApplicationCodeGenerator), debugFail:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to save changes to myapp file", NameOf(MyApplicationCodeGenerator))
                 End Try
             End If
 

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
@@ -891,7 +891,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                 '  simply throw a general exception of our own text than propagate this to the user.
                 Throw New Exception(SR.GetString(SR.RSE_Task_CantChangeCustomToolOrNamespace), ex)
 
-            Catch ex As Exception When Not Common.Utils.IsUnrecoverableException(ex)
+            Catch ex As Exception
                 'For anything else, combine our error messages.
                 Throw New Exception(SR.GetString(SR.RSE_Task_CantChangeCustomToolOrNamespace & Microsoft.VisualBasic.vbCrLf & ex.Message))
             End Try

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
@@ -891,9 +891,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                 '  simply throw a general exception of our own text than propagate this to the user.
                 Throw New Exception(SR.GetString(SR.RSE_Task_CantChangeCustomToolOrNamespace), ex)
 
-            Catch ex As Exception
-                Common.Utils.RethrowIfUnrecoverable(ex)
-
+            Catch ex As Exception When Not Common.Utils.IsUnrecoverableException(ex)
                 'For anything else, combine our error messages.
                 Throw New Exception(SR.GetString(SR.RSE_Task_CantChangeCustomToolOrNamespace & Microsoft.VisualBasic.vbCrLf & ex.Message))
             End Try
@@ -1475,11 +1473,11 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                 End If
                 Dim props3 As VSLangProj80.VBProjectProperties3 = TryCast(obj, VSLangProj80.VBProjectProperties3)
                 If props3 IsNot Nothing Then
-                    Return MyApplicationProperties.ApplicationTypeFromOutputType( _
-                                CUInt(props3.OutputType), _
+                    Return MyApplicationProperties.ApplicationTypeFromOutputType(
+                                CUInt(props3.OutputType),
                                 props3.MyType) = ApplicationTypes.WindowsApp
                 End If
-            Catch ex As Exception When Not Common.IsUnrecoverable(ex)
+            Catch ex As Exception When Common.ReportWithoutCrash(ex, NameOf(IsMySubMainSupported), NameOf(MyApplicationProperties))
             End Try
             Return False
         End Function

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityProjectService.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityProjectService.vb
@@ -80,7 +80,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                     Dim extensionsAddedSB As New StringBuilder()
                     Me.AddTemplates(addExtensionsDialog.ExtensionTemplatesToAdd, extensionsAddedSB)
                     Me.SetExtensionsStatus(extensionsAddedSB, Nothing)
-                Catch ex As Exception When Not IsUnrecoverable(ex)
+                Catch ex As Exception When ReportWithoutCrash(ex, NameOf(AddExtensionsFromPropPage), NameOf(MyExtensibilityProjectService))
                 Finally
                     _excludedTemplates = Nothing
                 End Try
@@ -127,11 +127,11 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' Get the extension template name and description from the machine settings.
         ''' This is called by MyExtensiblityProjectSettings.
         ''' </summary>
-        Public Sub GetExtensionTemplateNameAndDescription( _
-                ByVal id As String, ByVal version As Version, ByVal assemblyName As String, _
+        Public Sub GetExtensionTemplateNameAndDescription(
+                ByVal id As String, ByVal version As Version, ByVal assemblyName As String,
                 ByRef name As String, ByRef description As String)
-            _extensibilitySettings.GetExtensionTemplateNameAndDescription(Me.ProjectTypeID, _project, _
-                id, version, assemblyName, _
+            _extensibilitySettings.GetExtensionTemplateNameAndDescription(Me.ProjectTypeID, _project,
+                id, version, assemblyName,
                 name, description)
         End Sub
 
@@ -155,7 +155,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' <summary>
         ''' Create a new project service.
         ''' </summary>
-        Private Sub New(ByVal vbPackage As VBPackage, ByVal project As EnvDTE.Project, _
+        Private Sub New(ByVal vbPackage As VBPackage, ByVal project As EnvDTE.Project,
                 ByVal projectHierarchy As IVsHierarchy, ByVal extensibilitySettings As MyExtensibilitySettings)
             Debug.Assert(vbPackage IsNot Nothing, "vbPackage Is Nothing")
             Debug.Assert(project IsNot Nothing, "project Is Nothing")
@@ -182,22 +182,21 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                         If _projectHierarchy IsNot Nothing Then
                             Dim hr As Integer
                             Try
-                                hr = _projectHierarchy.GetGuidProperty( _
+                                hr = _projectHierarchy.GetGuidProperty(
                                     VSITEMID.ROOT, __VSHPROPID2.VSHPROPID_AddItemTemplatesGuid, projGuid)
-                            Catch ex As Exception When Not Common.Utils.IsUnrecoverable(ex)
+                            Catch ex As Exception
                                 hr = System.Runtime.InteropServices.Marshal.GetHRForException(ex)
                             End Try
                             If VSErrorHandler.Failed(hr) Then
-                                hr = _projectHierarchy.GetGuidProperty( _
+                                hr = _projectHierarchy.GetGuidProperty(
                                     VSITEMID.ROOT, __VSHPROPID.VSHPROPID_TypeGuid, projGuid)
                                 If VSErrorHandler.Failed(hr) Then
                                     projGuid = Guid.Empty
                                 End If
                             End If
                         End If
-                    Catch ex As Exception When Not Common.Utils.IsUnrecoverable(ex)
+                    Catch ex As Exception
                         ' This is a non-vital function - ignore if we fail to get the GUID...
-                        Debug.Fail(String.Format("Failed to get project guid: {0}", ex.ToString()))
                     End Try
                     If Guid.Empty.Equals(projGuid) Then
                         If _project IsNot Nothing Then
@@ -481,7 +480,8 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                         Else
                             projectFilesRemovedSB.Append(System.Globalization.CultureInfo.CurrentUICulture.TextInfo.ListSeparator & extensionProjectItemGroup.DisplayName)
                         End If
-                    Catch ex As Exception ' Ignore exceptions.
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(RemoveExtensionProjectItemGroups), NameOf(MyExtensibilityProjectService), considerExceptionAsRecoverable:=True)
+                        ' Ignore exceptions.
                     End Try
                 Next
 

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityProjectService.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityProjectService.vb
@@ -480,7 +480,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                         Else
                             projectFilesRemovedSB.Append(System.Globalization.CultureInfo.CurrentUICulture.TextInfo.ListSeparator & extensionProjectItemGroup.DisplayName)
                         End If
-                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(RemoveExtensionProjectItemGroups), NameOf(MyExtensibilityProjectService), considerExceptionAsRecoverable:=True)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(RemoveExtensionProjectItemGroups), NameOf(MyExtensibilityProjectService))
                         ' Ignore exceptions.
                     End Try
                 Next

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityProjectSettings.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityProjectSettings.vb
@@ -67,7 +67,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
             Debug.Assert(_extensionFolderProjectItem IsNot Nothing, "Could not create MyExtensions folder!")
             Try
                 _extensionFolderProjectItem.ProjectItems.AddFromTemplate(extensionTemplate.FilePath, suggestedName)
-            Catch ex As Exception When Not Utils.IsUnrecoverable(ex)
+            Catch ex As Exception When Utils.ReportWithoutCrash(ex, NameOf(AddExtensionTemplate), NameOf(MyExtensibilityProjectSettings))
                 DesignerMessageBox.Show(_serviceProvider, ex, Nothing)
             End Try
 
@@ -78,37 +78,37 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
 
             If _projectItemsAddedFromTemplate Is Nothing OrElse _projectItemsAddedFromTemplate.Count <= 0 Then
                 ' No project items were added, show warning message and return nothing.
-                DesignerMessageBox.Show(_serviceProvider, _
-                    String.Format(Res.CouldNotAddProjectItemTemplate_Message, extensionTemplate.DisplayName), _
-                    Res.CouldNotAddProjectItemTemplate_Title, _
+                DesignerMessageBox.Show(_serviceProvider,
+                    String.Format(Res.CouldNotAddProjectItemTemplate_Message, extensionTemplate.DisplayName),
+                    Res.CouldNotAddProjectItemTemplate_Title,
                     MessageBoxButtons.OK, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button1)
             ElseIf _vsBuildPropertyStorage IsNot Nothing Then
                 ' Some project items were added, if IVsBuildPropertyStorage is available, attempt to set the attribute.
                 result = New List(Of ProjectItem)
                 For Each projectItemAdded As ProjectItem In _projectItemsAddedFromTemplate
                     Try
-                        Dim extensionProjectItemID As UInteger = DTEUtils.ItemIdOfProjectItem( _
+                        Dim extensionProjectItemID As UInteger = DTEUtils.ItemIdOfProjectItem(
                             _projectHierarchy, projectItemAdded)
                         _vsBuildPropertyStorage.SetItemAttribute(extensionProjectItemID, s_MSBUILD_ATTR_ASSEMBLY, extensionTemplate.AssemblyFullName)
                         _vsBuildPropertyStorage.SetItemAttribute(extensionProjectItemID, s_MSBUILD_ATTR_ID, extensionTemplate.ID)
                         _vsBuildPropertyStorage.SetItemAttribute(extensionProjectItemID, s_MSBUILD_ATTR_VERSION, extensionTemplate.Version.ToString())
 
-                        Me.AddExtensionProjectFile(extensionTemplate.AssemblyFullName, projectItemAdded, _
+                        Me.AddExtensionProjectFile(extensionTemplate.AssemblyFullName, projectItemAdded,
                             extensionTemplate.ID, extensionTemplate.Version, extensionTemplate.DisplayName, extensionTemplate.Description)
 
                         result.Add(projectItemAdded)
-                    Catch ex As Exception When Not Common.Utils.IsUnrecoverable(ex) ' Ignore recoverable exceptions
-                        DesignerMessageBox.Show(_serviceProvider, _
-                            String.Format(Res.CouldNotSetExtensionAttributes_Message, _
-                                projectItemAdded.Name, extensionTemplate.DisplayName), _
-                            Res.CouldNotSetExtensionAttributes_Title, _
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(AddExtensionTemplate), NameOf(MyExtensibilityProjectSettings)) ' Ignore recoverable exceptions
+                        DesignerMessageBox.Show(_serviceProvider,
+                            String.Format(Res.CouldNotSetExtensionAttributes_Message,
+                                projectItemAdded.Name, extensionTemplate.DisplayName),
+                            Res.CouldNotSetExtensionAttributes_Title,
                             MessageBoxButtons.OK, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button1)
                     End Try
                 Next
                 If result.Count <= 0 Then
-                    DesignerMessageBox.Show(_serviceProvider, _
-                        String.Format(Res.CouldNotSetExtensionAttributes_AllItems, extensionTemplate.DisplayName), _
-                        Res.CouldNotSetExtensionAttributes_Title, _
+                    DesignerMessageBox.Show(_serviceProvider,
+                        String.Format(Res.CouldNotSetExtensionAttributes_AllItems, extensionTemplate.DisplayName),
+                        Res.CouldNotSetExtensionAttributes_Title,
                         MessageBoxButtons.OK, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button1)
                 End If
             End If
@@ -165,7 +165,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' </summary>
         Public Function GetExtensionProjectItemGroups(ByVal assemblyFullName As String) _
                 As List(Of MyExtensionProjectItemGroup)
-            If assemblyFullName IsNot Nothing AndAlso _
+            If assemblyFullName IsNot Nothing AndAlso
                     _extProjItemGroups IsNot Nothing Then
                 Return _extProjItemGroups.GetItems(assemblyFullName)
             Else
@@ -192,7 +192,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                 For i As Integer = 0 To extensionProjectItemGroup.ExtensionProjectItems.Count - 1
                     Try
                         extensionProjectItemGroup.ExtensionProjectItems(i).Delete()
-                    Catch ex As Exception When Not Utils.IsUnrecoverable(ex)
+                    Catch ex As Exception When Utils.ReportWithoutCrash(ex, NameOf(RemoveExtensionProjectItemGroup), NameOf(MyExtensibilityProjectSettings))
                     End Try
                 Next
             End If
@@ -257,14 +257,14 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' </summary>
         Private Function GetParentProjectItems() As ProjectItems
             ' Try to find "My Project" special folder first.
-            Dim myProjectFolderProjectItem As ProjectItem = _
+            Dim myProjectFolderProjectItem As ProjectItem =
                 MyApplicationProperties.GetProjectItemForProjectDesigner(_projectHierarchy)
 
             If myProjectFolderProjectItem Is Nothing Then
                 Debug.Assert(_project.ProjectItems IsNot Nothing, "Current project ProjectItems is NULL!")
                 Return _project.ProjectItems
             Else
-                Debug.Assert(myProjectFolderProjectItem.ProjectItems IsNot Nothing, _
+                Debug.Assert(myProjectFolderProjectItem.ProjectItems IsNot Nothing,
                     "My Project folder ProjectItems is NULL!")
                 Return myProjectFolderProjectItem.ProjectItems
             End If
@@ -290,8 +290,8 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' <summary>
         ''' Add the given extension project file to the list of extension project item groups.
         ''' </summary>
-        Private Sub AddExtensionProjectFile(ByVal assemblyFullName As String, ByVal extensionProjectItem As ProjectItem, _
-                ByVal extensionID As String, ByVal extensionVersion As Version, _
+        Private Sub AddExtensionProjectFile(ByVal assemblyFullName As String, ByVal extensionProjectItem As ProjectItem,
+                ByVal extensionID As String, ByVal extensionVersion As Version,
                 ByVal extensionName As String, ByVal extensionDescription As String)
             Debug.Assert(extensionProjectItem IsNot Nothing, "NULL extensionProjectItem!")
             Debug.Assert(Not String.IsNullOrEmpty(extensionID), "extensionID is NULL or empty!")
@@ -315,7 +315,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                 Next
             End If
             If currentExtensionProjectItemGroup Is Nothing Then
-                currentExtensionProjectItemGroup = New MyExtensionProjectItemGroup( _
+                currentExtensionProjectItemGroup = New MyExtensionProjectItemGroup(
                     extensionID, extensionVersion, extensionName, extensionDescription)
                 _extProjItemGroups.AddItem(assemblyFullName, currentExtensionProjectItemGroup)
             End If
@@ -374,10 +374,10 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
 
                 Dim templateName As String = Nothing
                 Dim templateDescription As String = Nothing
-                _projectService.GetExtensionTemplateNameAndDescription(templateID, templateVersion, assemblyName, _
+                _projectService.GetExtensionTemplateNameAndDescription(templateID, templateVersion, assemblyName,
                     templateName, templateDescription)
 
-                Me.AddExtensionProjectFile(assemblyName, extensionProjectItem, _
+                Me.AddExtensionProjectFile(assemblyName, extensionProjectItem,
                     templateID, templateVersion, templateName, templateDescription)
             Next
         End Sub
@@ -391,7 +391,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' Start listening to IVsTrackProjectDocumentsEvents2
         ''' </summary>
         Private Sub AdviseTrackProjectDocumentsEvents()
-            Dim trackProjectDocumentsEvents As TrackProjectDocumentsEventsHelper = _
+            Dim trackProjectDocumentsEvents As TrackProjectDocumentsEventsHelper =
                 MyExtensibilitySolutionService.Instance.TrackProjectDocumentsEvents
             If trackProjectDocumentsEvents IsNot Nothing Then
                 AddHandler trackProjectDocumentsEvents.AfterAddFilesEx, AddressOf Me.OnAfterAddFilesEx
@@ -407,7 +407,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' Stop listening to IVsTrackProjectDocumentsEvents2
         ''' </summary>
         Friend Sub UnadviseTrackProjectDocumentsEvents()
-            Dim trackProjectDocumentsEvents As TrackProjectDocumentsEventsHelper = _
+            Dim trackProjectDocumentsEvents As TrackProjectDocumentsEventsHelper =
                 MyExtensibilitySolutionService.Instance.TrackProjectDocumentsEvents
             If trackProjectDocumentsEvents IsNot Nothing Then
                 RemoveHandler trackProjectDocumentsEvents.AfterAddFilesEx, AddressOf Me.OnAfterAddFilesEx
@@ -437,7 +437,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                     For Each filePath As String In rgpszMkDocuments
                         If IsUnderFolder(filePath, myExtensionsFolderPath) Then
                             Dim fileName As String = Path.GetFileName(filePath)
-                            Dim subProjectItem As ProjectItem = _
+                            Dim subProjectItem As ProjectItem =
                                 DTEUtils.FindProjectItem(_extensionFolderProjectItem.ProjectItems, fileName)
                             Debug.Assert(subProjectItem IsNot Nothing, "Could not find subProjectItem!")
                             If _projectItemsAddedFromTemplate Is Nothing Then
@@ -583,7 +583,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
             Dim itemPath As String = Nothing
             Try
                 itemPath = projectItem.FileNames(1)
-            Catch ex As Exception When Not IsUnrecoverable(ex)
+            Catch ex As Exception When ReportWithoutCrash(ex, NameOf(GetProjectItemPath), NameOf(MyExtensibilityProjectSettings))
             End Try
             If itemPath IsNot Nothing Then
                 itemPath = RemoveEndingSeparator(itemPath)

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySettings.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySettings.vb
@@ -239,7 +239,8 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
             Dim templatesWithCustomData As Templates = Nothing
             Try
                 templatesWithCustomData = solution3.GetProjectItemTemplates(projectTypeID, s_CUSTOM_DATA_SIGNATURE)
-            Catch ex As Exception ' Ignore exceptions.
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(InitializeProjectKindSettings), NameOf(MyExtensibilitySettings), considerExceptionAsRecoverable:=True)
+                ' Ignore exceptions.
             End Try
             If templatesWithCustomData Is Nothing OrElse templatesWithCustomData.Count = 0 Then
                 Exit Sub
@@ -282,7 +283,8 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                     Dim xmlNode As XmlNode = xmlDocument.ReadNode(xmlReader)
                     xmlDocument.AppendChild(xmlNode)
                 End While
-            Catch ex As Exception ' Ignore exceptions.
+            Catch ex As Exception
+                ' Ignore exceptions.
             Finally
                 If xmlReader IsNot Nothing Then
                     xmlReader.Close()
@@ -345,7 +347,8 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
 
                 xmlWriter.WriteEndElement()
                 xmlWriter.WriteEndDocument()
-            Catch ex As Exception ' Ignore write exceptions.
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(SaveAssemblySettings), NameOf(MyExtensibilitySettings), considerExceptionAsRecoverable:=True)
+                ' Ignore write exceptions.
             Finally
                 If xmlWriter IsNot Nothing Then
                     xmlWriter.Close()
@@ -410,7 +413,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
             If Not StringIsNullEmptyOrBlank(attributeValue) Then
                 Try
                     result = DirectCast(AssemblyOptionConverter.ConvertFromInvariantString(attributeValue), AssemblyOption)
-                Catch ex As Exception When Not Utils.IsUnrecoverable(ex)
+                Catch ex As Exception When Utils.ReportWithoutCrash(ex, NameOf(ReadAssemblyOptionAttribute), NameOf(MyExtensibilitySettings))
                 End Try
             End If
             Return result
@@ -421,7 +424,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' Write an AssemblyOption value into the specified attribute using the specified XML text writer.
         ''' Try to use TypeConverter.ConvertToInvariantString, if fail, use the numeric value.
         ''' </summary>
-        Private Shared Sub WriteAssemblyOptionAttribute(ByVal writer As XmlTextWriter, _
+        Private Shared Sub WriteAssemblyOptionAttribute(ByVal writer As XmlTextWriter,
                 ByVal attributeName As String, ByVal value As AssemblyOption)
             Debug.Assert(writer IsNot Nothing, "Null writer!")
             Debug.Assert(Not StringIsNullEmptyOrBlank(attributeName), "Null attribute name!")
@@ -431,10 +434,9 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
             Dim text As String = Nothing
             Try
                 text = AssemblyOptionConverter.ConvertToInvariantString(value)
-            Catch ex As Exception When Not Utils.IsUnrecoverable(ex)
+            Catch ex As Exception When Utils.ReportWithoutCrash(ex, "Could not convert to invariant string", NameOf(MyExtensibilitySettings))
             End Try
             If text Is Nothing Then
-                Debug.Fail("Could not convert to invariant string!")
                 text = CInt(value).ToString()
             End If
             If text IsNot Nothing Then

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySettings.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySettings.vb
@@ -239,7 +239,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
             Dim templatesWithCustomData As Templates = Nothing
             Try
                 templatesWithCustomData = solution3.GetProjectItemTemplates(projectTypeID, s_CUSTOM_DATA_SIGNATURE)
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(InitializeProjectKindSettings), NameOf(MyExtensibilitySettings), considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(InitializeProjectKindSettings), NameOf(MyExtensibilitySettings))
                 ' Ignore exceptions.
             End Try
             If templatesWithCustomData Is Nothing OrElse templatesWithCustomData.Count = 0 Then
@@ -347,7 +347,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
 
                 xmlWriter.WriteEndElement()
                 xmlWriter.WriteEndDocument()
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(SaveAssemblySettings), NameOf(MyExtensibilitySettings), considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(SaveAssemblySettings), NameOf(MyExtensibilitySettings))
                 ' Ignore write exceptions.
             Finally
                 If xmlWriter IsNot Nothing Then

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySolutionService.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySolutionService.vb
@@ -111,7 +111,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
             ' Expect an IVsHierarchy but if none is provided, attempt to get it from IVsMonitorSelection.
             If projectHierarchy Is Nothing Then
                 Try
-                    Dim vsMonitorSelection As IVsMonitorSelection = TryCast( _
+                    Dim vsMonitorSelection As IVsMonitorSelection = TryCast(
                         _VBPackage.GetService(GetType(IVsMonitorSelection)), IVsMonitorSelection)
 
                     If vsMonitorSelection IsNot Nothing Then
@@ -121,7 +121,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                         Dim selectionContainerPointer As IntPtr = IntPtr.Zero
 
                         Try
-                            vsMonitorSelection.GetCurrentSelection( _
+                            vsMonitorSelection.GetCurrentSelection(
                                 vsHierarchyPointer, itemID, vsMultiItemSelect, selectionContainerPointer)
                         Finally
                             If selectionContainerPointer <> IntPtr.Zero Then
@@ -129,14 +129,14 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                             End If
 
                             If vsHierarchyPointer <> IntPtr.Zero Then
-                                projectHierarchy = TryCast( _
+                                projectHierarchy = TryCast(
                                     Marshal.GetObjectForIUnknown(vsHierarchyPointer), IVsHierarchy)
                                 Marshal.Release(vsHierarchyPointer)
                                 vsHierarchyPointer = IntPtr.Zero
                             End If
                         End Try
                     End If ' If vsMonitorSelection IsNot Nothing
-                Catch ex As Exception
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetProjectService), NameOf(MyExtensibilitySettings), considerExceptionAsRecoverable:=True)
                     ' Ignore exceptions.
                 End Try
             End If

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySolutionService.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySolutionService.vb
@@ -136,7 +136,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                             End If
                         End Try
                     End If ' If vsMonitorSelection IsNot Nothing
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetProjectService), NameOf(MyExtensibilitySettings), considerExceptionAsRecoverable:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetProjectService), NameOf(MyExtensibilitySettings))
                     ' Ignore exceptions.
                 End Try
             End If

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityUtil.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityUtil.vb
@@ -84,7 +84,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                 outputAsmName.Name = inputAsmName.Name
                 outputAsmName.Version = inputAsmName.Version
                 Return outputAsmName.FullName
-            Catch ex As Exception When Not IsUnrecoverable(ex)
+            Catch ex As Exception When ReportWithoutCrash(ex, NameOf(NormalizeAssemblyFullName), NameOf(MyExtensibilityUtil))
                 Return Nothing
             End Try
         End Function
@@ -138,7 +138,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                 _assemblyIndependentList.Add(item)
             Else
                 If _assemblyDictionary Is Nothing Then
-                    _assemblyDictionary = New Dictionary(Of String, AssemblyVersionDictionary(Of T))( _
+                    _assemblyDictionary = New Dictionary(Of String, AssemblyVersionDictionary(Of T))(
                         System.StringComparer.OrdinalIgnoreCase)
                 End If
                 Dim asmVersionDictionary As AssemblyVersionDictionary(Of T) = Nothing
@@ -222,7 +222,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
             End If
         End Sub
 
-        Private Sub ParseAssemblyFullName(ByVal assemblyFullName As String, _
+        Private Sub ParseAssemblyFullName(ByVal assemblyFullName As String,
                 ByRef assemblyName As String, ByRef assemblyVersion As Version)
 
             If StringIsNullEmptyOrBlank(assemblyFullName) Then
@@ -233,7 +233,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                     Dim asmName As New AssemblyName(assemblyFullName)
                     assemblyName = asmName.Name
                     assemblyVersion = asmName.Version
-                Catch ex As Exception When Not IsUnrecoverable(ex)
+                Catch ex As Exception When ReportWithoutCrash(ex, NameOf(ParseAssemblyFullName), NameOf(MyExtensibilityUtil))
                     assemblyName = Nothing
                     assemblyVersion = Nothing
                 End Try

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/TrackProjectDocumentsEventsHelper.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/TrackProjectDocumentsEventsHelper.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         Public Shared Function GetInstance(ByVal serviceProvider As IServiceProvider) As TrackProjectDocumentsEventsHelper
             Try
                 Return New TrackProjectDocumentsEventsHelper(serviceProvider)
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Fail to listen to IVsTrackProjectDocumentsEvents2", NameOf(TrackProjectDocumentsEventsHelper), debugFail:=True, considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Fail to listen to IVsTrackProjectDocumentsEvents2", NameOf(TrackProjectDocumentsEventsHelper))
                 Return Nothing
             End Try
         End Function

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/TrackProjectDocumentsEventsHelper.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/TrackProjectDocumentsEventsHelper.vb
@@ -12,8 +12,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         Public Shared Function GetInstance(ByVal serviceProvider As IServiceProvider) As TrackProjectDocumentsEventsHelper
             Try
                 Return New TrackProjectDocumentsEventsHelper(serviceProvider)
-            Catch ex As Exception
-                Debug.Fail(String.Format("Fail to listen to IVsTrackProjectDocumentsEvents2: {0}", ex.ToString()))
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Fail to listen to IVsTrackProjectDocumentsEvents2", NameOf(TrackProjectDocumentsEventsHelper), debugFail:=True, considerExceptionAsRecoverable:=True)
                 Return Nothing
             End Try
         End Function

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageBase.vb
@@ -185,8 +185,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                         Icon.Dispose()
                     Catch ex As ArgumentException
                         ShowErrorMessage(SR.GetString(SR.PPG_Application_BadIcon_1Arg, sFileName))
-                    Catch ex As Exception
-                        Common.RethrowIfUnrecoverable(ex)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(BrowseForAppIcon), NameOf(ApplicationPropPageBase))
                         ShowErrorMessage(ex)
                     End Try
                     If Not ValidIcon Then
@@ -199,8 +198,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     Dim ProjectItem As EnvDTE.ProjectItem = Nothing
                     Try
                         ProjectItem = AddIconFileToProject(sFileName)
-                    Catch ex As Exception
-                        Common.RethrowIfUnrecoverable(ex)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, SR.GetString(SR.PPG_Application_CantAddIcon), NameOf(ApplicationPropPageBase))
                         ShowErrorMessage(SR.GetString(SR.PPG_Application_CantAddIcon), ex)
                     End Try
 
@@ -308,9 +306,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     Dim IconContents As Byte() = IO.File.ReadAllBytes(path)
                     Dim IconStream As New IO.MemoryStream(IconContents, 0, IconContents.Length)
                     ApplicationIconPictureBox.Image = IconToImage(New Icon(IconStream), ApplicationIconPictureBox.ClientSize)
-                Catch ex As Exception
-                    Common.RethrowIfUnrecoverable(ex, True)
-
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(SetIconImagePath), NameOf(ApplicationPropPageBase), ignoreOutOfMemory:=True)
                     'This could mean a bad icon file, I/O problems, etc.  At any rate, it doesn't make sense to
                     '  display an error message (doesn't necessarily mean the user just selected it, it might have
                     '  been in the project file), so we'll just show a blank image
@@ -340,8 +336,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                         Dim ProjectItem As EnvDTE.ProjectItem = Nothing
                         Try
                             ProjectItem = AddIconFileToProject(path)
-                        Catch ex As Exception
-                            Common.RethrowIfUnrecoverable(ex)
+                        Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, SR.GetString(SR.PPG_Application_CantAddIcon), NameOf(ApplicationPropPageBase))
                             ShowErrorMessage(SR.GetString(SR.PPG_Application_CantAddIcon), ex)
                             Return False
                         End Try

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageBase.vb
@@ -306,7 +306,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     Dim IconContents As Byte() = IO.File.ReadAllBytes(path)
                     Dim IconStream As New IO.MemoryStream(IconContents, 0, IconContents.Length)
                     ApplicationIconPictureBox.Image = IconToImage(New Icon(IconStream), ApplicationIconPictureBox.ClientSize)
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(SetIconImagePath), NameOf(ApplicationPropPageBase), ignoreOutOfMemory:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(SetIconImagePath), NameOf(ApplicationPropPageBase))
                     'This could mean a bad icon file, I/O problems, etc.  At any rate, it doesn't make sense to
                     '  display an error message (doesn't necessarily mean the user just selected it, it might have
                     '  been in the project file), so we'll just show a blank image

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageInternalBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageInternalBase.vb
@@ -140,7 +140,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                     targetFrameworkSupported = True
                 End If
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Couldn't retrieve target framework assemblies, disabling combobox", NameOf(ApplicationPropPageInternalBase), considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Couldn't retrieve target framework assemblies, disabling combobox", NameOf(ApplicationPropPageInternalBase))
                 Switches.TracePDProperties(TraceLevel.Warning, ": {0}", ex.ToString())
                 targetFrameworkSupported = False
                 targetFrameworkComboBox.Items.Clear()

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageInternalBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageInternalBase.vb
@@ -140,8 +140,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                     targetFrameworkSupported = True
                 End If
-            Catch ex As Exception
-                Switches.TracePDProperties(TraceLevel.Warning, "Couldn't retrieve target framework assemblies, disabling combobox: {0}", ex.ToString())
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Couldn't retrieve target framework assemblies, disabling combobox", NameOf(ApplicationPropPageInternalBase), considerExceptionAsRecoverable:=True)
+                Switches.TracePDProperties(TraceLevel.Warning, ": {0}", ex.ToString())
                 targetFrameworkSupported = False
                 targetFrameworkComboBox.Items.Clear()
             End Try

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBBase.vb
@@ -269,7 +269,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     End If
 
                 End If
-            Catch ex As Exception When Common.ReportWithoutCrash(ex, NameOf(OnRootNamespaceChanged), NameOf(ApplicationPropPageBase), debugFail:=True)
+            Catch ex As Exception When Common.ReportWithoutCrash(ex, NameOf(OnRootNamespaceChanged), NameOf(ApplicationPropPageBase))
             End Try
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBBase.vb
@@ -269,8 +269,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     End If
 
                 End If
-            Catch ex As Exception When Not Common.IsUnrecoverable(ex)
-                Debug.Fail("OnRootNamespaceChanged threw an exception: " & ex.ToString)
+            Catch ex As Exception When Common.ReportWithoutCrash(ex, NameOf(OnRootNamespaceChanged), NameOf(ApplicationPropPageBase), debugFail:=True)
             End Try
         End Sub
 
@@ -688,8 +687,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                         VSErrorHandler.ThrowOnFailure(WindowFrame.Show())
                     End If
 
-                Catch ex As Exception
-                    Common.RethrowIfUnrecoverable(ex)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ViewUACSettings), NameOf(ApplicationPropPageVBBase))
                     If Not Me.ProjectReloadedDuringCheckout Then
                         ShowErrorMessage(ex)
                     End If

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
@@ -251,7 +251,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             If MyApplicationProperties IsNot Nothing Then
                 Try
                     MyApplicationProperties.RunCustomTool()
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(TryRunCustomToolForMyApplication), NameOf(ApplicationPropPageInternalBase), considerExceptionAsRecoverable:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(TryRunCustomToolForMyApplication), NameOf(ApplicationPropPageInternalBase))
                     ShowErrorMessage(ex)
                 End Try
             End If
@@ -795,7 +795,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     Debug.Fail("Failed to get IVBEntryPointProvider")
                 End If
 
-            Catch ex As System.Exception When Common.Utils.ReportWithoutCrash(ex, "An exception occurred in GetStartupForms() - using empty list", NameOf(ApplicationPropPageVBWinForms), debugFail:=True)
+            Catch ex As System.Exception When Common.Utils.ReportWithoutCrash(ex, "An exception occurred in GetStartupForms() - using empty list", NameOf(ApplicationPropPageVBWinForms))
             End Try
 
             Return New String() {}

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
@@ -251,7 +251,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             If MyApplicationProperties IsNot Nothing Then
                 Try
                     MyApplicationProperties.RunCustomTool()
-                Catch ex As Exception
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(TryRunCustomToolForMyApplication), NameOf(ApplicationPropPageInternalBase), considerExceptionAsRecoverable:=True)
                     ShowErrorMessage(ex)
                 End Try
             End If
@@ -795,9 +795,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     Debug.Fail("Failed to get IVBEntryPointProvider")
                 End If
 
-            Catch ex As System.Exception
-                Common.RethrowIfUnrecoverable(ex)
-                Debug.Fail("An exception occurred in GetStartupForms() - using empty list" & vbCrLf & ex.ToString)
+            Catch ex As System.Exception When Common.Utils.ReportWithoutCrash(ex, "An exception occurred in GetStartupForms() - using empty list", NameOf(ApplicationPropPageVBWinForms), debugFail:=True)
             End Try
 
             Return New String() {}
@@ -1014,7 +1012,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     Try
                         MyApplicationProperties.CustomSubMain = True
                         UseApplicationFrameworkCheckBox.CheckState = CheckState.Unchecked
-                    Catch ex As Exception When Not Utils.IsUnrecoverable(ex)
+                    Catch ex As Exception When Utils.ReportWithoutCrash(ex, NameOf(PostInitPage), NameOf(ApplicationPropPageVBWinForms))
                     End Try
                 End If
             End If
@@ -1473,7 +1471,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     ' add necessary references...
                     Try
                         AddRequiredReferences()
-                    Catch ex As Exception When Not Common.Utils.IsUnrecoverable(ex) AndAlso Not Common.Utils.IsCheckoutCanceledException(ex)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ApplicationTypeComboBox_SelectionChangeCommitted), NameOf(ApplicationPropPageVBWinForms)) AndAlso
+                        Not Common.Utils.IsCheckoutCanceledException(ex)
+
                         ShowErrorMessage(ex)
                     End Try
 
@@ -1499,7 +1499,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                 PopulateControlSet(outputType)
 
-            Catch ex As Exception When Not Common.Utils.IsUnrecoverable(ex)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ApplicationTypeComboBox_SelectionChangeCommitted), NameOf(ApplicationPropPageVBWinForms))
                 ' There are lots of issues with check-out... I leave it to vswhidbey 475879
                 Dim appTypeValue As Object = Nothing
                 Dim CurrentAppType As ApplicationTypes = CType(appTypeValue, ApplicationTypes)
@@ -1547,8 +1547,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             EnterProjectCheckoutSection()
             Try
                 MyApplicationProperties.NavigateToEvents()
-            Catch ex As Exception
-                Common.RethrowIfUnrecoverable(ex)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ViewCodeButton_Click), NameOf(ApplicationPropPageVBWinForms))
                 If Not Me.ProjectReloadedDuringCheckout Then
                     ShowErrorMessage(ex)
                 End If

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventCommandLineDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventCommandLineDialog.vb
@@ -228,7 +228,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                         System.Diagnostics.Debug.Fail("Can not find ServiceProvider")
                     End If
 
-                Catch ex As System.Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(InvokeHelp), NameOf(BuildEventCommandLineDialog), debugFail:=True, considerExceptionAsRecoverable:=True)
+                Catch ex As System.Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(InvokeHelp), NameOf(BuildEventCommandLineDialog))
                 End Try
             End If
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventCommandLineDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventCommandLineDialog.vb
@@ -228,8 +228,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                         System.Diagnostics.Debug.Fail("Can not find ServiceProvider")
                     End If
 
-                Catch ex As System.Exception
-                    System.Diagnostics.Debug.Fail("Unexpected exception during Help invocation " + ex.Message)
+                Catch ex As System.Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(InvokeHelp), NameOf(BuildEventCommandLineDialog), debugFail:=True, considerExceptionAsRecoverable:=True)
                 End Try
             End If
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CompilePropPage2.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CompilePropPage2.vb
@@ -163,9 +163,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                 Return CUInt(value) = VSLangProj110.prjOutputTypeEx.prjOutputTypeEx_Library _
                     AndAlso Not GetPropertyControlData(VsProjPropId.VBPROJPROPID_RegisterForComInterop).IsMissing
-            Catch ex As Exception
-                Common.Utils.RethrowIfUnrecoverable(ex)
-
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(RegisterForComInteropSupported), NameOf(CompilePropPage2))
                 'If the project doesn't support this property, the answer is no.
                 Return False
             End Try
@@ -457,9 +455,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                         UpdateWarningList()
                     End If
                     Return True
-                Catch ex As Exception
-                    Debug.Fail(String.Format("Failed to convert {0} to string ({1})", value, ex))
-                    Common.RethrowIfUnrecoverable(ex)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, $"Failed to convert {value} to string", NameOf(CompilePropPage2), debugFail:=True)
                 End Try
             Else
                 Debug.Fail("Why did we get a NULL value for option strict?")
@@ -1348,8 +1344,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     Static CLSID_InternetSecurityManager As New System.Guid("7b8a2d94-0ac9-11d1-896c-00c04fb6bfc4")
                     VSErrorHandler.ThrowOnFailure(localReg.CreateInstance(CLSID_InternetSecurityManager, Nothing, Interop.NativeMethods.IID_IUnknown, Interop.win.CLSCTX_INPROC_SERVER, ObjectPtr))
                     internetSecurityManager = TryCast(System.Runtime.InteropServices.Marshal.GetObjectForIUnknown(ObjectPtr), Interop.IInternetSecurityManager)
-                Catch Ex As Exception When Not Common.IsUnrecoverable(Ex)
-                    Debug.Fail(String.Format("Failed to create Interop.IInternetSecurityManager: {0}", Ex))
+                Catch Ex As Exception When Common.ReportWithoutCrash(Ex, "Failed to create Interop.IInternetSecurityManager", NameOf(CompilePropPage2), debugFail:=True)
                 Finally
                     If ObjectPtr <> IntPtr.Zero Then
                         System.Runtime.InteropServices.Marshal.Release(ObjectPtr)

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CompilePropPage2.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CompilePropPage2.vb
@@ -455,7 +455,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                         UpdateWarningList()
                     End If
                     Return True
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, $"Failed to convert {value} to string", NameOf(CompilePropPage2), debugFail:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, $"Failed to convert {value} to string", NameOf(CompilePropPage2))
                 End Try
             Else
                 Debug.Fail("Why did we get a NULL value for option strict?")
@@ -1344,7 +1344,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     Static CLSID_InternetSecurityManager As New System.Guid("7b8a2d94-0ac9-11d1-896c-00c04fb6bfc4")
                     VSErrorHandler.ThrowOnFailure(localReg.CreateInstance(CLSID_InternetSecurityManager, Nothing, Interop.NativeMethods.IID_IUnknown, Interop.win.CLSCTX_INPROC_SERVER, ObjectPtr))
                     internetSecurityManager = TryCast(System.Runtime.InteropServices.Marshal.GetObjectForIUnknown(ObjectPtr), Interop.IInternetSecurityManager)
-                Catch Ex As Exception When Common.ReportWithoutCrash(Ex, "Failed to create Interop.IInternetSecurityManager", NameOf(CompilePropPage2), debugFail:=True)
+                Catch Ex As Exception When Common.ReportWithoutCrash(Ex, "Failed to create Interop.IInternetSecurityManager", NameOf(CompilePropPage2))
                 Finally
                     If ObjectPtr <> IntPtr.Zero Then
                         System.Runtime.InteropServices.Marshal.Release(ObjectPtr)

--- a/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.vb
@@ -295,7 +295,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     sInitialDirectory = Path.Combine(GetProjectPath(), GetSelectedConfigOutputPath())
                 Catch ex As IO.IOException
                     'Ignore
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception getting project output path for selected config", NameOf(DebugPropPage), debugFail:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception getting project output path for selected config", NameOf(DebugPropPage))
                 End Try
             End If
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.vb
@@ -295,9 +295,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     sInitialDirectory = Path.Combine(GetProjectPath(), GetSelectedConfigOutputPath())
                 Catch ex As IO.IOException
                     'Ignore
-                Catch ex As Exception
-                    Common.RethrowIfUnrecoverable(ex)
-                    Debug.Fail("Exception getting project output path for selected config: " & ex.Message)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception getting project output path for selected config", NameOf(DebugPropPage), debugFail:=True)
                 End Try
             End If
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePathsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePathsPropPage.vb
@@ -343,8 +343,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     'Interpret as relative to the project path, and make it absolute
                     FolderText = IO.Path.Combine(GetProjectPath(), FolderText)
                     FolderText = Utils.AppendBackslash(FolderText)
-                Catch ex As Exception
-                    Common.RethrowIfUnrecoverable(ex)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetCurrentFolderPathAbsolute), NameOf(ReferencePathsPropPage))
                 End Try
             End If
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
@@ -933,7 +933,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                                 'Remove from local storage
                                 ReferenceList.Items.RemoveAt(ItemIndex)
 
-                            Catch ex As Exception When Not Common.IsUnrecoverable(ex)
+                            Catch ex As Exception When Common.ReportWithoutCrash(ex, NameOf(RemoveSelectedReference), NameOf(ReferencePropPage))
                                 If ProjectReloadedDuringCheckout Then
                                     ' If the Project could be reloaded, we should return ASAP, because the designer has been disposed
                                     Return
@@ -1031,7 +1031,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     End If
 
                     hr = UIHier.ExecCommand(VSITEMID.ROOT, guidVSStd2k, ECMD_ADDREFERENCE, 0, Nothing, System.IntPtr.Zero)
-                Catch ex As Exception When Not Common.IsUnrecoverable(ex)
+                Catch ex As Exception When Common.ReportWithoutCrash(ex, NameOf(referenceToolStripMenuItem_Click), NameOf(ReferencePropPage))
                     ShowErrorMessage(ex)
                 End Try
 
@@ -1069,7 +1069,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     Me.PopulateReferenceList()
                     Me.PopulateImportsList(True)
                 End If
-            Catch ex As Exception When Not Common.IsUnrecoverable(ex)
+            Catch ex As Exception When Common.ReportWithoutCrash(ex, NameOf(webReferenceToolStripMenuItem_Click), NameOf(ReferencePropPage))
                 If Not Common.IsCheckoutCanceledException(ex) Then
                     ShowErrorMessage(SR.GetString(SR.PPG_Reference_AddWebReference, ex.Message))
                 End If
@@ -1113,7 +1113,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                         Microsoft.Internal.Performance.CodeMarkers.Instance.CodeMarker(Microsoft.Internal.Performance.CodeMarkerEvent.perfMSVSEditorsReferencePageWCFAdded)
                     End If
-                Catch ex As Exception When Not Common.IsUnrecoverable(ex)
+                Catch ex As Exception When Common.ReportWithoutCrash(ex, NameOf(serviceReferenceToolStripMenuItem_Click), NameOf(ReferencePropPage))
                     If Not Common.IsCheckoutCanceledException(ex) Then
                         ShowErrorMessage(SR.GetString(SR.PPG_Reference_AddWebReference, ex.Message))
                     End If
@@ -1267,7 +1267,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     If referenceComponent IsNot Nothing Then
                         Try
                             referenceComponent.Update()
-                        Catch ex As Exception When Not Common.IsUnrecoverable(ex)
+                        Catch ex As Exception When Common.ReportWithoutCrash(ex, NameOf(UpdateReferences_Click), NameOf(ReferencePropPage))
                             If Not Common.IsCheckoutCanceledException(ex) Then
                                 ShowErrorMessage(SR.GetString(SR.PPG_Reference_FailedToUpdateWebReference, CType(referenceComponent, IReferenceComponent).GetName(), ex.Message))
                             End If
@@ -1404,7 +1404,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                         Try
                             _Imports.Remove(index)
                             valueUpdated = True
-                        Catch ex As Exception When Not Common.IsUnrecoverable(ex)
+                        Catch ex As Exception When Common.ReportWithoutCrash(ex, "Unexpected error when removing imports", NameOf(ReferencePropPage))
                             If Common.IsCheckoutCanceledException(ex) Then
                                 'Exit early - no need to show any UI, they've already seen it
                                 Return valueUpdated
@@ -1429,7 +1429,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                         Try
                             _Imports.Add(_Namespace)
                             valueUpdated = True
-                        Catch ex As Exception When Not Common.IsUnrecoverable(ex)
+                        Catch ex As Exception When Common.ReportWithoutCrash(ex, "Unexpected error when removing imports", NameOf(ReferencePropPage))
                             If Common.IsCheckoutCanceledException(ex) Then
                                 'Exit early - no need to show any UI, they've already seen it
                                 Return valueUpdated

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ServicesAuthenticationForm.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ServicesAuthenticationForm.vb
@@ -47,7 +47,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 Else
                     System.Diagnostics.Debug.Fail("Can not find ServiceProvider")
                 End If
-            Catch ex As System.Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ShowHelp), NameOf(ServicesAuthenticationForm), debugFail:=True, considerExceptionAsRecoverable:=True)
+            Catch ex As System.Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ShowHelp), NameOf(ServicesAuthenticationForm))
             End Try
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ServicesAuthenticationForm.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ServicesAuthenticationForm.vb
@@ -47,8 +47,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 Else
                     System.Diagnostics.Debug.Fail("Can not find ServiceProvider")
                 End If
-            Catch ex As System.Exception
-                System.Diagnostics.Debug.Fail("Unexpected exception during Help invocation " + ex.Message)
+            Catch ex As System.Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ShowHelp), NameOf(ServicesAuthenticationForm), debugFail:=True, considerExceptionAsRecoverable:=True)
             End Try
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ServicesPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ServicesPropPage.vb
@@ -331,8 +331,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     System.Diagnostics.Debug.Fail("Can not find ServiceProvider")
                 End If
 
-            Catch ex As System.Exception
-                System.Diagnostics.Debug.Fail("Unexpected exception during Help invocation " + ex.Message)
+            Catch ex As System.Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(InvokeHelp), NameOf(ServicesPropPage), debugFail:=True, considerExceptionAsRecoverable:=True)
             End Try
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ServicesPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ServicesPropPage.vb
@@ -331,7 +331,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     System.Diagnostics.Debug.Fail("Can not find ServiceProvider")
                 End If
 
-            Catch ex As System.Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(InvokeHelp), NameOf(ServicesPropPage), debugFail:=True, considerExceptionAsRecoverable:=True)
+            Catch ex As System.Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(InvokeHelp), NameOf(ServicesPropPage))
             End Try
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/UnusedReferencePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/UnusedReferencePropPage.vb
@@ -113,7 +113,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                 ' Get reference usage provider interface
                 _refUsageProvider = CType(ServiceProvider.GetService(NativeMethods.VBCompilerGuid), IVBReferenceUsageProvider)
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(InitDialog), NameOf(UnusedReferencePropPage), debugFail:=True, considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(InitDialog), NameOf(UnusedReferencePropPage))
                 Throw
             End Try
 
@@ -429,7 +429,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     End Using
                 End If
 
-            Catch ex As System.Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetUnusedRefs), NameOf(UnusedReferencePropPage), debugFail:=True)
+            Catch ex As System.Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetUnusedRefs), NameOf(UnusedReferencePropPage))
                 Result = ReferenceUsageResult.ReferenceUsageError
             Finally
                 ' Report status

--- a/src/Microsoft.VisualStudio.Editors/PropPages/UnusedReferencePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/UnusedReferencePropPage.vb
@@ -113,8 +113,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                 ' Get reference usage provider interface
                 _refUsageProvider = CType(ServiceProvider.GetService(NativeMethods.VBCompilerGuid), IVBReferenceUsageProvider)
-            Catch ex As Exception
-                Debug.Fail("An exception was thrown in UnusedReferencePropPage.InitDialog" & vbCrLf & ex.ToString)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(InitDialog), NameOf(UnusedReferencePropPage), debugFail:=True, considerExceptionAsRecoverable:=True)
                 Throw
             End Try
 
@@ -430,10 +429,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     End Using
                 End If
 
-            Catch ex As System.Exception
-                Common.RethrowIfUnrecoverable(ex)
-                Debug.Fail("An exception was thrown in GetUnusedRefs()" & vbCrLf & ex.ToString)
-
+            Catch ex As System.Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetUnusedRefs), NameOf(UnusedReferencePropPage), debugFail:=True)
                 Result = ReferenceUsageResult.ReferenceUsageError
             Finally
                 ' Report status

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/AppDotXamlDocument.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/AppDotXamlDocument.vb
@@ -147,7 +147,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                         End If
                         _isDisposed = True
                     End If
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(Dispose), NameOf(AppDotXamlDocument), debugFail:=True, considerExceptionAsRecoverable:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(Dispose), NameOf(AppDotXamlDocument))
                     Throw
                 End Try
             End Sub
@@ -925,7 +925,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                 Dim newPropertyValue As String = "(error)"
                 Try
                     newPropertyValue = GetApplicationPropertyValue(propertyName)
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Got an exception trying to verify the new property value in SetApplicationPropertyValue", NameOf(AppDotXamlDocument), debugFail:=True, considerExceptionAsRecoverable:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Got an exception trying to verify the new property value in SetApplicationPropertyValue", NameOf(AppDotXamlDocument))
                 End Try
 
                 If (Not value.Equals(newPropertyValue, StringComparison.Ordinal)) Then

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/AppDotXamlDocument.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/AppDotXamlDocument.vb
@@ -147,8 +147,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                         End If
                         _isDisposed = True
                     End If
-                Catch ex As Exception
-                    Debug.Fail("Exception in Dispose: " & ex.ToString())
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(Dispose), NameOf(AppDotXamlDocument), debugFail:=True, considerExceptionAsRecoverable:=True)
                     Throw
                 End Try
             End Sub
@@ -926,8 +925,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                 Dim newPropertyValue As String = "(error)"
                 Try
                     newPropertyValue = GetApplicationPropertyValue(propertyName)
-                Catch ex As Exception
-                    Debug.Fail("Got an exception trying to verify the new property value in SetApplicationPropertyValue: " & ex.ToString())
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Got an exception trying to verify the new property value in SetApplicationPropertyValue", NameOf(AppDotXamlDocument), debugFail:=True, considerExceptionAsRecoverable:=True)
                 End Try
 
                 If (Not value.Equals(newPropertyValue, StringComparison.Ordinal)) Then

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
@@ -354,7 +354,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                         ' we're the only person with it open, save the document
                         VSErrorHandler.ThrowOnFailure(rdt.SaveDocuments(CUInt(__VSRDTSAVEOPTIONS.RDTSAVEOPT_SaveIfDirty), hier, itemId, docCookie))
                     End If
-                Catch ex As Exception
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(TrySaveDocDataIfLastEditor), NameOf(ApplicationPropPageVBWPF), considerExceptionAsRecoverable:=True)
                     ShowErrorMessage(ex)
                 End Try
             End If
@@ -1527,7 +1527,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                         Else
                             Value = GetStartupObjectOrUriValueFromStorage()
                         End If
-                    Catch ex As Exception
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ReadUserDefinedProperty), NameOf(ApplicationPropPageVBWPF), considerExceptionAsRecoverable:=True)
                         If ShouldStartupUriBeDisplayedInsteadOfStartupObject() Then
                             Value = New StartupUri("")
                         Else
@@ -1538,14 +1538,14 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                 Case s_PROPNAME_ShutDownMode
                     Try
                         Value = GetShutdownModeFromStorage()
-                    Catch ex As Exception
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ReadUserDefinedProperty), NameOf(ApplicationPropPageVBWPF), considerExceptionAsRecoverable:=True)
                         Value = ""
                     End Try
 
                 Case s_PROPNAME_UseApplicationFramework
                     Try
                         Value = GetUseApplicationFrameworkFromStorage()
-                    Catch ex As Exception
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ReadUserDefinedProperty), NameOf(ApplicationPropPageVBWPF), considerExceptionAsRecoverable:=True)
                         Value = TriState.Disabled
                     End Try
 
@@ -1617,7 +1617,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                 If appXamlProjectItem.Document IsNot Nothing Then
                     appXamlProjectItem.Document.Activate()
                 End If
-            Catch ex As Exception
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(TryShowXamlEditor), NameOf(ApplicationPropPageVBWPF), considerExceptionAsRecoverable:=True)
                 ShowErrorMessage(ex)
             Finally
                 LeaveProjectCheckoutSection()
@@ -1828,8 +1828,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                     RemoveErrorControl()
                     RefreshPropertyValues()
                     DisplayErrorControlIfAppXamlIsInvalid()
-                Catch ex As Exception
-                    Debug.Fail("Unexpected exception in RetryPageLoad(): " & ex.ToString())
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(RetryPageLoad), NameOf(ApplicationPropPageVBWPF), debugFail:=True, considerExceptionAsRecoverable:=True)
                 End Try
             End If
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
@@ -354,7 +354,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                         ' we're the only person with it open, save the document
                         VSErrorHandler.ThrowOnFailure(rdt.SaveDocuments(CUInt(__VSRDTSAVEOPTIONS.RDTSAVEOPT_SaveIfDirty), hier, itemId, docCookie))
                     End If
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(TrySaveDocDataIfLastEditor), NameOf(ApplicationPropPageVBWPF), considerExceptionAsRecoverable:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(TrySaveDocDataIfLastEditor), NameOf(ApplicationPropPageVBWPF))
                     ShowErrorMessage(ex)
                 End Try
             End If
@@ -1527,7 +1527,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                         Else
                             Value = GetStartupObjectOrUriValueFromStorage()
                         End If
-                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ReadUserDefinedProperty), NameOf(ApplicationPropPageVBWPF), considerExceptionAsRecoverable:=True)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ReadUserDefinedProperty), NameOf(ApplicationPropPageVBWPF))
                         If ShouldStartupUriBeDisplayedInsteadOfStartupObject() Then
                             Value = New StartupUri("")
                         Else
@@ -1538,14 +1538,14 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                 Case s_PROPNAME_ShutDownMode
                     Try
                         Value = GetShutdownModeFromStorage()
-                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ReadUserDefinedProperty), NameOf(ApplicationPropPageVBWPF), considerExceptionAsRecoverable:=True)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ReadUserDefinedProperty), NameOf(ApplicationPropPageVBWPF))
                         Value = ""
                     End Try
 
                 Case s_PROPNAME_UseApplicationFramework
                     Try
                         Value = GetUseApplicationFrameworkFromStorage()
-                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ReadUserDefinedProperty), NameOf(ApplicationPropPageVBWPF), considerExceptionAsRecoverable:=True)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ReadUserDefinedProperty), NameOf(ApplicationPropPageVBWPF))
                         Value = TriState.Disabled
                     End Try
 
@@ -1617,7 +1617,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                 If appXamlProjectItem.Document IsNot Nothing Then
                     appXamlProjectItem.Document.Activate()
                 End If
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(TryShowXamlEditor), NameOf(ApplicationPropPageVBWPF), considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(TryShowXamlEditor), NameOf(ApplicationPropPageVBWPF))
                 ShowErrorMessage(ex)
             Finally
                 LeaveProjectCheckoutSection()
@@ -1828,7 +1828,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                     RemoveErrorControl()
                     RefreshPropertyValues()
                     DisplayErrorControlIfAppXamlIsInvalid()
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(RetryPageLoad), NameOf(ApplicationPropPageVBWPF), debugFail:=True, considerExceptionAsRecoverable:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(RetryPageLoad), NameOf(ApplicationPropPageVBWPF))
                 End Try
             End If
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WebReferenceComponent.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WebReferenceComponent.vb
@@ -27,8 +27,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Get
                 Try
                     Return _projectItem.Name
-                Catch ex As Exception
-                    Debug.Fail(ex.Message)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(Name), NameOf(WebReferenceComponent), debugFail:=True, considerExceptionAsRecoverable:=True)
                     Return String.Empty
                 End Try
             End Get
@@ -119,8 +118,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 If properties IsNot Nothing Then
                     Return properties.Item(propertyName)
                 End If
-            Catch e As System.ArgumentException
-                Debug.Fail(e.Message)
+            Catch e As System.ArgumentException When Common.Utils.ReportWithoutCrash(e, NameOf(GetItemProperty), NameOf(WebReferenceComponent), debugFail:=True, considerExceptionAsRecoverable:=True)
             End Try
             Return Nothing
         End Function

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WebReferenceComponent.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WebReferenceComponent.vb
@@ -27,7 +27,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Get
                 Try
                     Return _projectItem.Name
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(Name), NameOf(WebReferenceComponent), debugFail:=True, considerExceptionAsRecoverable:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(Name), NameOf(WebReferenceComponent))
                     Return String.Empty
                 End Try
             End Get
@@ -118,7 +118,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 If properties IsNot Nothing Then
                     Return properties.Item(propertyName)
                 End If
-            Catch e As System.ArgumentException When Common.Utils.ReportWithoutCrash(e, NameOf(GetItemProperty), NameOf(WebReferenceComponent), debugFail:=True, considerExceptionAsRecoverable:=True)
+            Catch e As System.ArgumentException When Common.Utils.ReportWithoutCrash(e, NameOf(GetItemProperty), NameOf(WebReferenceComponent))
             End Try
             Return Nothing
         End Function

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/FileWatcher.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/FileWatcher.vb
@@ -251,8 +251,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     Throw
                 Catch ex As StackOverflowException
                     Throw
-                Catch ex As Exception
-                    RethrowIfUnrecoverable(ex)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(FileWatcher.New), NameOf(FileWatcher))
                     'CONSIDER: The directory does not exist.  Find a parent directory that
                     '  does exist.  What if drive doesn't exist?
                     Debug.WriteLineIf(Switches.RSEFileWatcher.TraceInfo, "FileWatcher: Unable to create FileSystemWatcher: directory does not exist: " & DirectoryPath)

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/FindReplace.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/FindReplace.vb
@@ -330,8 +330,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                                         If Text Is Nothing Then
                                             Text = ""
                                         End If
-                                    Catch ex As Exception
-                                        RethrowIfUnrecoverable(ex)
+                                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(Find), NameOf(FindReplace))
                                         Text = ""
                                     End Try
                                 End If

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
@@ -516,9 +516,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     If _cachedValue.IsAlive AndAlso CurrentCachedValue IsNot Nothing AndAlso TypeOf CurrentCachedValue Is IDisposable Then
                         Try
                             CType(CurrentCachedValue, IDisposable).Dispose()
-                        Catch ex As Exception
-                            RethrowIfUnrecoverable(ex)
-                            Debug.Fail("Disposing a resource value threw an exception: " & ex.ToString())
+                        Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Disposing a resource value threw an exception", NameOf(Resource), debugFail:=True)
                         End Try
                     End If
                     _cachedValue = Nothing
@@ -1163,9 +1161,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
                     Debug.Assert(TypeName <> "", "ResXDataNode.GetValueTypeName() should never return an empty string or Nothing (not even for ResXNullRef)")
                     Return TypeName
-                Catch ex As Exception
-                    RethrowIfUnrecoverable(ex)
-                    Debug.Fail("Unexpected exception - ResXDataNode.GetValueTypeName() is not supposed to throw exceptions (except unrecoverable ones), it should instead return the typename as in the original .resx file - exception: " & ex.Message)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Unexpected exception - ResXDataNode.GetValueTypeName() is not supposed to throw exceptions (except unrecoverable ones), it should instead return the typename as in the original .resx file", NameOf(Resource), debugFail:=True)
                     Return SR.GetString(SR.RSE_UnknownType)
                 End Try
             End Get
@@ -1376,8 +1372,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Public Function TryGetValue() As Object
             Try
                 Return GetValue()
-            Catch ex As Exception
-                RethrowIfUnrecoverable(ex, IgnoreOutOfMemory:=True) 'We ignore OOM - the resource may simply be big.  We're okay dealing with that.
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(TryGetValue), NameOf(Resource), ignoreOutOfMemory:=True) 'We ignore OOM - the resource may simply be big.  We're okay dealing with that.
                 Return Nothing
             End Try
         End Function
@@ -1458,7 +1453,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="ExceptionToRethrow">The exception to rethrow, if any.  May be the same exeption as ExceptionFromGetValue or different.</param>
         ''' <remarks></remarks>
         Friend Sub SetTaskFromGetValueException(ByVal ExceptionFromGetValue As Exception, ByRef ExceptionToRethrow As Exception)
-            RethrowIfUnrecoverable(ExceptionFromGetValue)
+            If Not Common.Utils.ReportWithoutCrash(ExceptionFromGetValue, NameOf(SetTaskFromGetValueException), NameOf(Resource)) Then
+                Throw ExceptionToRethrow
+            End If
 
             'We hit an exception.  Add a task list item for resource instantiation (if it doesn't already exist)
 
@@ -1643,16 +1640,14 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             With _cachedImageProperties
                 Try
                     .FriendlySize = ResourceTypeEditor.GetResourceFriendlySize(Me)
-                Catch ex As Exception
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(CacheFriendlyTypeAndSize), NameOf(Resource), ignoreOutOfMemory:=True)
                     'Ignore exceptions, including out of memory - just use empty string
-                    RethrowIfUnrecoverable(ex, IgnoreOutOfMemory:=True)
                 End Try
 
                 Try
                     .FriendlyTypeDescription = ResourceTypeEditor.GetResourceFriendlyTypeDescription(Me)
-                Catch ex As Exception
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(CacheFriendlyTypeAndSize), NameOf(Resource), ignoreOutOfMemory:=True)
                     'Ignore exceptions, including out of memory - just use empty string
-                    RethrowIfUnrecoverable(ex, IgnoreOutOfMemory:=True)
                 End Try
             End With
         End Sub
@@ -1758,8 +1753,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                                     'Okay, it's a non-linked memory blob of a .wav file.  Treat it as such.
                                     TypeEditor = ResourceTypeEditors.Audio
                                 End If
-                            Catch ex As Exception
-                                RethrowIfUnrecoverable(ex)
+                            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(DetermineResourceTypeEditor), NameOf(Resource))
                                 'Ignore any problems (there shouldn't be) - better to handle this incorrect as a binary 
                                 '  blob than to throw an exception during the loading of the resx.
                             End Try
@@ -2058,8 +2052,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
                     'No exceptions were thrown, so no task list entries should be associated with this.
                     ClearTask(ResourceFile.ResourceTaskType.CantInstantiateResource)
-                Catch ex As Exception
-                    RethrowIfUnrecoverable(ex, IgnoreOutOfMemory:=True) 'We want task list entries for out of memory loading a resource
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(CheckValueForErrors), NameOf(Resource), ignoreOutOfMemory:=True) 'We want task list entries for out of memory loading a resource
 
                     'Create task list entry
                     SetTaskFromGetValueException(ex, ex)
@@ -2719,8 +2712,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Dim ConvertedValue As Object = Nothing
             Try
                 ConvertedValue = StringResourceEditor.StringParseFormattedCellValue(Me, CStr(NewFormattedValue))
-            Catch ex As Exception
-                RethrowIfUnrecoverable(ex)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ValidateValueAsString), NameOf(Resource))
                 FailureException = ex
             End Try
 
@@ -2733,8 +2725,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 '  resource, or it will be too late and cause problems.
                 Try
                     Dim DummyString As String = StringResourceEditor.StringGetFormattedCellValue(Me, ConvertedValue)
-                Catch ex As Exception
-                    RethrowIfUnrecoverable(ex)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ValidateValueAsString), NameOf(Resource))
                     FailureException = ex
                 End Try
             End If
@@ -2913,8 +2904,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 If ParentResourceFile IsNot Nothing Then
                     Try
                         Value = DirectCast(ResourceTypeEditor, ResourceTypeEditorStringBase).StringGetFormattedCellValue(Me, Me.GetValue)
-                    Catch ex As Exception
-                        RethrowIfUnrecoverable(ex)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ToString), NameOf(Resource))
                         Value = ex.Message
                     End Try
                 Else
@@ -2946,9 +2936,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     Me.EncodingWithoutUndo = Utility.GuessFileEncoding(Me.AbsoluteLinkPathAndFileName)
                 Catch ex As IOException
                     'Ignore
-                Catch ex As Exception
-                    RethrowIfUnrecoverable(ex)
-                    Debug.Fail("Unexpected failure in GuessFileEncoding - ignoring")
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Unexpected failure in GuessFileEncoding", NameOf(Resource), debugFail:=True)
                 End Try
             End If
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
@@ -516,7 +516,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     If _cachedValue.IsAlive AndAlso CurrentCachedValue IsNot Nothing AndAlso TypeOf CurrentCachedValue Is IDisposable Then
                         Try
                             CType(CurrentCachedValue, IDisposable).Dispose()
-                        Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Disposing a resource value threw an exception", NameOf(Resource), debugFail:=True)
+                        Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Disposing a resource value threw an exception", NameOf(Resource))
                         End Try
                     End If
                     _cachedValue = Nothing
@@ -1161,7 +1161,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
                     Debug.Assert(TypeName <> "", "ResXDataNode.GetValueTypeName() should never return an empty string or Nothing (not even for ResXNullRef)")
                     Return TypeName
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Unexpected exception - ResXDataNode.GetValueTypeName() is not supposed to throw exceptions (except unrecoverable ones), it should instead return the typename as in the original .resx file", NameOf(Resource), debugFail:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Unexpected exception - ResXDataNode.GetValueTypeName() is not supposed to throw exceptions (except unrecoverable ones), it should instead return the typename as in the original .resx file", NameOf(Resource))
                     Return SR.GetString(SR.RSE_UnknownType)
                 End Try
             End Get
@@ -1372,7 +1372,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Public Function TryGetValue() As Object
             Try
                 Return GetValue()
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(TryGetValue), NameOf(Resource), ignoreOutOfMemory:=True) 'We ignore OOM - the resource may simply be big.  We're okay dealing with that.
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(TryGetValue), NameOf(Resource)) 'We ignore OOM - the resource may simply be big.  We're okay dealing with that.
                 Return Nothing
             End Try
         End Function
@@ -1640,13 +1640,13 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             With _cachedImageProperties
                 Try
                     .FriendlySize = ResourceTypeEditor.GetResourceFriendlySize(Me)
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(CacheFriendlyTypeAndSize), NameOf(Resource), ignoreOutOfMemory:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(CacheFriendlyTypeAndSize), NameOf(Resource))
                     'Ignore exceptions, including out of memory - just use empty string
                 End Try
 
                 Try
                     .FriendlyTypeDescription = ResourceTypeEditor.GetResourceFriendlyTypeDescription(Me)
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(CacheFriendlyTypeAndSize), NameOf(Resource), ignoreOutOfMemory:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(CacheFriendlyTypeAndSize), NameOf(Resource))
                     'Ignore exceptions, including out of memory - just use empty string
                 End Try
             End With
@@ -2052,7 +2052,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
                     'No exceptions were thrown, so no task list entries should be associated with this.
                     ClearTask(ResourceFile.ResourceTaskType.CantInstantiateResource)
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(CheckValueForErrors), NameOf(Resource), ignoreOutOfMemory:=True) 'We want task list entries for out of memory loading a resource
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(CheckValueForErrors), NameOf(Resource)) 'We want task list entries for out of memory loading a resource
 
                     'Create task list entry
                     SetTaskFromGetValueException(ex, ex)
@@ -2936,7 +2936,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     Me.EncodingWithoutUndo = Utility.GuessFileEncoding(Me.AbsoluteLinkPathAndFileName)
                 Catch ex As IOException
                     'Ignore
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Unexpected failure in GuessFileEncoding", NameOf(Resource), debugFail:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Unexpected failure in GuessFileEncoding", NameOf(Resource))
                 End Try
             End If
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorDesignerLoader.vb
@@ -58,7 +58,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 Else
                     Debug.Fail("m_RootComponent is Nothing")
                 End If
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception during flush", NameOf(ResourceEditorDesignerLoader), debugFail:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception during flush", NameOf(ResourceEditorDesignerLoader))
                 Throw
             End Try
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorDesignerLoader.vb
@@ -58,9 +58,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 Else
                     Debug.Fail("m_RootComponent is Nothing")
                 End If
-            Catch ex As Exception
-                RethrowIfUnrecoverable(ex)
-                Debug.Fail("Warning: Exception during flush: " & ex.ToString())
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception during flush", NameOf(ResourceEditorDesignerLoader), debugFail:=True)
                 Throw
             End Try
         End Sub
@@ -149,9 +147,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
                         'Now that we know the load succeeded, we can try registering our view helper
                         NewResourceEditorRoot.RootDesigner.RegisterViewHelper()
-                    Catch ex As Exception
-                        RethrowIfUnrecoverable(ex)
-
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(HandleLoad), NameOf(ResourceEditorDesignerLoader))
                         _rootComponent = Nothing
 
                         'No need to dispose the resource editor root, the host will do this for us.

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootComponent.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootComponent.vb
@@ -233,11 +233,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     Dim kindString As String = parentItem.Kind
                     Try
                         Dim kindGuid As Guid = New Guid(kindString)
-                        If kindGuid.Equals(new Guid(EnvDTE.Constants.vsProjectItemKindPhysicalFile)) Then
+                        If kindGuid.Equals(New Guid(EnvDTE.Constants.vsProjectItemKindPhysicalFile)) Then
                             Return True
                         End If
-                    Catch ex As Exception
-                        Common.RethrowIfUnrecoverable(ex)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(IsDependentItem), NameOf(ResourceEditorRootComponent))
                     End Try
                 End If
             End If
@@ -294,9 +293,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 End While
             Catch ex As FormatException
                 ' Ignore this ...
-            Catch ex As Exception
-                Common.RethrowIfUnrecoverable(ex)
-                Debug.Fail(ex.Message)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(IsInGlobalResourceFolderInASP), NameOf(ResourceEditorRootComponent))
             End Try
             Return False
         End Function

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootDesigner.vb
@@ -355,9 +355,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         End If
                     End If
                 End If
-            Catch ex As Exception
-                RethrowIfUnrecoverable(ex)
-                Return ""
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetResXFileNameAndPath), NameOf(ResourceEditorRootDesigner))
+                Return String.Empty
             End Try
 
             Debug.Fail("Couldn't get name of resx file for UI purposes - returning empty string")
@@ -402,9 +401,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         '
                         'So, nothing for us to do.
                     End If
-                Catch ex As Exception
-                    RethrowIfUnrecoverable(ex)
-                    Debug.Fail("Exception trying to persist editor state: " & ex.ToString())
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception trying to persist editor state", NameOf(ResourceEditorRootDesigner), debugFail:=True)
                     'Ignore error
                 End Try
             End If
@@ -427,9 +424,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     If EditorState IsNot Nothing AndAlso EditorState.StatePersisted Then
                         EditorState.DepersistStateInto(_view)
                     End If
-                Catch ex As Exception
-                    RethrowIfUnrecoverable(ex)
-                    Debug.Fail("Exception trying to restore editor state after reload: " & ex.ToString)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception trying to restore editor state after reload", NameOf(ResourceEditorRootDesigner), debugFail:=True)
                     'Now ignore the exception
                 End Try
             End If
@@ -489,9 +484,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         Debug.Fail("View not set in RegisterViewHelper() - can't delay-register view helper")
                     End If
                 End If
-            Catch ex As Exception
-                RethrowIfUnrecoverable(ex)
-                Debug.Fail(ex.ToString)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(RegisterViewHelper), NameOf(ResourceEditorRootDesigner), debugFail:=True)
             End Try
         End Sub
 
@@ -508,9 +501,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 If VsWindowFrame IsNot Nothing Then
                     VSErrorHandler.ThrowOnFailure(VsWindowFrame.SetProperty(__VSFPROPID.VSFPROPID_ViewHelper, New UnknownWrapper(Nothing)))
                 End If
-            Catch ex As Exception
-                RethrowIfUnrecoverable(ex)
-                Debug.Fail(ex.ToString)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(UnRegisterViewHelper), NameOf(ResourceEditorRootDesigner), debugFail:=True)
             End Try
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootDesigner.vb
@@ -401,7 +401,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         '
                         'So, nothing for us to do.
                     End If
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception trying to persist editor state", NameOf(ResourceEditorRootDesigner), debugFail:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception trying to persist editor state", NameOf(ResourceEditorRootDesigner))
                     'Ignore error
                 End Try
             End If
@@ -424,7 +424,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     If EditorState IsNot Nothing AndAlso EditorState.StatePersisted Then
                         EditorState.DepersistStateInto(_view)
                     End If
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception trying to restore editor state after reload", NameOf(ResourceEditorRootDesigner), debugFail:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception trying to restore editor state after reload", NameOf(ResourceEditorRootDesigner))
                     'Now ignore the exception
                 End Try
             End If
@@ -484,7 +484,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         Debug.Fail("View not set in RegisterViewHelper() - can't delay-register view helper")
                     End If
                 End If
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(RegisterViewHelper), NameOf(ResourceEditorRootDesigner), debugFail:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(RegisterViewHelper), NameOf(ResourceEditorRootDesigner))
             End Try
         End Sub
 
@@ -501,7 +501,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 If VsWindowFrame IsNot Nothing Then
                     VSErrorHandler.ThrowOnFailure(VsWindowFrame.SetProperty(__VSFPROPID.VSFPROPID_ViewHelper, New UnknownWrapper(Nothing)))
                 End If
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(UnRegisterViewHelper), NameOf(ResourceEditorRootDesigner), debugFail:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(UnRegisterViewHelper), NameOf(ResourceEditorRootDesigner))
             End Try
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -505,7 +505,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                                 Return TryCast(value, String)
                             End If
                         End Using
-                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(SafeExtensions), NameOf(ResourceEditorView), debugFail:=True)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(SafeExtensions), NameOf(ResourceEditorView))
                     End Try
                 End If
                 Return String.Empty
@@ -523,7 +523,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                                 registryKey.SetValue("SafeExtensions", value, RegistryValueKind.String)
                             End Using
                         End If
-                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(SafeExtensions), NameOf(ResourceEditorView), debugFail:=True)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(SafeExtensions), NameOf(ResourceEditorView))
                     End Try
                 End If
             End Set
@@ -1530,7 +1530,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                             selectionService.SetSelectedComponents(Resources, SelectionTypes.Replace)
                         End If
                     End Using
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception in property grid select", NameOf(ResourceEditorView), debugFail:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception in property grid select", NameOf(ResourceEditorView))
                 End Try
             End If
         End Sub
@@ -1554,7 +1554,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Try
                 PropertyGridUpdate()
                 RootDesigner.InvalidateFindLoop(ResourcesAddedOrRemoved:=False)
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ResourceListView_SelectedIndexChanged), NameOf(ResourceEditorView), debugFail:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ResourceListView_SelectedIndexChanged), NameOf(ResourceEditorView))
             End Try
         End Sub
 
@@ -1572,7 +1572,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     PropertyGridUpdate()
                     RootDesigner.InvalidateFindLoop(ResourcesAddedOrRemoved:=False)
                 End If
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(StringTable_RowStateChanged), NameOf(ResourceEditorView), debugFail:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(StringTable_RowStateChanged), NameOf(ResourceEditorView))
             End Try
         End Sub
 
@@ -1588,7 +1588,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Try
                 PropertyGridUpdate()
                 RootDesigner.InvalidateFindLoop(ResourcesAddedOrRemoved:=False)
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(StringTable_CellEnter), NameOf(ResourceEditorView), debugFail:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(StringTable_CellEnter), NameOf(ResourceEditorView))
             End Try
         End Sub
 
@@ -2180,7 +2180,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                             HighestPriority = Priority
                             Exit For
                         End If
-                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetResourceTypeEditorForFileExtension), NameOf(ResourceEditorView), debugWriteLine:=True)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetResourceTypeEditorForFileExtension), NameOf(ResourceEditorView))
                         'Swallow the error and continue to the next candidate resource type editor
                     End Try
                 Next
@@ -2748,8 +2748,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     End If
                 Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex,
                                                                            $"Failed trying to copy linked or non-linked resource {Resource.Name} to temporary file {TempFileName} - ignoring and moving to next resource",
-                                                                           NameOf(ResourceEditorView),
-                                                                           debugWriteLine:=True)
+                                                                           NameOf(ResourceEditorView))
                     'Swallow the exception and move on to the next resource
                 End Try
             Next
@@ -4467,7 +4466,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     Debug.Assert(NewResource IsNot Nothing)
                     Try
                         EditOrOpenWith(NewResource, UseOpenWithDialog:=False)
-                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Got an exception trying to open the new resource in a separate editor - ignoring and continuing", NameOf(ResourceEditorView), ignoreOutOfMemory:=True, debugFail:=True)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Got an exception trying to open the new resource in a separate editor - ignoring and continuing", NameOf(ResourceEditorView))
                         'Ignore errors trying to open the editor for the file.  That's confusing to the user, because it
                         '  makes it appear that the resource wasn't successfully added, but it was.  Let them double-click
                         '  it if they want to edit, at which point they'll get the error and it will be less confusing.
@@ -4556,7 +4555,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             If e.Button = System.Windows.Forms.MouseButtons.Right Then
                 Try
                     Me.RootDesigner.ShowContextMenu(Constants.MenuConstants.ResXContextMenuID, e.X, e.Y)
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ShowContextMenu), NameOf(ResourceEditorView), ignoreOutOfMemory:=True, debugFail:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ShowContextMenu), NameOf(ResourceEditorView))
                 End Try
             Else
                 Debug.Fail("Wrong mouse button!")
@@ -4745,7 +4744,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     If File.Exists(FileName) Then
                         File.Delete(FileName)
                     End If
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, $"Unable to delete temporary file: {FileName}", NameOf(ResourceEditorView), debugFail:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, $"Unable to delete temporary file: {FileName}", NameOf(ResourceEditorView))
                 End Try
             Next
         End Sub
@@ -4762,7 +4761,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     If Directory.Exists(FolderName) Then
                         Directory.Delete(FolderName)
                     End If
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, $"Unable to delete temporary folder: {FolderName}", NameOf(ResourceEditorView), debugFail:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, $"Unable to delete temporary folder: {FolderName}", NameOf(ResourceEditorView))
                 End Try
             Next
         End Sub
@@ -4784,7 +4783,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 Directory.CreateDirectory(NewFolder)
                 _deleteFoldersOnEditorExit.Add(NewFolder)
                 Return NewFolder
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Couldn't create subfolder under TEMP directory - using TEMP directory itself instead", NameOf(ResourceEditorView), debugFail:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Couldn't create subfolder under TEMP directory - using TEMP directory itself instead", NameOf(ResourceEditorView))
             End Try
 
             'Had trouble creating a subfolder of TEMP.  Just return TEMP instead.
@@ -5104,7 +5103,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         _typeResolutionServiceCache = DynamicTypeService.GetTypeResolutionService(Hierarchy)
                     End If
                 End If
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception trying to retrieve project references", NameOf(ResourceEditorView), debugFail:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception trying to retrieve project references", NameOf(ResourceEditorView))
                 _typeResolutionServiceCache = Nothing
             End Try
 
@@ -5222,7 +5221,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Catch ex As COMException When ex.ErrorCode = win.DISP_E_MEMBERNOTFOUND OrElse ex.ErrorCode = win.OLECMDERR_E_NOTSUPPORTED
                 'Ignore this, if the project does not support this (like SmartPhone project)...
                 Return False
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(IsDefaultResXFile), NameOf(ResourceEditorView), debugFail:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(IsDefaultResXFile), NameOf(ResourceEditorView))
                 'If we hit some other unexpected error, we don't want to bomb out, as not being able to load the
                 '  designer would be worse than having me not recognize the default resx file.
                 Return False
@@ -5409,7 +5408,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                                                   OrElse ex.ErrorCode = NativeMethods.OLECMDERR_E_CANCELED _
                                                   OrElse ex.ErrorCode = NativeMethods.E_FAIL
                         ' We should ignore if the customer cancels this or we can not build the project...
-                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(CallGlobalRename), NameOf(ResourceEditorView), ignoreOutOfMemory:=True)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(CallGlobalRename), NameOf(ResourceEditorView))
                         DsMsgBox(ex)
                     Finally
                         ResourceEditorRefactorNotify.AllowSymbolRename = False

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -505,12 +505,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                                 Return TryCast(value, String)
                             End If
                         End Using
-                    Catch ex As Exception
-                        RethrowIfUnrecoverable(ex)
-                        Debug.Fail(ex.Message)
-                        'Catch ex As Object
-                        '    Debug.Fail("Unexpected, non-CLS compliant exception")
-                        '    Throw ex
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(SafeExtensions), NameOf(ResourceEditorView), debugFail:=True)
                     End Try
                 End If
                 Return String.Empty
@@ -528,12 +523,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                                 registryKey.SetValue("SafeExtensions", value, RegistryValueKind.String)
                             End Using
                         End If
-                    Catch ex As Exception
-                        RethrowIfUnrecoverable(ex)
-                        Debug.Fail(ex.Message)
-                        'Catch ex As Object
-                        '    Debug.Fail("Unexpected, non-CLS compliant exception")
-                        '    Throw ex
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(SafeExtensions), NameOf(ResourceEditorView), debugFail:=True)
                     End Try
                 End If
             End Set
@@ -1540,9 +1530,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                             selectionService.SetSelectedComponents(Resources, SelectionTypes.Replace)
                         End If
                     End Using
-                Catch ex As Exception
-                    RethrowIfUnrecoverable(ex)
-                    Debug.Fail("Exception in property grid select: " & ex.ToString)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception in property grid select", NameOf(ResourceEditorView), debugFail:=True)
                 End Try
             End If
         End Sub
@@ -1566,9 +1554,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Try
                 PropertyGridUpdate()
                 RootDesigner.InvalidateFindLoop(ResourcesAddedOrRemoved:=False)
-            Catch ex As Exception
-                RethrowIfUnrecoverable(ex)
-                Debug.Fail(ex.ToString)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ResourceListView_SelectedIndexChanged), NameOf(ResourceEditorView), debugFail:=True)
             End Try
         End Sub
 
@@ -1586,9 +1572,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     PropertyGridUpdate()
                     RootDesigner.InvalidateFindLoop(ResourcesAddedOrRemoved:=False)
                 End If
-            Catch ex As Exception
-                RethrowIfUnrecoverable(ex)
-                Debug.Fail(ex.ToString)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(StringTable_RowStateChanged), NameOf(ResourceEditorView), debugFail:=True)
             End Try
         End Sub
 
@@ -1604,9 +1588,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Try
                 PropertyGridUpdate()
                 RootDesigner.InvalidateFindLoop(ResourcesAddedOrRemoved:=False)
-            Catch ex As Exception
-                RethrowIfUnrecoverable(ex)
-                Debug.Fail(ex.ToString)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(StringTable_CellEnter), NameOf(ResourceEditorView), debugFail:=True)
             End Try
         End Sub
 
@@ -2198,9 +2180,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                             HighestPriority = Priority
                             Exit For
                         End If
-                    Catch ex As Exception
-                        RethrowIfUnrecoverable(ex)
-                        Debug.WriteLine("GetResourceTypeEditorForFileExtension: Exception thrown: " & ex.Message)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetResourceTypeEditorForFileExtension), NameOf(ResourceEditorView), debugWriteLine:=True)
                         'Swallow the error and continue to the next candidate resource type editor
                     End Try
                 Next
@@ -2587,8 +2567,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             If DataFormatSupported(Data, DragDropEffects.Copy, ActualEffect, ActualFormat) Then
                 Try
                     DragDropPaste(Data, DragDropEffects.Copy, ActualEffect:=ActualEffect)
-                Catch ex As Exception
-                    RethrowIfUnrecoverable(ex)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(MenuPaste), NameOf(ResourceEditorView))
                     DsMsgBox(ex)
                 End Try
             End If
@@ -2740,9 +2719,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 Try
                     If Resource.IsLink Then
                         'Linked file - copy the target of the link to a temp
-                        TempFileName = GetTemporaryFile( _
-                            AutoDelete.DeleteOnClipboardFlush, _
-                            ParentDirectory:=TempFolder, _
+                        TempFileName = GetTemporaryFile(
+                            AutoDelete.DeleteOnClipboardFlush,
+                            ParentDirectory:=TempFolder,
                             PreferredFileName:=Path.GetFileName(Resource.AbsoluteLinkPathAndFileName))
                         File.Copy(Resource.AbsoluteLinkPathAndFileName, TempFileName)
 
@@ -2753,9 +2732,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     Else
                         If Resource.ResourceTypeEditor.CanSaveResourceToFile(Resource) Then
                             'Non-linked.  Export the resource to a temp.
-                            TempFileName = GetTemporaryFile( _
-                                AutoDelete.DeleteOnClipboardFlush, _
-                                ParentDirectory:=TempFolder, _
+                            TempFileName = GetTemporaryFile(
+                                AutoDelete.DeleteOnClipboardFlush,
+                                ParentDirectory:=TempFolder,
                                 PreferredFileName:=CreateLegalFileName(Resource.Name) _
                                     & Resource.ResourceTypeEditor.GetResourceFileExtension(Resource))
                             Resource.ResourceTypeEditor.SaveResourceToFile(Resource, TempFileName)
@@ -2767,12 +2746,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     If TempFileName <> "" Then
                         ResourceFileNames.Add(TempFileName)
                     End If
-                Catch ex As Exception
-                    RethrowIfUnrecoverable(ex)
-
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex,
+                                                                           $"Failed trying to copy linked or non-linked resource {Resource.Name} to temporary file {TempFileName} - ignoring and moving to next resource",
+                                                                           NameOf(ResourceEditorView),
+                                                                           debugWriteLine:=True)
                     'Swallow the exception and move on to the next resource
-                    Debug.WriteLine("Failed trying to copy linked or non-linked resource " & Resource.Name & " to temporary file " & TempFileName & " - ignoring and moving to next resource" _
-                        & VB.vbCrLf & ex.Message)
                 End Try
             Next
             'Build a list of filenames out of the saved/exported files.
@@ -2996,8 +2974,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
             Try
                 DragDropPaste(e.Data, e.AllowedEffect, ActualEffect:=e.Effect)
-            Catch ex As Exception
-                RethrowIfUnrecoverable(ex)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(OnDragDrop), NameOf(ResourceEditorView))
                 DsMsgBox(ex)
                 e.Effect = DragDropEffects.None
             Finally
@@ -3609,8 +3586,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 '  project.
                 'And those are the semantics that we want...
                 VSErrorHandler.ThrowOnFailure(OpenDocumentService.OpenDocumentViaProject(ResourceFullPathTolerant, OpenLogView, ServiceProvider, Hierarchy, ItemId, WindowFrame))
-            Catch ex As Exception
-                RethrowIfUnrecoverable(ex)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(EditOrOpenWith), NameOf(ResourceEditorView))
                 If TypeOf ex Is System.Runtime.InteropServices.COMException Then
                     If CType(ex, System.Runtime.InteropServices.COMException).ErrorCode = Editors.Interop.win.OLE_E_PROMPTSAVECANCELLED Then
                         'We get this error when the user cancels the Open With dialog.  Obviously, we ignore this error and cancel.
@@ -3657,9 +3633,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                             Dim Filter As String = ResourceToExportFrom.ResourceTypeEditor.GetSaveFileDialogFilter(Path.GetExtension(SuggestedFileName))
                             Dim FilterIndex As Integer = 0
                             Dim UserCanceled As Boolean
-                            Dim FileAndPathToExportTo As String = ShowSaveFileDialog( _
-                                UserCanceled, _
-                                Title, Filter, FilterIndex, _
+                            Dim FileAndPathToExportTo As String = ShowSaveFileDialog(
+                                UserCanceled,
+                                Title, Filter, FilterIndex,
                                 SuggestedFileName, StickyExportPath)
                             If Not UserCanceled AndAlso FileAndPathToExportTo <> "" Then
                                 StickyExportPath = Path.GetDirectoryName(FileAndPathToExportTo)
@@ -3682,8 +3658,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         End If
                     End If
                 End If
-            Catch ex As Exception
-                RethrowIfUnrecoverable(ex)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(MenuExport), NameOf(ResourceEditorView))
                 DsMsgBox(ex)
             End Try
         End Sub
@@ -3706,8 +3681,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 Try
                     ' If we can't check out the resource file, do not pop up any dialog...
                     RootDesigner.DesignerLoader.ManualCheckOut()
-                Catch ex As Exception
-                    RethrowIfUnrecoverable(ex)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(MenuImport), NameOf(ResourceEditorView))
                     'Report errors to the user.
                     DsMsgBox(ex)
                     Return
@@ -3746,8 +3720,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
                             'BUGFIX:Dev11#35824 Save the directory where the user import resources for the next time.
                             StickyImportPath = Path.GetDirectoryName(FileAndPathToImportFrom)
-                        Catch ex As Exception
-                            RethrowIfUnrecoverable(ex)
+                        Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(MenuImport), NameOf(ResourceEditorView))
                             'Report errors to the user.
                             DsMsgBox(ex)
                         End Try
@@ -3853,9 +3826,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 Dim Extension As String = ""
                 Try
                     Extension = Resource.ResourceTypeEditor.GetResourceFileExtension(Resource)
-                Catch ex As Exception
-                    RethrowIfUnrecoverable(ex)
-
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetSuggestedFileNameForResource), NameOf(ResourceEditorView))
                     'If an error, simply don't add an extension.
                 End Try
                 Return CreateLegalFileName(Resource.Name) & Extension
@@ -3969,8 +3940,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     'Save the resource
                     Resource.ResourceTypeEditor.SaveResourceToFile(Resource, FileAndPathToExportTo)
                 Next
-            Catch ex As Exception
-                RethrowIfUnrecoverable(ex)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ExportResources), NameOf(ResourceEditorView))
                 DsMsgBox(ex)
             End Try
         End Sub
@@ -4229,8 +4199,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 'NOTE: we update the existing item as bug 382459 said.
                 'FixInvalidIdentifiers:=True because we want to fix invalid identifiers in the copy/paste and drag/drop scenarios
                 AddOrUpdateResourcesFromFiles(FilesToAdd, CopyFileIfExists:=False, AlwaysAddNew:=False, FixInvalidIdentifiers:=True)
-            Catch ex As Exception
-                RethrowIfUnrecoverable(ex)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ButtonAdd_ExistingFile_Click), NameOf(ResourceEditorView))
                 DsMsgBox(ex)
             End Try
         End Sub
@@ -4458,8 +4427,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     'Write out a blank resource into the new file
                     Try
                         TypeEditor.CreateNewResourceFile(NewResourceFilePath)
-                    Catch ex As Exception
-                        RethrowIfUnrecoverable(ex)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, SR.GetString(SR.RSE_Err_CantCreateNewResource_2Args, NewResourceFilePath, ex.Message), NameOf(ResourceEditorView))
                         DsMsgBox(SR.GetString(SR.RSE_Err_CantCreateNewResource_2Args, NewResourceFilePath, ex.Message), MessageBoxButtons.OK, MessageBoxIcon.Error, , HelpIDs.Err_CantCreateNewResource)
                         Exit Sub
                     End Try
@@ -4489,7 +4457,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     '  and deactivated again.  
                     Try
                         Me.RootDesigner.DesignerLoader.RunSingleFileGenerator(True)
-                    Catch ex As Exception When Not Common.IsUnrecoverable(ex)
+                    Catch ex As Exception When Common.ReportWithoutCrash(ex, NameOf(QueryAddNewLinkedResource), NameOf(ResourceEditorView))
                         DsMsgBox(ex)
                     End Try
 
@@ -4499,13 +4467,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     Debug.Assert(NewResource IsNot Nothing)
                     Try
                         EditOrOpenWith(NewResource, UseOpenWithDialog:=False)
-                    Catch ex As Exception
-                        RethrowIfUnrecoverable(ex, IgnoreOutOfMemory:=True)
-
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Got an exception trying to open the new resource in a separate editor - ignoring and continuing", NameOf(ResourceEditorView), ignoreOutOfMemory:=True, debugFail:=True)
                         'Ignore errors trying to open the editor for the file.  That's confusing to the user, because it
                         '  makes it appear that the resource wasn't successfully added, but it was.  Let them double-click
                         '  it if they want to edit, at which point they'll get the error and it will be less confusing.
-                        Debug.Fail("Got an exception trying to open the new resource in a separate editor - ignoring and continuing" & Microsoft.VisualBasic.vbCrLf & ex.ToString)
                     End Try
                 End Using
             Catch ex As Exception
@@ -4591,9 +4556,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             If e.Button = System.Windows.Forms.MouseButtons.Right Then
                 Try
                     Me.RootDesigner.ShowContextMenu(Constants.MenuConstants.ResXContextMenuID, e.X, e.Y)
-                Catch ex As Exception
-                    RethrowIfUnrecoverable(ex)
-                    Debug.Fail(ex.ToString)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ShowContextMenu), NameOf(ResourceEditorView), ignoreOutOfMemory:=True, debugFail:=True)
                 End Try
             Else
                 Debug.Fail("Wrong mouse button!")
@@ -4782,9 +4745,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     If File.Exists(FileName) Then
                         File.Delete(FileName)
                     End If
-                Catch ex As Exception
-                    RethrowIfUnrecoverable(ex)
-                    Debug.Fail("Unable to delete temporary file: " & FileName & VB.vbCrLf & ex.Message)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, $"Unable to delete temporary file: {FileName}", NameOf(ResourceEditorView), debugFail:=True)
                 End Try
             Next
         End Sub
@@ -4801,9 +4762,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     If Directory.Exists(FolderName) Then
                         Directory.Delete(FolderName)
                     End If
-                Catch ex As Exception
-                    RethrowIfUnrecoverable(ex)
-                    Debug.Fail("Unable to delete temporary folder: " & FolderName & VB.vbCrLf & ex.Message)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, $"Unable to delete temporary folder: {FolderName}", NameOf(ResourceEditorView), debugFail:=True)
                 End Try
             Next
         End Sub
@@ -4825,9 +4784,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 Directory.CreateDirectory(NewFolder)
                 _deleteFoldersOnEditorExit.Add(NewFolder)
                 Return NewFolder
-            Catch ex As Exception
-                RethrowIfUnrecoverable(ex)
-                Debug.Fail("Couldn't create subfolder under TEMP directory - using TEMP directory itself instead")
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Couldn't create subfolder under TEMP directory - using TEMP directory itself instead", NameOf(ResourceEditorView), debugFail:=True)
             End Try
 
             'Had trouble creating a subfolder of TEMP.  Just return TEMP instead.
@@ -5147,9 +5104,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         _typeResolutionServiceCache = DynamicTypeService.GetTypeResolutionService(Hierarchy)
                     End If
                 End If
-            Catch ex As Exception
-                RethrowIfUnrecoverable(ex)
-                Debug.Fail("Exception trying to retrieve project references: " & ex.ToString())
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception trying to retrieve project references", NameOf(ResourceEditorView), debugFail:=True)
                 _typeResolutionServiceCache = Nothing
             End Try
 
@@ -5267,12 +5222,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Catch ex As COMException When ex.ErrorCode = win.DISP_E_MEMBERNOTFOUND OrElse ex.ErrorCode = win.OLECMDERR_E_NOTSUPPORTED
                 'Ignore this, if the project does not support this (like SmartPhone project)...
                 Return False
-            Catch ex As Exception
-                RethrowIfUnrecoverable(ex)
-
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(IsDefaultResXFile), NameOf(ResourceEditorView), debugFail:=True)
                 'If we hit some other unexpected error, we don't want to bomb out, as not being able to load the
                 '  designer would be worse than having me not recognize the default resx file.
-                Debug.Fail("Unexpected exception in IsDefaultResXFile - returning False")
                 Return False
             End Try
 
@@ -5311,8 +5263,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         If cultureInfo IsNot Nothing Then
                             isLocalizedFileName = True
                         End If
-                    Catch ex As Exception
-                        RethrowIfUnrecoverable(ex)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(IsLocalizedResXFile), NameOf(ResourceEditorView))
                     End Try
                 End If
             End If
@@ -5458,8 +5409,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                                                   OrElse ex.ErrorCode = NativeMethods.OLECMDERR_E_CANCELED _
                                                   OrElse ex.ErrorCode = NativeMethods.E_FAIL
                         ' We should ignore if the customer cancels this or we can not build the project...
-                    Catch ex As Exception
-                        Common.Utils.RethrowIfUnrecoverable(ex, True)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(CallGlobalRename), NameOf(ResourceEditorView), ignoreOutOfMemory:=True)
                         DsMsgBox(ex)
                     Finally
                         ResourceEditorRefactorNotify.AllowSymbolRename = False

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView_EditorState.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView_EditorState.vb
@@ -134,9 +134,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     Next
 
                     _statePersisted = True
-                Catch ex As Exception
-                    RethrowIfUnrecoverable(ex)
-                    Debug.Fail("Exception depersisting editor state - state will not be restored.  " & ex.ToString())
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception depersisting editor state - state will not be restored", $"{NameOf(ResourceEditorView)}-{NameOf(EditorState)}", debugFail:=True)
                     Clear()
 
                     'Exception can be safely ignored.  They just won't get the state restored later.
@@ -160,10 +158,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                             For i As Integer = 0 To _stringTableColumnWidths.Length - 1
                                 Try
                                     View.StringTable.Columns(i).Width = _stringTableColumnWidths(i)
-                                Catch ex As Exception
-                                    RethrowIfUnrecoverable(ex)
+                                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Unable to set stringtable column width in restoring editor state", $"{NameOf(ResourceEditorView)}-{NameOf(EditorState)}", debugFail:=True)
                                     'Ignore exceptions if unable to set a column width (columns can have minimum widths)
-                                    Debug.Fail("Unable to set stringtable column width in restoring editor state: " & ex.ToString)
                                 End Try
                             Next
                         End If
@@ -173,10 +169,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                             For i As Integer = 0 To _listViewColumnWidths.Length - 1
                                 Try
                                     View._resourceListView.Columns(i).Width = _listViewColumnWidths(i)
-                                Catch ex As Exception
-                                    RethrowIfUnrecoverable(ex)
+                                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Unable to set listview column width in restoring editor state", $"{NameOf(ResourceEditorView)}-{NameOf(EditorState)}", debugFail:=True)
                                     'Ignore exceptions
-                                    Debug.Fail("Unable to set listview column width in restoring editor state: " & ex.ToString)
                                 End Try
                             Next
                         End If
@@ -222,9 +216,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                             _stringTableCurrentCellAddress = View.StringTable.CurrentCellAddress
                         End If
 
-                    Catch ex As Exception
-                        RethrowIfUnrecoverable(ex)
-                        Debug.Fail("Exception saving editor state - state will not be saved.  " & ex.ToString)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception saving editor state - state will not be saved", $"{NameOf(ResourceEditorView)}-{NameOf(EditorState)}", debugFail:=True)
                         Clear()
 
                         'Exception can be safely ignored.  They just won't get the state restored later.

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView_EditorState.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView_EditorState.vb
@@ -134,7 +134,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     Next
 
                     _statePersisted = True
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception depersisting editor state - state will not be restored", $"{NameOf(ResourceEditorView)}-{NameOf(EditorState)}", debugFail:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception depersisting editor state - state will not be restored", $"{NameOf(ResourceEditorView)}-{NameOf(EditorState)}")
                     Clear()
 
                     'Exception can be safely ignored.  They just won't get the state restored later.
@@ -158,7 +158,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                             For i As Integer = 0 To _stringTableColumnWidths.Length - 1
                                 Try
                                     View.StringTable.Columns(i).Width = _stringTableColumnWidths(i)
-                                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Unable to set stringtable column width in restoring editor state", $"{NameOf(ResourceEditorView)}-{NameOf(EditorState)}", debugFail:=True)
+                                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Unable to set stringtable column width in restoring editor state", $"{NameOf(ResourceEditorView)}-{NameOf(EditorState)}")
                                     'Ignore exceptions if unable to set a column width (columns can have minimum widths)
                                 End Try
                             Next
@@ -169,7 +169,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                             For i As Integer = 0 To _listViewColumnWidths.Length - 1
                                 Try
                                     View._resourceListView.Columns(i).Width = _listViewColumnWidths(i)
-                                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Unable to set listview column width in restoring editor state", $"{NameOf(ResourceEditorView)}-{NameOf(EditorState)}", debugFail:=True)
+                                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Unable to set listview column width in restoring editor state", $"{NameOf(ResourceEditorView)}-{NameOf(EditorState)}")
                                     'Ignore exceptions
                                 End Try
                             Next
@@ -216,7 +216,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                             _stringTableCurrentCellAddress = View.StringTable.CurrentCellAddress
                         End If
 
-                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception saving editor state - state will not be saved", $"{NameOf(ResourceEditorView)}-{NameOf(EditorState)}", debugFail:=True)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception saving editor state - state will not be saved", $"{NameOf(ResourceEditorView)}-{NameOf(EditorState)}")
                         Clear()
 
                         'Exception can be safely ignored.  They just won't get the state restored later.

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
@@ -367,7 +367,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     Debug.Fail("Bad unique name prefix - localization bug?")
                     UniqueNamePrefix = ""
                 End If
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetUniqueName), NameOf(ResourceFile), debugFail:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetUniqueName), NameOf(ResourceFile))
                 UniqueNamePrefix = ""
             End Try
 
@@ -799,7 +799,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             _resourcesHash.Remove(Resource.Name.ToUpperInvariant())
             Try
                 Resource.NameRawWithoutUndo = e.NewName
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Unexpected error changing the name of the resource", NameOf(ResourceFile), debugFail:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Unexpected error changing the name of the resource", NameOf(ResourceFile))
             End Try
             _resourcesHash.Add(Resource.Name.ToUpperInvariant(), Resource)
 
@@ -941,7 +941,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                                     lastName = Resource.Name
                                 End If
                             End If
-                        Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ReadResources), NameOf(ResourceFile), considerExceptionAsRecoverable:=True)
+                        Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ReadResources), NameOf(ResourceFile))
                             If Resource IsNot Nothing Then
                                 Resource.Dispose()
                             End If
@@ -1685,7 +1685,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                                     ' Let the project system to handle the exactly version...
                                     vsLangProj.References.Add(assmeblyName)
                                 End If
-                            Catch ex As Exception When Common.ReportWithoutCrash(ex, "Failed to add reference to assembly contining type", NameOf(ResourceFile), debugFail:=Not TypeOf ex Is CheckoutException)
+                            Catch ex As CheckoutException
+                                ' Ignore CheckoutException
+                            Catch ex As Exception When Common.ReportWithoutCrash(ex, "Failed to add reference to assembly contining type", NameOf(ResourceFile))
                                 ' We should ignore the error if the project system failed to do so..
 
                                 ' NOTE: we need consider to prompt the user an waring message. But it could be very annoying if we pop up many message boxes in one transaction.
@@ -1780,10 +1782,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             If View IsNot Nothing AndAlso View.GetDesignerLoader() IsNot Nothing Then
                 Try
                     View.GetDesignerLoader().RunSingleFileGenerator(True)
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(DelayFlushAndRunCustomToolImpl), NameOf(ResourceFile), considerExceptionAsRecoverable:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(DelayFlushAndRunCustomToolImpl), NameOf(ResourceFile))
                     Try
                         View.DsMsgBox(ex.Message, MessageBoxButtons.OK, MessageBoxIcon.Error)
-                    Catch ex2 As exception When Common.Utils.ReportWithoutCrash(ex2, "Unable to show exception message for exception", NameOf(DelayFlushAndRunCustomToolImpl), debugFail:=True)
+                    Catch ex2 As exception When Common.Utils.ReportWithoutCrash(ex2, "Unable to show exception message for exception", NameOf(DelayFlushAndRunCustomToolImpl))
                     End Try
                 End Try
             End If

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
@@ -510,7 +510,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 'See if we're able to check out the file before allowing the user to try to rename the resource.
                 ParentView.RootDesigner.DesignerLoader.ManualCheckOut()
                 ParentView.OnItemBeginEdit()
-            Catch ex As Exception
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(OnBeforeLabelEdit), NameOf(ResourceListView), considerExceptionAsRecoverable:=True)
                 e.CancelEdit = True
                 ParentView.DsMsgBox(ex)
             End Try
@@ -553,7 +553,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 Else
                     Debug.Fail("Couldn't find resource from index")
                 End If
-            Catch ex As Exception
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(OnAfterLabelEdit), NameOf(ResourceListView), considerExceptionAsRecoverable:=True)
                 ParentView.DsMsgBox(ex)
             End Try
         End Sub
@@ -1132,9 +1132,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Else
                 Try
                     ThumbnailSourceImage = Resource.ResourceTypeEditor.GetImageForThumbnail(Resource, Me.BackColor)
-                Catch ex As Exception
-                    RethrowIfUnrecoverable(ex, IgnoreOutOfMemory:=True)
-
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetThumbnailIndex), NameOf(ResourceListView), ignoreOutOfMemory:=True)
                     'For some reason, we could not get a value for this resource.  So, we use an error glyph for the
                     '  source of the thumbnail image instead.  Note that an alternative would be to have a single
                     '  thumbnail in the thumbnail cache representing an error be used for all error cases.  However,
@@ -1172,8 +1170,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
                 'NOTE: This is a slow operation, we should prevent to do so if it is possible...
                 Thumbnail = CreateThumbnail(ThumbnailSourceImage, ThumbnailSize, DrawBorder, _borderWidth, _selectionBorderWidth, _thumbnailImageList.TransparentColor)
-            Catch ex As Exception
-                Debug.Fail("Failed creating thumbnail")
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed creating thumbnail", NameOf(ResourceListView), debugFail:=True, considerExceptionAsRecoverable:=True)
                 Thumbnail = Nothing
             End Try
             Using Thumbnail

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
@@ -510,7 +510,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 'See if we're able to check out the file before allowing the user to try to rename the resource.
                 ParentView.RootDesigner.DesignerLoader.ManualCheckOut()
                 ParentView.OnItemBeginEdit()
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(OnBeforeLabelEdit), NameOf(ResourceListView), considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(OnBeforeLabelEdit), NameOf(ResourceListView))
                 e.CancelEdit = True
                 ParentView.DsMsgBox(ex)
             End Try
@@ -553,7 +553,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 Else
                     Debug.Fail("Couldn't find resource from index")
                 End If
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(OnAfterLabelEdit), NameOf(ResourceListView), considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(OnAfterLabelEdit), NameOf(ResourceListView))
                 ParentView.DsMsgBox(ex)
             End Try
         End Sub
@@ -1132,7 +1132,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Else
                 Try
                     ThumbnailSourceImage = Resource.ResourceTypeEditor.GetImageForThumbnail(Resource, Me.BackColor)
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetThumbnailIndex), NameOf(ResourceListView), ignoreOutOfMemory:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetThumbnailIndex), NameOf(ResourceListView))
                     'For some reason, we could not get a value for this resource.  So, we use an error glyph for the
                     '  source of the thumbnail image instead.  Note that an alternative would be to have a single
                     '  thumbnail in the thumbnail cache representing an error be used for all error cases.  However,
@@ -1170,7 +1170,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
                 'NOTE: This is a slow operation, we should prevent to do so if it is possible...
                 Thumbnail = CreateThumbnail(ThumbnailSourceImage, ThumbnailSize, DrawBorder, _borderWidth, _selectionBorderWidth, _thumbnailImageList.TransparentColor)
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed creating thumbnail", NameOf(ResourceListView), debugFail:=True, considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed creating thumbnail", NameOf(ResourceListView))
                 Thumbnail = Nothing
             End Try
             Using Thumbnail

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceSerializationService_Store.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceSerializationService_Store.vb
@@ -405,8 +405,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                             Else
                                 StringValue = PropertyValue.ToString()
                             End If
-                        Catch ex As Exception
-                            RethrowIfUnrecoverable(ex)
+                        Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(DeserializeHelper), NameOf(ResourceSerializationService))
                             StringValue = ex.Message
                         End Try
                         Trace("   ... Resource property: {0} = {1}", SerializedObject.PropertyName, StringValue)

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
@@ -1006,8 +1006,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     Dim StringResourceEditor As ResourceTypeEditorStringBase = DirectCast(Resource.ResourceTypeEditor, ResourceTypeEditorStringBase)
                     Try
                         Value = StringResourceEditor.StringGetFormattedCellValue(Resource, Resource.GetValue())
-                    Catch ex As Exception
-                        Common.RethrowIfUnrecoverable(ex)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetResourceCellStringValue), NameOf(ResourceStringTable))
                     End Try
                     Debug.WriteLineIf(Switches.RSEVirtualStringTable.TraceVerbose, "RSEVirtualStringTable: OnCellValueNeeded: Value: " & Value)
 
@@ -1056,8 +1055,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     e.ErrorText = ResourceFile.GetResourceTaskMessage(Resource, ResourceEditor.ResourceFile.ResourceTaskType.CantInstantiateResource)
                     Try
                         Dim value As Object = StringResourceEditor.StringGetFormattedCellValue(Resource, Resource.GetValue())
-                    Catch ex As Exception
-                        RethrowIfUnrecoverable(ex, IgnoreOutOfMemory:=True)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(OnCellErrorTextNeeded), NameOf(ResourceStringTable), ignoreOutOfMemory:=True)
                         If e.ErrorText = "" Then
                             'If there wasn't already an error message stored, use the exception we just got.
                             e.ErrorText = ex.Message

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
@@ -1055,7 +1055,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     e.ErrorText = ResourceFile.GetResourceTaskMessage(Resource, ResourceEditor.ResourceFile.ResourceTaskType.CantInstantiateResource)
                     Try
                         Dim value As Object = StringResourceEditor.StringGetFormattedCellValue(Resource, Resource.GetValue())
-                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(OnCellErrorTextNeeded), NameOf(ResourceStringTable), ignoreOutOfMemory:=True)
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(OnCellErrorTextNeeded), NameOf(ResourceStringTable))
                         If e.ErrorText = "" Then
                             'If there wasn't already an error message stored, use the exception we just got.
                             e.ErrorText = ex.Message

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditor.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditor.vb
@@ -7,8 +7,6 @@ Imports System.ComponentModel
 Imports System.Drawing
 Imports System.IO
 Imports System.Reflection
-Imports Microsoft.VisualStudio.Editors.Common.Utils
-
 
 Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
@@ -546,8 +544,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Friend Function TryCanSaveResourceToFile(ByVal Resource As IResource) As Boolean
             Try
                 Return CanSaveResourceToFile(Resource)
-            Catch ex As Exception
-                RethrowIfUnrecoverable(ex)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(TryCanSaveResourceToFile), NameOf(ResourceTypeEditor))
             End Try
 
             Return False

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourcesFolderService.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourcesFolderService.vb
@@ -683,14 +683,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         VsProjectsKey.Close()
                     End Try
                 End If
-            Catch ex As OutOfMemoryException
-                Throw
-            Catch ex As ThreadAbortException
-                Throw
-            Catch ex As StackOverflowException
-                Throw
-            Catch ex As Exception
-                Debug.Fail("Exception thrown trying to get ResourcesFolderBehavior value from local registry: " & ex.Message)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception thrown trying to get ResourcesFolderBehavior value from local registry", NameOf(ResourcesFolderService), debugFail:=True)
                 'Ignore any other exceptions - perhaps the key was the wrong data type, etc.  It will simply be treated as
                 '  if the behavior is AddNone.
             End Try
@@ -775,15 +768,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 Return ProjectItems.Item(Name)
             Catch ex As ArgumentException
                 'This is the expected exception if the key could not be found.
-            Catch ex As OutOfMemoryException
-                Throw
-            Catch ex As ThreadAbortException
-                Throw
-            Catch ex As StackOverflowException
-                Throw
-            Catch ex As Exception
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Unexpected exception searching for an item in ProjectItems", NameOf(ResourcesFolderService), debugFail:=True)
                 'Any other error - shouldn't be the case, but it might depend on the project implementation
-                Debug.Fail("Unexpected exception searching for an item in ProjectItems: " & ex.Message)
             End Try
 
             Return Nothing

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourcesFolderService.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourcesFolderService.vb
@@ -683,7 +683,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         VsProjectsKey.Close()
                     End Try
                 End If
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception thrown trying to get ResourcesFolderBehavior value from local registry", NameOf(ResourcesFolderService), debugFail:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception thrown trying to get ResourcesFolderBehavior value from local registry", NameOf(ResourcesFolderService))
                 'Ignore any other exceptions - perhaps the key was the wrong data type, etc.  It will simply be treated as
                 '  if the behavior is AddNone.
             End Try
@@ -768,7 +768,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 Return ProjectItems.Item(Name)
             Catch ex As ArgumentException
                 'This is the expected exception if the key could not be found.
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Unexpected exception searching for an item in ProjectItems", NameOf(ResourcesFolderService), debugFail:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Unexpected exception searching for an item in ProjectItems", NameOf(ResourcesFolderService))
                 'Any other error - shouldn't be the case, but it might depend on the project implementation
             End Try
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResxItemWizard.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResxItemWizard.vb
@@ -86,8 +86,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                             If (itemProperty IsNot Nothing) Then
                                 Try
                                     itemProperty.Value = value
-                                Catch ex As Exception
-                                    Debug.Fail("Setting property " & name & " to value " & value & " threw: " & ex.Message)
+                                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ProjectItemFinishedGenerating), NameOf(ResxItemWizard), debugFail:=True, considerExceptionAsRecoverable:=True)
                                 End Try
                             End If
                         End If

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResxItemWizard.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResxItemWizard.vb
@@ -86,7 +86,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                             If (itemProperty IsNot Nothing) Then
                                 Try
                                     itemProperty.Value = value
-                                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ProjectItemFinishedGenerating), NameOf(ResxItemWizard), debugFail:=True, considerExceptionAsRecoverable:=True)
+                                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ProjectItemFinishedGenerating), NameOf(ResxItemWizard))
                                 End Try
                             End If
                         End If

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ThumbnailCache.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ThumbnailCache.vb
@@ -202,7 +202,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     _imageList.Images.Add(Thumbnail)
                     Debug.Assert(ThumbnailCount - 1 + _reservedImagesCount = Index)
                     ThumbnailInserted = True
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(Add), NameOf(ThumbnailCache), ignoreOutOfMemory:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(Add), NameOf(ThumbnailCache))
                     'Hmmm, can't add a new index?  Let's try again, requesting that we recycle an
                     '  old image if possible.  If it still fails, we can't do anything else
                     '  to thwart the exception.

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ThumbnailCache.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ThumbnailCache.vb
@@ -202,9 +202,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     _imageList.Images.Add(Thumbnail)
                     Debug.Assert(ThumbnailCount - 1 + _reservedImagesCount = Index)
                     ThumbnailInserted = True
-                Catch ex As Exception
-                    RethrowIfUnrecoverable(ex, IgnoreOutOfMemory:=True)
-
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(Add), NameOf(ThumbnailCache), ignoreOutOfMemory:=True)
                     'Hmmm, can't add a new index?  Let's try again, requesting that we recycle an
                     '  old image if possible.  If it still fails, we can't do anything else
                     '  to thwart the exception.

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Utility.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Utility.vb
@@ -576,9 +576,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Try
                 Dim Converter As TypeConverter = TypeDescriptor.GetConverter(GetType(Font))
                 Return DirectCast(Converter.ConvertFromInvariantString(FontAsString), Font)
-            Catch ex As Exception
-                RethrowIfUnrecoverable(ex)
-                Debug.Fail("Unable to create requested font: " & FontAsString)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, $"Unable to create requested font {FontAsString}", NameOf(Utility), debugFail:=True)
             End Try
 
             Return Nothing

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Utility.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Utility.vb
@@ -576,7 +576,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Try
                 Dim Converter As TypeConverter = TypeDescriptor.GetConverter(GetType(Font))
                 Return DirectCast(Converter.ConvertFromInvariantString(FontAsString), Font)
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, $"Unable to create requested font {FontAsString}", NameOf(Utility), debugFail:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, $"Unable to create requested font {FontAsString}", NameOf(Utility))
             End Try
 
             Return Nothing

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/AppConfigSerializer.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/AppConfigSerializer.vb
@@ -218,15 +218,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                             AppConfigDocData = DocDataService.GetFileDocData(AppConfigFileName, Access, Nothing)
                         Catch ex As System.ComponentModel.Design.CheckoutException
                             Throw
-                        Catch Ex As Exception
-                            Debug.Fail(String.Format("DocDataService.GetFileDocData threw exception: {0}", Ex))
+                        Catch Ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetAppConfigDocData), NameOf(AppConfigSerializer), debugFail:=True, considerExceptionAsRecoverable:=True)
                             Throw
                         End Try
                     Else
                         Try
                             AppConfigDocData = New DocData(ServiceProvider, AppConfigFileName)
-                        Catch ex As Exception
-                            Debug.Fail(String.Format("DocData constructor threw exception: {0}", ex))
+                        Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetAppConfigDocData), NameOf(AppConfigSerializer), debugFail:=True, considerExceptionAsRecoverable:=True)
                             Throw
                         End Try
                     End If
@@ -349,7 +347,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 Try
                     Debug.Assert(Hierarchy IsNot Nothing, "Must have an IVsHierarchy in order to be able to sync user config files!")
                     SynchronizeUserConfig(SectionName, Hierarchy, ConfigHelperService, Settings, AppConfigDocData)
-                Catch ex As Exception When Not Common.IsUnrecoverable(ex)
+                Catch ex As Exception When Common.ReportWithoutCrash(ex, "Exception during synchronize user config files", NameOf(AppConfigSerializer))
                     ' Can't do very much here - but we shouldn't abort the save!
                 End Try
             End If
@@ -406,7 +404,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                     map.ExeConfigFilename = AppConfigDocData.Name
                     map.LocalUserConfigFilename = ConfigHelperService.GetUserConfigurationPath(hierSp, project, ConfigurationUserLevel.PerUserRoamingAndLocal, UnderVsHost, BuildConfig)
                     map.RoamingUserConfigFilename = ConfigHelperService.GetUserConfigurationPath(hierSp, project, ConfigurationUserLevel.PerUserRoaming, UnderVsHost, BuildConfig)
-                Catch ex As Exception When Not Common.Utils.IsUnrecoverable(ex)
+                Catch ex As Exception When Not Common.Utils.ReportWithoutCrash(ex, NameOf(SynchronizeUserConfig), NameOf(AppConfigSerializer))
                     ' Can't really do anything - synchronize will fail...
                     Return
                 End Try

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/AppConfigSerializer.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/AppConfigSerializer.vb
@@ -218,13 +218,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                             AppConfigDocData = DocDataService.GetFileDocData(AppConfigFileName, Access, Nothing)
                         Catch ex As System.ComponentModel.Design.CheckoutException
                             Throw
-                        Catch Ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetAppConfigDocData), NameOf(AppConfigSerializer), debugFail:=True, considerExceptionAsRecoverable:=True)
+                        Catch Ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetAppConfigDocData), NameOf(AppConfigSerializer))
                             Throw
                         End Try
                     Else
                         Try
                             AppConfigDocData = New DocData(ServiceProvider, AppConfigFileName)
-                        Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetAppConfigDocData), NameOf(AppConfigSerializer), debugFail:=True, considerExceptionAsRecoverable:=True)
+                        Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetAppConfigDocData), NameOf(AppConfigSerializer))
                             Throw
                         End Try
                     End If

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ConnectionStringUITypeEditor.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ConnectionStringUITypeEditor.vb
@@ -159,7 +159,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                     ' Well, we better return the old value...
                     Return oValue
                 End If
-            Catch ex As Exception When Not Common.IsUnrecoverable(ex)
+            Catch ex As Exception When Common.IsUnrecoverableException(ex)
                 'Just throw the exception, caller should handle this.
                 Throw
             Finally
@@ -186,8 +186,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             Try
                 Dim DataConnectionProperties As IVsDataConnectionProperties = GetConnectionStringProperties(ProviderManager, DataProvider, ConnectionString)
                 Return ContainsSensitiveData(DataConnectionProperties)
-            Catch ex As Exception
-                Common.Utils.RethrowIfUnrecoverable(ex)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ContainsSensitiveData), NameOf(ConnectionStringUITypeEditor))
             End Try
             ' The secure & safe assumption is that it does contain sensitive data
             Return True

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ConnectionStringUITypeEditor.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ConnectionStringUITypeEditor.vb
@@ -159,9 +159,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                     ' Well, we better return the old value...
                     Return oValue
                 End If
-            Catch ex As Exception When Common.IsUnrecoverableException(ex)
-                'Just throw the exception, caller should handle this.
-                Throw
             Finally
                 If dataConnectionDialog IsNot Nothing Then
                     dataConnectionDialog.Dispose()

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ProjectUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ProjectUtils.vb
@@ -326,8 +326,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
                             If projProp IsNot Nothing Then
                                 rootNamespace = CStr(projProp.Value)
                             End If
-                        Catch ex As Exception
-                            Debug.Fail(String.Format("Failed to get root namespace to remove from class name: {0}", ex))
+                        Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to get root namespace to remove from class name", NameOf(ProjectUtils), debugFail:=True, considerExceptionAsRecoverable:=True)
                         End Try
                         ExtendingNamespace = New CodeNamespace(Common.Utils.RemoveRootNamespace(cc2.Namespace.FullName, rootNamespace))
                     Else

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ProjectUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ProjectUtils.vb
@@ -326,7 +326,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
                             If projProp IsNot Nothing Then
                                 rootNamespace = CStr(projProp.Value)
                             End If
-                        Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to get root namespace to remove from class name", NameOf(ProjectUtils), debugFail:=True, considerExceptionAsRecoverable:=True)
+                        Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to get root namespace to remove from class name", NameOf(ProjectUtils))
                         End Try
                         ExtendingNamespace = New CodeNamespace(Common.Utils.RemoveRootNamespace(cc2.Namespace.FullName, rootNamespace))
                     Else

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesigner.vb
@@ -225,7 +225,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                         If Settings.UseSpecialClassName Then
                             Return SettingsDesigner.s_specialClassName
                         End If
-                    Catch ex As Exception When Common.ReportWithoutCrash(ex, String.Format("Failed to crack open {0} to determine if we were supposed to use the ""Special"" settings class name", FullPath), NameOf(SettingsDesigner), debugFail:=True)
+                    Catch ex As Exception When Common.ReportWithoutCrash(ex, String.Format("Failed to crack open {0} to determine if we were supposed to use the ""Special"" settings class name", FullPath), NameOf(SettingsDesigner))
                     End Try
                 End If
 
@@ -233,7 +233,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 ' Not a special case - let's return the "normal" class name which is based on the file name...
                 '
                 Return GeneratedClassNameFromPath(FullPath)
-            Catch ex As Exception When Common.ReportWithoutCrash(ex, "Failed to determine if we were supposed to use the ""Special"" settings class name", NameOf(SettingsDesigner), debugFail:=True)
+            Catch ex As Exception When Common.ReportWithoutCrash(ex, "Failed to determine if we were supposed to use the ""Special"" settings class name", NameOf(SettingsDesigner))
             End Try
             Return ""
         End Function

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesigner.vb
@@ -201,7 +201,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                     isVbProject = Common.Utils.IsVbProject(Hierarchy)
                 End If
 
-                If isVbProject AndAlso _
+                If isVbProject AndAlso
                     ((itemId <> VSITEMID.NIL AndAlso IsDefaultSettingsFile(Hierarchy, itemId)) _
                     OrElse (FullPath <> "" AndAlso IsDefaultSettingsFile(Hierarchy, FullPath))) _
                 Then
@@ -225,8 +225,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                         If Settings.UseSpecialClassName Then
                             Return SettingsDesigner.s_specialClassName
                         End If
-                    Catch ex As Exception When Not Common.IsUnrecoverable(ex)
-                        Debug.Fail(String.Format("Failed to crack open {0} to determine if we were supposed to use the ""Special"" settings class name: {1}", FullPath, ex))
+                    Catch ex As Exception When Common.ReportWithoutCrash(ex, String.Format("Failed to crack open {0} to determine if we were supposed to use the ""Special"" settings class name", FullPath), NameOf(SettingsDesigner), debugFail:=True)
                     End Try
                 End If
 
@@ -234,8 +233,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 ' Not a special case - let's return the "normal" class name which is based on the file name...
                 '
                 Return GeneratedClassNameFromPath(FullPath)
-            Catch ex As Exception When Not Common.IsUnrecoverable(ex)
-                Debug.Fail(String.Format("Failed to determine if we were supposed to use the ""Special"" settings class name: {0}", ex))
+            Catch ex As Exception When Common.ReportWithoutCrash(ex, "Failed to determine if we were supposed to use the ""Special"" settings class name", NameOf(SettingsDesigner), debugFail:=True)
             End Try
             Return ""
         End Function
@@ -453,7 +451,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 For Each file As String In files
                     Try
                         System.IO.File.Delete(file)
-                    Catch ex As Exception When Not Common.IsUnrecoverable(ex)
+                    Catch ex As Exception When Common.ReportWithoutCrash(ex, NameOf(DeleteFilesAndDirectories), NameOf(SettingsDesigner))
                         completeSuccess = False
                     End Try
                 Next
@@ -463,7 +461,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 For Each directory As String In directories
                     Try
                         System.IO.Directory.Delete(directory, False)
-                    Catch ex As Exception When Not Common.IsUnrecoverable(ex)
+                    Catch ex As Exception When Common.ReportWithoutCrash(ex, NameOf(DeleteFilesAndDirectories), NameOf(SettingsDesigner))
                         completeSuccess = False
                     End Try
                 Next

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerLoader.vb
@@ -443,7 +443,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                                                           OrElse ex.ErrorCode = NativeMethods.OLECMDERR_E_CANCELED _
                                                           OrElse ex.ErrorCode = NativeMethods.E_FAIL
                                 ' We should ignore if the customer cancels this or we can not build the project...
-                            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to rename symbol", NameOf(SettingsDesignerLoader), ignoreOutOfMemory:=True)
+                            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to rename symbol", NameOf(SettingsDesignerLoader))
                                 DesignerFramework.DesignerMessageBox.Show(_serviceProvider, ex, DesignerFramework.DesignUtil.GetDefaultCaption(_serviceProvider))
                             Finally
                                 SettingsSingleFileGeneratorBase.AllowSymbolRename = False
@@ -526,7 +526,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             Catch ex As System.Configuration.ConfigurationErrorsException
                 ' We failed to load the app config xml document....
                 DesignerFramework.DesignUtil.ReportError(_serviceProvider, SR.GetString(SR.SD_FailedToLoadAppConfigValues), HelpIDs.Err_LoadingAppConfigFile)
-            Catch Ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to load app.config", NameOf(SettingsDesignerLoader), debugFail:=True, considerExceptionAsRecoverable:=True)
+            Catch Ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to load app.config", NameOf(SettingsDesignerLoader))
                 Throw
             End Try
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
@@ -926,7 +926,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
             Try
                 Return DesignerLoader.EnsureCheckedOut()
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(EnsureCheckedOut), NameOf(SettingsDesignerView), debugFail:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(EnsureCheckedOut), NameOf(SettingsDesignerView))
                 Throw
             End Try
         End Function
@@ -939,7 +939,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
             Try
                 Return DesignerLoader.InDesignMode
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(InDesignMode), NameOf(SettingsDesignerView), debugFail:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(InDesignMode), NameOf(SettingsDesignerView))
                 Throw
             End Try
         End Function
@@ -1404,7 +1404,9 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                                 vsLangProj.References.Add(newType.Assembly.GetName().Name)
                             End If
                         End If
-                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to add reference to assembly contining type", NameOf(SettingsDesignerView), debugFail:=Not TypeOf ex Is CheckoutException)
+                    Catch ex As CheckoutException
+                        'Ignore CheckoutException
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to add reference to assembly contining type", NameOf(SettingsDesignerView))
                         ' Well, we mostly tried to be nice to the user and automatically add the reference here... 
                         ' If we fail, the user will see an annoying error about undefined types, but it shouldn't be the
                         ' end of the world...
@@ -1496,7 +1498,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                         suggestedFileName = "Settings"
                     End If
                     ProjectUtils.OpenAndMaybeAddExtendingFile(FullyQualifedClassName, suggestedFileName, Settings.Site, Hierarchy, ProjectItem, CType(VSMDCodeDomProvider.CodeDomProvider, System.CodeDom.Compiler.CodeDomProvider), Me)
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ViewCode), NameOf(SettingsDesignerView), considerExceptionAsRecoverable:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ViewCode), NameOf(SettingsDesignerView))
                     If Settings IsNot Nothing AndAlso Settings.Site IsNot Nothing Then
                         ' We better tell the user that something went wrong (if we still have a settings/settings.site that is)
                         DesignerFramework.DesignerMessageBox.Show(Settings.Site, ex, DesignerFramework.DesignUtil.GetDefaultCaption(Settings.Site))

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
@@ -926,8 +926,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
             Try
                 Return DesignerLoader.EnsureCheckedOut()
-            Catch ex As Exception When Not Common.Utils.IsUnrecoverable(ex)
-                Debug.Fail(String.Format("SettingsDesignerView::EnsureCheckedOut: Caught exception {0}", ex))
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(EnsureCheckedOut), NameOf(SettingsDesignerView), debugFail:=True)
                 Throw
             End Try
         End Function
@@ -940,8 +939,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
             Try
                 Return DesignerLoader.InDesignMode
-            Catch ex As Exception
-                Debug.Fail(String.Format("SettingsDesignerView::InDesignMode: Caught exception {0}", ex))
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(InDesignMode), NameOf(SettingsDesignerView), debugFail:=True)
                 Throw
             End Try
         End Function
@@ -1406,13 +1404,10 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                                 vsLangProj.References.Add(newType.Assembly.GetName().Name)
                             End If
                         End If
-                    Catch ex As Exception
+                    Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to add reference to assembly contining type", NameOf(SettingsDesignerView), debugFail:=Not TypeOf ex Is CheckoutException)
                         ' Well, we mostly tried to be nice to the user and automatically add the reference here... 
                         ' If we fail, the user will see an annoying error about undefined types, but it shouldn't be the
                         ' end of the world...
-                        If Not TypeOf ex Is CheckoutException Then
-                            Debug.Fail("Failed to add reference to assembly contining type " & newTypeName)
-                        End If
                     End Try
                 End If
             End If
@@ -1501,7 +1496,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                         suggestedFileName = "Settings"
                     End If
                     ProjectUtils.OpenAndMaybeAddExtendingFile(FullyQualifedClassName, suggestedFileName, Settings.Site, Hierarchy, ProjectItem, CType(VSMDCodeDomProvider.CodeDomProvider, System.CodeDom.Compiler.CodeDomProvider), Me)
-                Catch ex As Exception
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(ViewCode), NameOf(SettingsDesignerView), considerExceptionAsRecoverable:=True)
                     If Settings IsNot Nothing AndAlso Settings.Site IsNot Nothing Then
                         ' We better tell the user that something went wrong (if we still have a settings/settings.site that is)
                         DesignerFramework.DesignerMessageBox.Show(Settings.Site, ex, DesignerFramework.DesignUtil.GetDefaultCaption(Settings.Site))
@@ -1793,7 +1788,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 Try
                     configDirs = SettingsDesigner.FindUserConfigDirectories(DesignerLoader.VsHierarchy)
                     filesToDelete = SettingsDesigner.FindUserConfigFiles(configDirs)
-                Catch ex As Exception When Not Common.IsUnrecoverable(ex)
+                Catch ex As Exception When Common.ReportWithoutCrash(ex, NameOf(MenuSynchronizeUserConfig), NameOf(SettingsDesignerView))
                 End Try
 
                 If filesToDelete Is Nothing OrElse filesToDelete.Count = 0 Then

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSerializer.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSerializer.vb
@@ -161,7 +161,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 If mungeClassNameAttribute IsNot Nothing Then
                     Try
                         Settings.UseSpecialClassName = XmlConvert.ToBoolean(mungeClassNameAttribute.Value)
-                    Catch ex As Exception When Not Common.IsUnrecoverable(ex)
+                    Catch ex As Exception When Common.ReportWithoutCrash(ex, NameOf(Deserialize), NameOf(SettingsSerializer))
                         Settings.UseSpecialClassName = False
                     End Try
                 End If

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
@@ -832,9 +832,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                         Marshal.Release(punkVsBrowseObject)
                     End If
                 End Try
-            Catch ex As Exception
-                Debug.WriteLine(ex.ToString())
-                Debug.Fail("Why did we fail to get the DefaultNamespace?" & Microsoft.VisualBasic.vbCrLf & ex.ToString())
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to get the DefaultNamespace", NameOf(SettingsSingleFileGenerator), debugFail:=True, considerExceptionAsRecoverable:=True)
             End Try
 
             Return rootNamespace

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
@@ -832,7 +832,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                         Marshal.Release(punkVsBrowseObject)
                     End If
                 End Try
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to get the DefaultNamespace", NameOf(SettingsSingleFileGenerator), debugFail:=True, considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to get the DefaultNamespace", NameOf(SettingsSingleFileGenerator))
             End Try
 
             Return rootNamespace

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsValueSerializer.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsValueSerializer.vb
@@ -81,7 +81,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             Dim serializedValue As String = Nothing
             Try
                 serializedValue = SerializeImpl(value, culture)
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to serialize value", NameOf(SettingsValueSerializer), debugFail:=True, considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to serialize value", NameOf(SettingsValueSerializer))
             End Try
 
             ' Make sure we always return a valid string...

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsValueSerializer.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsValueSerializer.vb
@@ -81,10 +81,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             Dim serializedValue As String = Nothing
             Try
                 serializedValue = SerializeImpl(value, culture)
-            Catch ex As Exception
-#If DEBUG Then
-                System.Diagnostics.Debug.Fail(String.Format("Failed to serialize value: {0}", ex))
-#End If
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to serialize value", NameOf(SettingsValueSerializer), debugFail:=True, considerExceptionAsRecoverable:=True)
             End Try
 
             ' Make sure we always return a valid string...

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypeEditorHostControl.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypeEditorHostControl.vb
@@ -345,7 +345,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                         Try
                             existingValue = System.Activator.CreateInstance(ValueType)
                             passedNewInstanceToEditor = True
-                        Catch ex As Exception When Not Common.IsUnrecoverable(ex)
+                        Catch ex As Exception When Common.ReportWithoutCrash(ex, NameOf(ShowUITypeEditor), NameOf(TypeEditorHostControl))
                         End Try
                     End If
                     Dim editedValue As Object = _typeEditor.EditValue(Context, Me, existingValue)

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypePickerDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypePickerDialog.vb
@@ -351,10 +351,9 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 ' Let's report the error and keep the dialog open!
                 ReportError(SR.GetString(SR.SD_ERR_InvalidTypeName_1Arg, TypeName))
                 Return False
-            Catch ex As Exception
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, $"Unexpected exception caught when resolving type {TypeName}", NameOf(TypePickerDialog), debugFail:=True, considerExceptionAsRecoverable:=True)
                 ' We don't know what happened here - let's assume that the type name was bad...
                 ' Let's report the error and keep the dialog open!
-                Debug.Fail(String.Format("Unexpected {0} caught when resolving type {1}: {2}", ex.GetType().Name, TypeName, ex))
                 ReportError(SR.GetString(SR.SD_ERR_InvalidTypeName_1Arg, TypeName))
                 Return False
             End Try

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypePickerDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypePickerDialog.vb
@@ -351,7 +351,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 ' Let's report the error and keep the dialog open!
                 ReportError(SR.GetString(SR.SD_ERR_InvalidTypeName_1Arg, TypeName))
                 Return False
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, $"Unexpected exception caught when resolving type {TypeName}", NameOf(TypePickerDialog), debugFail:=True, considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, $"Unexpected exception caught when resolving type {TypeName}", NameOf(TypePickerDialog))
                 ' We don't know what happened here - let's assume that the type name was bad...
                 ' Let's report the error and keep the dialog open!
                 ReportError(SR.GetString(SR.SD_ERR_InvalidTypeName_1Arg, TypeName))

--- a/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
@@ -773,7 +773,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
                         Try
                             Dim attrs As __VSRDTATTRIB = CType(System.Enum.ToObject(GetType(__VSRDTATTRIB), attributes), __VSRDTATTRIB)
                             Debug.WriteLine("SettingsGlobalObjectProvider.OnAfterAttributeChange(" & attrs.ToString("G") & ")...")
-                        Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(OnAfterAttributeChange), NameOf(SettingsGlobalObjectProvider), debugFail:=True, considerExceptionAsRecoverable:=True)
+                        Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(OnAfterAttributeChange), NameOf(SettingsGlobalObjectProvider))
                         End Try
                     End If
 #End If
@@ -807,7 +807,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
                         Try
                             Dim flags As _VSRDTFLAGS = CType(System.Enum.ToObject(GetType(_VSRDTFLAGS), lockType), _VSRDTFLAGS)
                             Debug.WriteLine("SettingsGlobalObjectProvider.OnAfterFirstDocumentLock(" & flags.ToString("G") & ")...")
-                        Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(OnAfterFirstDocumentLock), NameOf(SettingsGlobalObjectProvider), debugFail:=True, considerExceptionAsRecoverable:=True)
+                        Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(OnAfterFirstDocumentLock), NameOf(SettingsGlobalObjectProvider))
                         End Try
                     End If
 #End If
@@ -845,7 +845,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
                         Try
                             Dim flags As _VSRDTFLAGS = CType(System.Enum.ToObject(GetType(_VSRDTFLAGS), lockType), _VSRDTFLAGS)
                             Debug.WriteLine("SettingsGlobalObjectProvider.OnBeforeLastDocumentUnlock(" & flags.ToString("G") & ")...")
-                        Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(OnBeforeLastDocumentUnlock), NameOf(SettingsGlobalObjectProvider), debugFail:=True, considerExceptionAsRecoverable:=True)
+                        Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(OnBeforeLastDocumentUnlock), NameOf(SettingsGlobalObjectProvider))
                         End Try
                     End If
 #End If
@@ -1134,7 +1134,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
                     If (projItem IsNot Nothing) Then
                         OnProjectItemAdded(projItem)
                     End If
-                Catch Ex As Exception When Common.Utils.ReportWithoutCrash(Ex, "Caught exception while trying to map added/removed files to project items", NameOf(SettingsGlobalObjectProvider), debugFail:=True)
+                Catch Ex As Exception When Common.Utils.ReportWithoutCrash(Ex, "Caught exception while trying to map added/removed files to project items", NameOf(SettingsGlobalObjectProvider))
                     ' Dunno what kind of exceptions ParseCanonicalName or GetProperty may throw....
                 End Try
             End If
@@ -1457,7 +1457,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             Catch argEx As System.ArgumentException
                 ' venus throws this since they don't support the CustomTool property, and all we
                 '   can do is catch it and ignore it
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(EnsureGeneratingSettingClass), NameOf(SettingsGlobalObjectProvider), debugFail:=True, considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(EnsureGeneratingSettingClass), NameOf(SettingsGlobalObjectProvider))
                 ' we don't expect to fail randomly, but we also don't really want to propagate
                 '   failures from project systems we don't know about out to the user through
                 '   the global-object-service since users won't really know that we're setting
@@ -1578,7 +1578,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
 #If DEBUG Then
                     Debug.WriteLineIf(SettingsGlobalObjectProvider.GlobalSettings.TraceVerbose, "SettingsFileGlobalObject.LoadSettings(" & CStr(_className) & ") -- editLocks=" & editLocks & ", readLocks=" & readLocks & "...")
 #End If
-                Catch Ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to get document info for document", NameOf(SettingsGlobalObjectProvider), debugFail:=True, considerExceptionAsRecoverable:=True)
+                Catch Ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to get document info for document", NameOf(SettingsGlobalObjectProvider))
                     Throw
                 End Try
 
@@ -1857,7 +1857,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
                             If vsProjItem IsNot Nothing Then
                                 Try
                                     vsProjItem.RunCustomTool()
-                                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to run custom tool", NameOf(SettingsGlobalObjectProvider), debugFail:=True)
+                                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to run custom tool", NameOf(SettingsGlobalObjectProvider))
                                 End Try
                             End If
                         End If

--- a/src/Microsoft.VisualStudio.Editors/package/EditorToolsOptionsPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/package/EditorToolsOptionsPage.vb
@@ -113,8 +113,7 @@ Namespace Microsoft.VisualStudio.Editors.Package
                 _dialog.LineNumbers = CBool(textEditorProperties.Item(s_showLineNumbersItem).Value)
 
                 _dialog.Enabled = True
-            Catch ex As Exception
-                Debug.Fail("EditorToolsOptionPage::LoadSettings Caught exception " & ex.Message & " " & ex.StackTrace)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(LoadSettings), NameOf(EditorToolsOptionsPage), debugFail:=True, considerExceptionAsRecoverable:=True)
                 _dialog.Enabled = False
             Finally
                 fontsAndColorsProperties = Nothing
@@ -153,8 +152,7 @@ Namespace Microsoft.VisualStudio.Editors.Package
                 prefs.uTabSize = CUInt(_dialog.TabSize)
                 prefs.fWordWrap = CUInt(_dialog.WordWrap)
                 Apply(prefs)
-            Catch ex As Exception
-                Debug.Fail("EditorToolsOptionPage::SaveSettings Caught exception " & ex.Message)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(SaveSettings), NameOf(EditorToolsOptionsPage), debugFail:=True, considerExceptionAsRecoverable:=True)
             End Try
             textEditorProperties = Nothing
             dte = Nothing

--- a/src/Microsoft.VisualStudio.Editors/package/EditorToolsOptionsPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/package/EditorToolsOptionsPage.vb
@@ -113,7 +113,7 @@ Namespace Microsoft.VisualStudio.Editors.Package
                 _dialog.LineNumbers = CBool(textEditorProperties.Item(s_showLineNumbersItem).Value)
 
                 _dialog.Enabled = True
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(LoadSettings), NameOf(EditorToolsOptionsPage), debugFail:=True, considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(LoadSettings), NameOf(EditorToolsOptionsPage))
                 _dialog.Enabled = False
             Finally
                 fontsAndColorsProperties = Nothing
@@ -152,7 +152,7 @@ Namespace Microsoft.VisualStudio.Editors.Package
                 prefs.uTabSize = CUInt(_dialog.TabSize)
                 prefs.fWordWrap = CUInt(_dialog.WordWrap)
                 Apply(prefs)
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(SaveSettings), NameOf(EditorToolsOptionsPage), debugFail:=True, considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(SaveSettings), NameOf(EditorToolsOptionsPage))
             End Try
             textEditorProperties = Nothing
             dte = Nothing

--- a/src/Microsoft.VisualStudio.Editors/package/VBPackage.vb
+++ b/src/Microsoft.VisualStudio.Editors/package/VBPackage.vb
@@ -65,22 +65,22 @@ Namespace Microsoft.VisualStudio.Editors
             'Register editor factories
             Try
                 MyBase.RegisterEditorFactory(New SettingsDesigner.SettingsDesignerEditorFactory)
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception registering settings designer editor factory", NameOf(VBPackage), debugFail:=True, considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception registering settings designer editor factory", NameOf(VBPackage))
                 Throw
             End Try
             Try
                 MyBase.RegisterEditorFactory(New ResourceEditor.ResourceEditorFactory)
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception registering resource editor factory", NameOf(VBPackage), debugFail:=True, considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception registering resource editor factory", NameOf(VBPackage))
                 Throw
             End Try
             Try
                 MyBase.RegisterEditorFactory(New Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerEditorFactory)
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception registering application resource editor factory", NameOf(VBPackage), debugFail:=True, considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception registering application resource editor factory", NameOf(VBPackage))
                 Throw
             End Try
             Try
                 MyBase.RegisterEditorFactory(New PropPageDesigner.PropPageDesignerEditorFactory)
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception registering property page designer editor factory", NameOf(VBPackage), debugFail:=True, considerExceptionAsRecoverable:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception registering property page designer editor factory", NameOf(VBPackage))
                 Throw
             End Try
 
@@ -254,7 +254,7 @@ Namespace Microsoft.VisualStudio.Editors
                         End If
                         _lastViewedProjectDesignerTab(projGuid) = tab
                     End While
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to read settings", NameOf(VBPackage), debugFail:=True)
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to read settings", NameOf(VBPackage))
                 End Try
             Else
                 MyBase.OnLoadOptions(key, stream)
@@ -309,7 +309,7 @@ Namespace Microsoft.VisualStudio.Editors
                 If hierarchy IsNot Nothing Then
                     VSErrorHandler.ThrowOnFailure(hierarchy.GetGuidProperty(VSITEMID.ROOT, __VSHPROPID.VSHPROPID_ProjectIDGuid, projGuid))
                 End If
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to get project guid", NameOf(VBPackage), debugFail:=True)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to get project guid", NameOf(VBPackage))
                 ' This is a non-vital function - ignore if we fail to get the GUID...
             End Try
             Return projGuid
@@ -452,7 +452,7 @@ Namespace Microsoft.VisualStudio.Editors
                             End If
                         Loop
                     End If
-                Catch ex As Exception When Common.ReportWithoutCrash(ex, "Failed when trying to clean up user.config files", NameOf(VBPackage), debugFail:=True)
+                Catch ex As Exception When Common.ReportWithoutCrash(ex, "Failed when trying to clean up user.config files", NameOf(VBPackage))
                 End Try
                 Return Editors.Interop.NativeMethods.S_OK
             End Function

--- a/src/Microsoft.VisualStudio.Editors/package/VBPackage.vb
+++ b/src/Microsoft.VisualStudio.Editors/package/VBPackage.vb
@@ -65,26 +65,22 @@ Namespace Microsoft.VisualStudio.Editors
             'Register editor factories
             Try
                 MyBase.RegisterEditorFactory(New SettingsDesigner.SettingsDesignerEditorFactory)
-            Catch ex As Exception
-                Debug.Fail("Exception registering settings designer editor factory: " & ex.ToString())
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception registering settings designer editor factory", NameOf(VBPackage), debugFail:=True, considerExceptionAsRecoverable:=True)
                 Throw
             End Try
             Try
                 MyBase.RegisterEditorFactory(New ResourceEditor.ResourceEditorFactory)
-            Catch ex As Exception
-                Debug.Fail("Exception registering registry editor editor factory: " & ex.ToString())
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception registering resource editor factory", NameOf(VBPackage), debugFail:=True, considerExceptionAsRecoverable:=True)
                 Throw
             End Try
             Try
                 MyBase.RegisterEditorFactory(New Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerEditorFactory)
-            Catch ex As Exception
-                Debug.Fail("Exception registering application designer editor factory: " & ex.ToString())
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception registering application resource editor factory", NameOf(VBPackage), debugFail:=True, considerExceptionAsRecoverable:=True)
                 Throw
             End Try
             Try
                 MyBase.RegisterEditorFactory(New PropPageDesigner.PropPageDesignerEditorFactory)
-            Catch ex As Exception
-                Debug.Fail("Exception registering property page designer editor factory: " & ex.ToString())
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Exception registering property page designer editor factory", NameOf(VBPackage), debugFail:=True, considerExceptionAsRecoverable:=True)
                 Throw
             End Try
 
@@ -258,8 +254,7 @@ Namespace Microsoft.VisualStudio.Editors
                         End If
                         _lastViewedProjectDesignerTab(projGuid) = tab
                     End While
-                Catch ex As Exception When Not Common.Utils.IsUnrecoverable(ex)
-                    Debug.Fail(String.Format("Failed to read settings: {0}", ex))
+                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to read settings", NameOf(VBPackage), debugFail:=True)
                 End Try
             Else
                 MyBase.OnLoadOptions(key, stream)
@@ -314,9 +309,8 @@ Namespace Microsoft.VisualStudio.Editors
                 If hierarchy IsNot Nothing Then
                     VSErrorHandler.ThrowOnFailure(hierarchy.GetGuidProperty(VSITEMID.ROOT, __VSHPROPID.VSHPROPID_ProjectIDGuid, projGuid))
                 End If
-            Catch ex As Exception When Not Common.Utils.IsUnrecoverable(ex)
+            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed to get project guid", NameOf(VBPackage), debugFail:=True)
                 ' This is a non-vital function - ignore if we fail to get the GUID...
-                Debug.Fail(String.Format("Failed to get project guid: {0}", ex))
             End Try
             Return projGuid
         End Function
@@ -458,10 +452,7 @@ Namespace Microsoft.VisualStudio.Editors
                             End If
                         Loop
                     End If
-                Catch ex As Exception When Not Common.IsUnrecoverable(ex)
-#If DEBUG Then
-                    Debug.Fail(String.Format("Failed when trying to clean up user.config files... {0}", ex))
-#End If
+                Catch ex As Exception When Common.ReportWithoutCrash(ex, "Failed when trying to clean up user.config files", NameOf(VBPackage), debugFail:=True)
                 End Try
                 Return Editors.Interop.NativeMethods.S_OK
             End Function

--- a/src/ProjectSystem.sln
+++ b/src/ProjectSystem.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.25413.0
+VisualStudioVersion = 15.0.25402.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeployTestDependencies", "DeployTestDependencies\DeployTestDependencies.csproj", "{37BA82E6-9ABD-4ACA-AA26-2DFD39A359A5}"
 EndProject

--- a/src/ProjectSystem.sln
+++ b/src/ProjectSystem.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.25402.0
+VisualStudioVersion = 15.0.25413.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeployTestDependencies", "DeployTestDependencies\DeployTestDependencies.csproj", "{37BA82E6-9ABD-4ACA-AA26-2DFD39A359A5}"
 EndProject


### PR DESCRIPTION
…udio.Editors

**Logging Infrastructure:** We are using the VS Telemetry APIs to log actionable exceptions, this is the recommended approach across DevDiv for Dev15.

**Added API:** Added a utility API "ReportWithoutCrash" that given an exception, logs telemetry for the exception with context (name of the throwing component and additional context message) and returns whether or not the exception is recoverable. API has optional flags to trigger Debug.Fail or treat given exception as always recoverable (catch all filter).

**Code changes in the project to consume this API:** API is always invoked in the exception filter for catch clauses. Cases where this API invocation was added:

1. Debug.Fail within catch clause: We surely care about telemetry for these cases.
2. Existing invocations of Utils.IsUnrecoverableException in catch filters where telemetry might help fix/cleanup code: Used my best judgement on whether telemetry data is helpful, erring on conservative side of more data when I was unsure.
3. [WIP] Silently swallowing System.Exception without re-throwing. It is recommended to catch specific exception kinds for scenarios where we know an operation might throw. However, there are tons of such occurrences across the project, and it is not clear if we going to clean up all of them. I have changed few places to add invocations to ReportWithoutCrash, but fixing over the entire project would need someone familiar with the code to do an audit.

**Related issue:** https://github.com/dotnet/roslyn-project-system/issues/41