### PR TITLE
Add ApplicationManifest property to the application page

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="ProjectSystem\AppDesignerFolderProjectTreePropertiesProviderTests.cs" />
     <Compile Include="ProjectSystem\Debug\ManagedDebuggerImageTypeServiceTests.cs" />
     <Compile Include="ProjectSystem\Imaging\ProjectImageProviderAggregatorTests.cs" />
+    <Compile Include="ProjectSystem\Properties\ApplicationManifestValueProviderTests.cs" />
     <Compile Include="ProjectSystem\Properties\ImplicitProjectPropertiesProviderTests.cs" />
     <Compile Include="ProjectSystem\ProjectRootImageProjectTreeModifierTests.cs" />
     <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\InterceptedProjectPropertiesProviderTests.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectPropertiesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectPropertiesFactory.cs
@@ -26,14 +26,22 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return mock;
         }
 
-        public static Mock<IProjectProperties> MockWithPropertyAndSet(string propertyName, string setValue)
+        public static Mock<IProjectProperties> MockWithPropertyAndValue(string propertyName, string setValue)
         {
-            return MockWithPropertiesAndSet(new Dictionary<string, string>() { { propertyName, setValue } });
+            return MockWithPropertiesAndValues(new Dictionary<string, string>() { { propertyName, setValue } });
         }
-
-        public static Mock<IProjectProperties> MockWithPropertiesAndSet(Dictionary<string, string> propertyNameAndValues)
+        
+        public static Mock<IProjectProperties> MockWithPropertiesAndValues(Dictionary<string, string> propertyNameAndValues)
         {
             var mock = MockWithProperties(propertyNameAndValues.Keys);
+
+            mock.Setup(t => t.GetEvaluatedPropertyValueAsync(
+                It.IsIn<string>(propertyNameAndValues.Keys)))
+                 .Returns<string>(k => Task.FromResult(propertyNameAndValues[k]));
+
+            mock.Setup(t => t.GetUnevaluatedPropertyValueAsync(
+                It.IsIn<string>(propertyNameAndValues.Keys)))
+                 .Returns<string>(k => Task.FromResult(propertyNameAndValues[k]));
 
             mock.Setup(t => t.SetPropertyValueAsync(
                 It.IsIn<string>(propertyNameAndValues.Keys),
@@ -44,28 +52,25 @@ namespace Microsoft.VisualStudio.ProjectSystem
                         propertyNameAndValues[k] = v;
                     }));
 
-            return mock;
-        }
-
-        public static Mock<IProjectProperties> MockWithPropertiesAndGetSet(Dictionary<string, string> propertyNameAndValues)
-        {
-            var mock = MockWithPropertiesAndSet(propertyNameAndValues);
-
-            mock.Setup(t => t.GetEvaluatedPropertyValueAsync(
-                It.IsIn<string>(propertyNameAndValues.Keys)))
-                 .Returns<string>(k => Task.FromResult(propertyNameAndValues[k]));
-
-            mock.Setup(t => t.GetUnevaluatedPropertyValueAsync(
-                It.IsIn<string>(propertyNameAndValues.Keys)))
-                 .Returns<string>(k => Task.FromResult(propertyNameAndValues[k]));
+            mock.Setup(t => t.DeletePropertyAsync(
+                It.IsIn<string>(propertyNameAndValues.Keys),
+                null))
+                 .Returns<string, IReadOnlyDictionary<string, string>>((propName, d) =>
+                    Task.Run(() =>
+                    {
+                        propertyNameAndValues[propName] = null;
+                    }));
 
             return mock;
         }
 
         public static IProjectProperties CreateWithProperty(string propertyName)
             => MockWithProperty(propertyName).Object;
+        
+        public static IProjectProperties CreateWithPropertyAndValue(string propertyName, string setValue)
+            => MockWithPropertyAndValue(propertyName, setValue).Object;
 
-        public static IProjectProperties CreateWithPropertyAndSet(string propertyName, string setValue)
-            => MockWithPropertyAndSet(propertyName, setValue).Object;
+        public static IProjectProperties CreateWithPropertiesAndValues(Dictionary<string, string> propertyNameAndValues)
+            => MockWithPropertiesAndValues(propertyNameAndValues).Object;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectPropertiesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectPropertiesFactory.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             return MockWithPropertiesAndValues(new Dictionary<string, string>() { { propertyName, setValue } });
         }
-        
+
         public static Mock<IProjectProperties> MockWithPropertiesAndValues(Dictionary<string, string> propertyNameAndValues)
         {
             var mock = MockWithProperties(propertyNameAndValues.Keys);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/ApplicationManifestValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/ApplicationManifestValueProviderTests.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    [ProjectSystemTrait]
+    public class ApplicationManifestValueProviderTests
+    {
+        [Theory]
+        [InlineData(@"C:\somepath", "true", @"C:\somepath")]
+        [InlineData(@"Invalidpath/\/", "true", @"Invalidpath/\/")]
+        [InlineData("", "true", "NoManifest")]
+        [InlineData("", "TRue", "NoManifest")]
+        [InlineData("", "false", "DefaultManifest")]
+        [InlineData("", null, "DefaultManifest")]
+        public async Task GetApplicationManifest(string appManifestPropValue, string noManifestValue, string expectedValue)
+        {
+            var provider = new ApplicationManifestValueProvider(IUnconfiguredProjectFactory.Create(), IProjectTreeServiceFactory.Create());
+            var defaultProperties = IProjectPropertiesFactory.CreateWithPropertyAndValue("NoWin32Manifest", noManifestValue);
+
+            var appManifestValue = await provider.OnGetEvaluatedPropertyValueAsync(appManifestPropValue, defaultProperties);
+            Assert.Equal(expectedValue, appManifestValue);
+        }
+
+
+        [Theory]
+        [InlineData(@"inp.man", "true", @"out.man", @"out.man", null)]
+        [InlineData(@"C:\projectdir\foo.man", "true", @"C:\projectdir\bar.man", @"bar.man", null)]
+        [InlineData(@"C:\projectdir\foo.man", "true", @" a asd ", @" a asd ", null)]
+        [InlineData(@"C:\projectdir\foo.man", null, @"NoManifest", null, "true")]
+        [InlineData(@"C:\projectdir\foo.man", null, @"nomANifest", null, "true")]
+        [InlineData(@"C:\projectdir\foo.man", null, @"DefaultManifest", null, null)]
+        [InlineData(@"C:\projectdir\foo.man", null, "", null, null)]
+        [InlineData(@"C:\projectdir\foo.man", null, null, null, null)]
+        public async Task SetApplicationManifest(string appManifestPropValue, string noManifestPropValue, string valueToSet, string expectedAppManifestValue, string expectedNoManifestValue)
+        {
+            var provider = new ApplicationManifestValueProvider(IUnconfiguredProjectFactory.Create(filePath:@"C:\projectdir\proj.proj"), IProjectTreeServiceFactory.Create());
+            var defaultProperties = IProjectPropertiesFactory.CreateWithPropertiesAndValues(new Dictionary<string, string>
+                                                                                            {
+                                                                                                { "ApplicationManifest", appManifestPropValue },
+                                                                                                { "NoWin32Manifest", noManifestPropValue }
+                                                                                            });
+            
+            var appManifestValue = await provider.OnSetPropertyValueAsync(valueToSet, defaultProperties);
+            var noManifestValue = await defaultProperties.GetEvaluatedPropertyValueAsync("NoWin32Manifest");
+
+            Assert.Equal(expectedAppManifestValue, appManifestValue);
+            Assert.Equal(expectedNoManifestValue, noManifestValue);
+        }
+    }
+}
+

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/ApplicationManifestValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/ApplicationManifestValueProviderTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData("", null, "DefaultManifest")]
         public async Task GetApplicationManifest(string appManifestPropValue, string noManifestValue, string expectedValue)
         {
-            var provider = new ApplicationManifestValueProvider(IUnconfiguredProjectFactory.Create(), IProjectTreeServiceFactory.Create());
+            var provider = new ApplicationManifestValueProvider(IUnconfiguredProjectFactory.Create());
             var defaultProperties = IProjectPropertiesFactory.CreateWithPropertyAndValue("NoWin32Manifest", noManifestValue);
 
             var appManifestValue = await provider.OnGetEvaluatedPropertyValueAsync(appManifestPropValue, defaultProperties);
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData(@"C:\projectdir\foo.man", null, null, null, null)]
         public async Task SetApplicationManifest(string appManifestPropValue, string noManifestPropValue, string valueToSet, string expectedAppManifestValue, string expectedNoManifestValue)
         {
-            var provider = new ApplicationManifestValueProvider(IUnconfiguredProjectFactory.Create(filePath:@"C:\projectdir\proj.proj"), IProjectTreeServiceFactory.Create());
+            var provider = new ApplicationManifestValueProvider(IUnconfiguredProjectFactory.Create(filePath:@"C:\projectdir\proj.proj"));
             var defaultProperties = IProjectPropertiesFactory.CreateWithPropertiesAndValues(new Dictionary<string, string>
                                                                                             {
                                                                                                 { "ApplicationManifest", appManifestPropValue },

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/ImplicitProjectPropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/ImplicitProjectPropertiesProviderTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             properties.SetPropertyValueAsync("ProjectGuid", "7259e9ef-87d1-45a5-95c6-3a8432d23776");
 
             // verify all the setups
-            delegatePropertiesMock.VerifyAll();
+            delegatePropertiesMock.Verify(p => p.SetPropertyValueAsync("ProjectGuid", "7259e9ef-87d1-45a5-95c6-3a8432d23776", null));
         }
 
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/ImplicitProjectPropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/ImplicitProjectPropertiesProviderTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         public void Constructor_NullUnconfiguredProject_ThrowsArgumentNullException()
         {
             var delegatePropertiesMock = IProjectPropertiesFactory
-                .MockWithPropertyAndSet("ProjectGuid", "7259e9ef-87d1-45a5-95c6-3a8432d23776");
+                .MockWithPropertyAndValue("ProjectGuid", "7259e9ef-87d1-45a5-95c6-3a8432d23776");
 
             var delegateProperties = delegatePropertiesMock.Object;
             var delegateProvider = IProjectPropertiesProviderFactory.Create(delegateProperties);
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var unconfiguredProject = IUnconfiguredProjectFactory.Create();
 
             var delegatePropertiesMock = IProjectPropertiesFactory
-                .MockWithPropertyAndSet("ProjectGuid", "7259e9ef-87d1-45a5-95c6-3a8432d23776");
+                .MockWithPropertyAndValue("ProjectGuid", "7259e9ef-87d1-45a5-95c6-3a8432d23776");
 
             var delegateProperties = delegatePropertiesMock.Object;
             var delegateProvider = IProjectPropertiesProviderFactory.Create(delegateProperties);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/AssemblyOriginatorKeyFileValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/AssemblyOriginatorKeyFileValueProviderTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
@@ -19,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.ProjectPropertiesProviders
             string keyFileName = "KeyFile.snk";
             string keyFileFullPath = $@"{projectFolder}\{keyFileName}";
             var delegatePropertiesMock = IProjectPropertiesFactory
-                .MockWithPropertiesAndGetSet(new Dictionary<string, string>() {
+                .MockWithPropertiesAndValues(new Dictionary<string, string>() {
                     { AssemblyOriginatorKeyFilePropertyName, keyFileFullPath }
                 });
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectPropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectPropertiesProviderTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         public async Task VerifyInterceptedPropertiesProviderAsync()
         {
             var delegatePropertiesMock = IProjectPropertiesFactory
-                .MockWithPropertiesAndGetSet(new Dictionary<string, string>() {
+                .MockWithPropertiesAndValues(new Dictionary<string, string>() {
                     { MockPropertyName, "DummyValue" }
                 });
             

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -39,6 +39,7 @@
     <Compile Include="ProjectSystem\Properties\DelegatedProjectPropertiesProviderBase.cs" />
     <Compile Include="ProjectSystem\Properties\DelegatedProjectPropertiesBase.cs" />
     <Compile Include="ProjectSystem\Properties\ImplicitProjectPropertiesProvider.cs" />
+    <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\ApplicationManifestValueProvider.cs" />
     <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\ExportInterceptingPropertyValueProviderAttribute.cs" />
     <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\IInterceptingPropertyValueProviderMetadata.cs" />
     <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\InterceptingPropertyValueProviderBase.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationManifestValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationManifestValueProvider.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using System;
+using System.IO;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    [ExportInterceptingPropertyValueProvider("ApplicationManifest")]
+    internal sealed class ApplicationManifestValueProvider : InterceptingPropertyValueProviderBase
+    {
+        private readonly UnconfiguredProject _unconfiguredProject;
+
+        [ImportingConstructor]
+        public ApplicationManifestValueProvider(UnconfiguredProject unconfiguredProject)
+        {
+            Requires.NotNull(unconfiguredProject, nameof(unconfiguredProject));
+
+            _unconfiguredProject = unconfiguredProject;
+        }
+
+        public override async Task<string> OnGetEvaluatedPropertyValueAsync(string evaluatedPropertyValue, IProjectProperties defaultProperties)
+        {
+            if (!string.IsNullOrEmpty(evaluatedPropertyValue))
+            {
+                return evaluatedPropertyValue;
+            }
+
+            string noManifest = await defaultProperties.GetEvaluatedPropertyValueAsync("NoWin32Manifest").ConfigureAwait(false);
+            if (noManifest.Equals("true"))
+            {
+                return "NoManifest";
+            }
+
+            return "DefaultManifest";
+        }
+
+        public override async Task<string> OnSetPropertyValueAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string> dimensionalConditions = null)
+        {
+            if (!PathHelper.IsFileNameValid(unevaluatedPropertyValue))
+            {
+                throw new ArgumentException("Invalid file path");
+            }
+
+            // We treat NULL/empty value as reset to default and remove the two properties from the project.
+            if (string.IsNullOrEmpty(unevaluatedPropertyValue))
+            {
+                await defaultProperties.DeletePropertyAsync("ApplicationManifest").ConfigureAwait(false);
+                await defaultProperties.DeletePropertyAsync("NoManifest").ConfigureAwait(false);
+            }
+            else if (string.Equals(unevaluatedPropertyValue, "NoManifest"))
+            {
+                await defaultProperties.DeletePropertyAsync("ApplicationManifest").ConfigureAwait(false);
+                await defaultProperties.SetPropertyValueAsync("NoManifest", "true").ConfigureAwait(false);
+            }
+            else
+            {
+                await defaultProperties.DeletePropertyAsync("NoManifest").ConfigureAwait(false);
+                string relativePath;
+                if (Path.IsPathRooted(unevaluatedPropertyValue) &&
+                    PathHelper.TryMakeRelativeToProjectDirectory(_unconfiguredProject, unevaluatedPropertyValue, out relativePath))
+                {
+                    return relativePath;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationManifestValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationManifestValueProvider.cs
@@ -12,15 +12,35 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     internal sealed class ApplicationManifestValueProvider : InterceptingPropertyValueProviderBase
     {
         private readonly UnconfiguredProject _unconfiguredProject;
+        private readonly IProjectTreeService _projectTreeService;
+
+        private const string NoManifestMSBuildProperty = "NoWin32Manifest";
+        private const string ApplicationManifestMSBuildProperty = "ApplicationManifest";
+        private const string NoManifestValue = "NoManifest";
+        private const string DefaultManifestValue = "DefaultManifest";
 
         [ImportingConstructor]
-        public ApplicationManifestValueProvider(UnconfiguredProject unconfiguredProject)
+        public ApplicationManifestValueProvider(UnconfiguredProject unconfiguredProject, IProjectTreeService projectTreeService)
         {
             Requires.NotNull(unconfiguredProject, nameof(unconfiguredProject));
+            Requires.NotNull(projectTreeService, nameof(projectTreeService));
 
             _unconfiguredProject = unconfiguredProject;
+            _projectTreeService = projectTreeService;
         }
 
+        /// <summary>
+        /// Gets the application manifest property
+        /// </summary>
+        /// <remarks>
+        /// The Application Manifest's value is one of three possibilites:
+        ///     - It's either a path to file that is the manifest
+        ///     - It's the value "NoManifest" which means the application doesn't have a manifest.
+        ///     - It's the value "DefaultManifest" which means that the application will have a default manifest.
+        ///     
+        /// These three values map to two MSBuild properties - ApplicationManifest (specified if it's a path) or NoWin32Manfiest 
+        /// which is true for the second case and false or non-existent for the third.
+        /// </remarks>
         public override async Task<string> OnGetEvaluatedPropertyValueAsync(string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
             if (!string.IsNullOrEmpty(evaluatedPropertyValue))
@@ -28,45 +48,55 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 return evaluatedPropertyValue;
             }
 
-            string noManifest = await defaultProperties.GetEvaluatedPropertyValueAsync("NoWin32Manifest").ConfigureAwait(false);
-            if (noManifest.Equals("true"))
+            string noManifestPropertyValue = await defaultProperties.GetEvaluatedPropertyValueAsync(NoManifestMSBuildProperty).ConfigureAwait(false);
+            if (noManifestPropertyValue?.Equals("true", StringComparison.InvariantCultureIgnoreCase) == true)
             {
-                return "NoManifest";
+                return NoManifestValue;
             }
 
-            return "DefaultManifest";
+            // It doesnt matter if it is set to false or the value is not present. We default to "DefaultManifest" scenario.
+            return DefaultManifestValue;
         }
 
+        /// <summary>
+        /// Sets the application manifest property
+        /// </summary>
         public override async Task<string> OnSetPropertyValueAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string> dimensionalConditions = null)
         {
-            if (!PathHelper.IsFileNameValid(unevaluatedPropertyValue))
-            {
-                throw new ArgumentException("Invalid file path");
-            }
+            string returnValue = null;
 
             // We treat NULL/empty value as reset to default and remove the two properties from the project.
-            if (string.IsNullOrEmpty(unevaluatedPropertyValue))
+            if (string.IsNullOrEmpty(unevaluatedPropertyValue) || string.Equals(unevaluatedPropertyValue, DefaultManifestValue, StringComparison.InvariantCultureIgnoreCase))
             {
-                await defaultProperties.DeletePropertyAsync("ApplicationManifest").ConfigureAwait(false);
-                await defaultProperties.DeletePropertyAsync("NoManifest").ConfigureAwait(false);
+                await defaultProperties.DeletePropertyAsync(ApplicationManifestMSBuildProperty).ConfigureAwait(false);
+                await defaultProperties.DeletePropertyAsync(NoManifestMSBuildProperty).ConfigureAwait(false);
             }
-            else if (string.Equals(unevaluatedPropertyValue, "NoManifest"))
+            else if (string.Equals(unevaluatedPropertyValue, NoManifestValue, StringComparison.InvariantCultureIgnoreCase))
             {
-                await defaultProperties.DeletePropertyAsync("ApplicationManifest").ConfigureAwait(false);
-                await defaultProperties.SetPropertyValueAsync("NoManifest", "true").ConfigureAwait(false);
+                await defaultProperties.DeletePropertyAsync(ApplicationManifestMSBuildProperty).ConfigureAwait(false);
+                await defaultProperties.SetPropertyValueAsync(NoManifestMSBuildProperty, "true").ConfigureAwait(false);
             }
             else
             {
-                await defaultProperties.DeletePropertyAsync("NoManifest").ConfigureAwait(false);
+                await defaultProperties.DeletePropertyAsync(NoManifestMSBuildProperty).ConfigureAwait(false);
+
+                // If we can make the path relative to the project folder do so. Otherwise just use the given path.
                 string relativePath;
                 if (Path.IsPathRooted(unevaluatedPropertyValue) &&
                     PathHelper.TryMakeRelativeToProjectDirectory(_unconfiguredProject, unevaluatedPropertyValue, out relativePath))
                 {
-                    return relativePath;
+                    returnValue = relativePath;
+                }
+                else
+                {
+                    returnValue = unevaluatedPropertyValue;
                 }
             }
 
-            return null;
+            // Push the changes so that they take effect immediately, since the property pages try to read the value right after the set.
+            await _projectTreeService.PublishLatestTreeAsync().ConfigureAwait(false);
+
+            return returnValue;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -51,7 +51,7 @@
   </StringProperty>
   <StringProperty Name="Win32ResourceFile" DisplayName="Win32 Resource File">
     <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="Win32Resource" />
+      <DataSource Persistence="ProjectFile" PersistedName="Win32Resource" HasConfigurationCondition="False" />
     </StringProperty.DataSource>
   </StringProperty>
   <StringListProperty Name="AvailablePlatforms" Separator="," Visible="False" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -46,7 +46,7 @@
   <StringProperty Name="StartupObject" DisplayName="Type that contains the entry point" />
   <StringProperty Name="ApplicationManifest" DisplayName="Application Manifest" >
     <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterception" PersistedName="ApplicationManifest" />
+      <DataSource Persistence="ProjectFileWithInterception" PersistedName="ApplicationManifest" HasConfigurationCondition="false" />
     </StringProperty.DataSource>
   </StringProperty>
   <StringProperty Name="Win32ResourceFile" DisplayName="Win32 Resource File">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -44,6 +44,11 @@
     </EnumProperty.DataSource>
   </EnumProperty>
   <StringProperty Name="StartupObject" DisplayName="Type that contains the entry point" />
+  <StringProperty Name="ApplicationManifest" DisplayName="Application Manifest" >
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception" PersistedName="ApplicationManifest" />
+    </StringProperty.DataSource>
+  </StringProperty>
   <StringProperty Name="Win32ResourceFile" DisplayName="Win32 Resource File">
     <StringProperty.DataSource>
       <DataSource Persistence="ProjectFile" PersistedName="Win32Resource" />


### PR DESCRIPTION
The application manifest is backed by two MSBuild properties. This change adds an intercepting property provider that maps back and forth from the MSBuild properties. 

@dotnet/project-system 