### PR TITLE
Update design time targets

### DIFF
--- a/src/Targets/Microsoft.CSharp.DesignTime.targets
+++ b/src/Targets/Microsoft.CSharp.DesignTime.targets
@@ -12,7 +12,7 @@
     <AppDesignerFolderContentsVisibleOnlyInShowAllFiles Condition="'$(AppDesignerFolderContentsVisibleOnlyInShowAllFiles)' == ''">false</AppDesignerFolderContentsVisibleOnlyInShowAllFiles>
 
     <!-- See: https://github.com/dotnet/roslyn-project-system/issues/201 -->
-    <CustomCommonXamlResourcesDirectory Condition="$(CustomCommonXamlResourcesDirectory) == ''">$(CommonXamlResourcesDirectory)</CustomCommonXamlResourcesDirectory>
+    <CustomCommonXamlResourcesDirectory Condition="$(CustomCommonXamlResourcesDirectory) == ''">$(MSBuildThisFileDirectory)</CustomCommonXamlResourcesDirectory>
   </PropertyGroup>
 
   <!-- Project Capabilities -->

--- a/src/Targets/Microsoft.VisualBasic.DesignTime.targets
+++ b/src/Targets/Microsoft.VisualBasic.DesignTime.targets
@@ -12,7 +12,7 @@
     <AppDesignerFolderContentsVisibleOnlyInShowAllFiles Condition="'$(AppDesignerFolderContentsVisibleOnlyInShowAllFiles)' == ''">true</AppDesignerFolderContentsVisibleOnlyInShowAllFiles>
     
     <!-- See: https://github.com/dotnet/roslyn-project-system/issues/201 -->
-    <CustomCommonXamlResourcesDirectory Condition="$(CustomCommonXamlResourcesDirectory) == ''">$(CommonXamlResourcesDirectory)</CustomCommonXamlResourcesDirectory>
+    <CustomCommonXamlResourcesDirectory Condition="$(CustomCommonXamlResourcesDirectory) == ''">$(MSBuildThisFileDirectory)</CustomCommonXamlResourcesDirectory>
   </PropertyGroup>
 
   <!-- Project Capabilities -->


### PR DESCRIPTION
Update design time targets to look in the current folder for XAML files by default.

Using this approach to unblock us for next preview. Later we need to move the XAML files into language specific folders to support localization (#128)

@dotnet/project-system 