### PR TITLE
Fix the output type enum values for class libraries

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
@@ -813,7 +813,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     Return ProjectProperties.OutputType
                 Else
                     Dim obj As Object = TryGetNonCommonPropertyValue(GetPropertyDescriptor("OutputType"))
-                    Return CType(obj, VSLangProj.prjOutputType)
+                    Try
+                        Return CType(obj, VSLangProj.prjOutputType)
+                    Catch ex As Exception
+                        Return 0
+                    End Try
                 End If
             End Get
         End Property

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
@@ -252,7 +252,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
             If Not PropertyControlData.IsSpecialValue(value) Then
 
-                Dim uIntValue As UInteger = CUInt(value)
+                Dim uIntValue As UInteger = 0
+                Try
+                    uIntValue = CUInt(value)
+                Catch ex As Exception
+                End Try
+
                 didSelectItem = SelectItemInOutputTypeComboBox(Me.OutputType, uIntValue)
 
                 If didSelectItem Then
@@ -632,7 +637,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 PopulateStartupObject(True, False)
             Else
                 '(Okay to use OutputTypeControlData.InitialValue because we checked IsMissing above)
-                Me.PopulateControlSet(CUInt(OutputTypeControlData.InitialValue))
+                Dim outputType As UInteger = 0
+                Try
+                    outputType = CUInt(OutputTypeControlData.InitialValue)
+                Catch ex As Exception
+                End Try
+                Me.PopulateControlSet(outputType)
                 Me.EnableControlSet()
                 Return True
             End If

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/OutputTypeEnumProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/OutputTypeEnumProviderTests.cs
@@ -29,11 +29,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         }
 
         [Theory]
-        [InlineData("dll", "0")]
+        [InlineData("winexe", "0")]
         [InlineData("exe", "1")]
-        [InlineData("winexe", "2")]
-        [InlineData("winmdobj", "0")]
+        [InlineData("library", "2")]
         [InlineData("appcontainerexe", "1")]
+        [InlineData("winmdobj", "2")]
         public async Task TryCreateEnumValue(string input, string expected)
         {
             var provider = new OutputTypeEnumProvider();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/OutputTypeEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/OutputTypeEnumProvider.cs
@@ -26,15 +26,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         {
             private readonly Dictionary<string, IEnumValue> _listedOutputTypeValues = new Dictionary<string, IEnumValue>
             {
-                { "dll",             new PageEnumValue(new EnumValue {Name = "dll",    DisplayName = "0" }) },
-                { "exe",             new PageEnumValue(new EnumValue {Name = "exe",    DisplayName = "1" }) },
-                { "winexe",          new PageEnumValue(new EnumValue {Name = "winexe", DisplayName = "2" }) }
+                { "winexe",          new PageEnumValue(new EnumValue {Name = "winexe",  DisplayName = "0" }) },
+                { "exe",             new PageEnumValue(new EnumValue {Name = "exe",     DisplayName = "1" }) },
+                { "library",         new PageEnumValue(new EnumValue {Name = "library", DisplayName = "2" }) },
             };
 
             private readonly Dictionary<string, IEnumValue> _mappedOutputTypeValues = new Dictionary<string, IEnumValue>
             {
-                { "winmdobj",        new PageEnumValue(new EnumValue {Name = "dll",    DisplayName = "0" }) },
-                { "appcontainerexe", new PageEnumValue(new EnumValue {Name = "exe",    DisplayName = "1" }) }
+                { "winmdobj",        new PageEnumValue(new EnumValue {Name = "library", DisplayName = "2" }) },
+                { "appcontainerexe", new PageEnumValue(new EnumValue {Name = "exe",     DisplayName = "1" }) }
             };
 
             public bool AllowCustomValues => false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -34,11 +34,11 @@
   <StringProperty Name="OutputName" Visible="False" />
   <DynamicEnumProperty Name="OutputType" DisplayName="Output Type" EnumProvider="OutputTypeEnumProvider" />
   <EnumProperty Name="OutputTypeEx" DisplayName="Output Type">
-    <EnumValue Name="dll" DisplayName="0" />
+    <EnumValue Name="winexe" DisplayName="0" />
     <EnumValue Name="exe" DisplayName="1" />
-    <EnumValue Name="winexe" DisplayName="2" />
-    <EnumValue Name="winmdobj" DisplayName="3" />
-    <EnumValue Name="appcontainerexe" DisplayName="4" />
+    <EnumValue Name="library" DisplayName="2" />
+    <EnumValue Name="appcontainerexe" DisplayName="3" />
+    <EnumValue Name="winmdobj" DisplayName="4" />
     <EnumProperty.DataSource>
       <DataSource Persistence="ProjectFile" PersistedName="OutputType" />
     </EnumProperty.DataSource>

--- a/src/ProjectSystem.sln
+++ b/src/ProjectSystem.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.25402.0
+VisualStudioVersion = 15.0.25302.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeployTestDependencies", "DeployTestDependencies\DeployTestDependencies.csproj", "{37BA82E6-9ABD-4ACA-AA26-2DFD39A359A5}"
 EndProject
@@ -34,6 +34,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests", "Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests\Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests.csproj", "{2F58FC7F-85D9-427A-84F0-A6AA741E5BBA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectSystemSetup", "ProjectSystemSetup\ProjectSystemSetup.csproj", "{9FBD7EF2-9449-486D-9FDD-FA56160AA8BB}"
+	ProjectSection(ProjectDependencies) = postProject
+		{49705330-A4F5-47EA-BB10-3B783CE91AEA} = {49705330-A4F5-47EA-BB10-3B783CE91AEA}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualStudioEditorsSetup", "VisualStudioEditorsSetup\VisualStudioEditorsSetup.csproj", "{49705330-A4F5-47EA-BB10-3B783CE91AEA}"
 EndProject
@@ -146,6 +149,10 @@ Global
 		{9FBD7EF2-9449-486D-9FDD-FA56160AA8BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9FBD7EF2-9449-486D-9FDD-FA56160AA8BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9FBD7EF2-9449-486D-9FDD-FA56160AA8BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{49705330-A4F5-47EA-BB10-3B783CE91AEA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{49705330-A4F5-47EA-BB10-3B783CE91AEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{49705330-A4F5-47EA-BB10-3B783CE91AEA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{49705330-A4F5-47EA-BB10-3B783CE91AEA}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A57DDFE5-AB0E-4371-98E5-11B9218DF11C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A57DDFE5-AB0E-4371-98E5-11B9218DF11C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A57DDFE5-AB0E-4371-98E5-11B9218DF11C}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -190,10 +197,6 @@ Global
 		{369DCA0F-A079-4D0C-8B32-53879199B681}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{369DCA0F-A079-4D0C-8B32-53879199B681}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{369DCA0F-A079-4D0C-8B32-53879199B681}.Release|Any CPU.Build.0 = Release|Any CPU
-		{49705330-A4F5-47EA-BB10-3B783CE91AEA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{49705330-A4F5-47EA-BB10-3B783CE91AEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{49705330-A4F5-47EA-BB10-3B783CE91AEA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{49705330-A4F5-47EA-BB10-3B783CE91AEA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The output type value for class libraries is "Library" and not "dll" as the CPS XAML files defines it. Also I had the enum values wrong which caused the wrong values to get selected in the OutputType combobox of the app property page.

@dotnet/project-system 