### PR TITLE
Fixes a class cast issue that was causing CTRL+F5 to not work. Addresses #279.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/ManagedDebuggerImageTypeServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/ManagedDebuggerImageTypeServiceTests.cs
@@ -4,6 +4,8 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Imaging;
 using Xunit;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.Build.Framework.XamlTypes;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
@@ -98,10 +100,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
         private ManagedDebuggerImageTypeService CreateInstance(string outputType)
         {
+            var outputTypeEnum = new PageEnumValue(new EnumValue() { Name = outputType });
+
             var data = new PropertyPageData() {
                 Category = ConfigurationGeneral.SchemaName,
                 PropertyName = ConfigurationGeneral.OutputTypeProperty,
-                Value = outputType
+                Value = outputTypeEnum
             };
 
             var project = IUnconfiguredProjectFactory.Create();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ManagedDebuggerImageTypeService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ManagedDebuggerImageTypeService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.VisualStudio.ProjectSystem.Properties;
 using System;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
@@ -35,10 +36,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var configuration = await _properties.GetConfigurationGeneralPropertiesAsync()
                                                  .ConfigureAwait(false);
 
-            string outputType = (string)await configuration.OutputType.GetValueAsync()
+
+            PageEnumValue outputType = (PageEnumValue)await configuration.OutputType.GetValueAsync()
                                                                       .ConfigureAwait(false);
 
-            return StringComparers.PropertyValues.Equals(outputType, ConfigurationGeneral.OutputTypeValues.exe);
+            return StringComparers.PropertyValues.Equals(outputType.Name, ConfigurationGeneral.OutputTypeValues.exe);
         }
 
         

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ManagedDebuggerImageTypeService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ManagedDebuggerImageTypeService.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                                                  .ConfigureAwait(false);
 
 
-            PageEnumValue outputType = (PageEnumValue)await configuration.OutputType.GetValueAsync()
+            IEnumValue outputType = (IEnumValue)await configuration.OutputType.GetValueAsync()
                                                                       .ConfigureAwait(false);
 
             return StringComparers.PropertyValues.Equals(outputType.Name, ConfigurationGeneral.OutputTypeValues.exe);


### PR DESCRIPTION
Fixes a small class-cast issue with the debug run. This fixes #279.