### PR TITLE
Prevent TraceSource package from injecting reference

### DIFF
--- a/src/Dependencies/VisualStudio/project.json
+++ b/src/Dependencies/VisualStudio/project.json
@@ -25,7 +25,10 @@
     "Microsoft.VisualStudio.ImageCatalog": "15.0.25123-Dev15Preview",
     "Microsoft.VisualStudio.Shell.Design": "15.0.25123-Dev15Preview",
     "Microsoft.VisualStudio.Shell.15.0": "15.0.25123-Dev15Preview",
-    "Microsoft.VisualStudio.Telemetry": "15.0.691-master31907920"
+    "Microsoft.VisualStudio.Telemetry": {
+		"version": "15.0.691-master31907920",
+		"exclude": "build"
+	}
   },
   "frameworks": {
     ".NETFramework,Version=v4.6": { }


### PR DESCRIPTION
Fixes #276

TraceSource package injects a reference into the build, which conflicts with the reference that the NuGet build task injects, this causes the NuGet build task to remove the reference, causing VS to fail to resolve the reference and complain.

Prevent Telemetry and hence TraceSource from injecting build targets.