### PR TITLE
Register a CPS trace listener

### DIFF
--- a/src/ProjectSystemDogfoodSetup/ProjectSystemDogfoodSetup.csproj
+++ b/src/ProjectSystemDogfoodSetup/ProjectSystemDogfoodSetup.csproj
@@ -11,9 +11,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <AssemblyName>ProjectSystemDogfoodSetup</AssemblyName>
-    <GeneratePkgDefFile>false</GeneratePkgDefFile>
+    <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>
-    <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
+    <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
     <ImportVSSDKTargets>true</ImportVSSDKTargets>
@@ -48,6 +48,12 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj">
+      <Project>{23BCBC90-ED65-4EE3-8AF1-DD7CAEFDBEE9}</Project>
+      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.TestServices</Name>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
+    </ProjectReference>
     <ProjectReference Include="..\ProjectSystemSetup\ProjectSystemSetup.csproj">
       <Project>{9fbd7ef2-9449-486d-9fdd-fa56160aa8bb}</Project>
       <Name>ProjectSystemSetup</Name>
@@ -56,6 +62,10 @@
       <Project>{49705330-a4f5-47ea-bb10-3b783ce91aea}</Project>
       <Name>VisualStudioEditorsSetup</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="VisualStudio\Packaging\DogfoodProjectSystemPackage.DebuggerTraceListener.cs" />
+    <Compile Include="VisualStudio\Packaging\DogfoodProjectSystemPackage.cs" />
   </ItemGroup>
   <Import Project="..\..\build\Targets\VSL.Imports.targets" />
 </Project>

--- a/src/ProjectSystemDogfoodSetup/VisualStudio/Packaging/DogfoodProjectSystemPackage.DebuggerTraceListener.cs
+++ b/src/ProjectSystemDogfoodSetup/VisualStudio/Packaging/DogfoodProjectSystemPackage.DebuggerTraceListener.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.Diagnostics
+{
+    partial class DogfoodProjectSystemPackage
+    {
+        private class DebuggerTraceListener : TraceListener
+        {
+            internal DebuggerTraceListener()
+            {
+            }
+
+            public override void Write(string message)
+            {
+                if (Debugger.IsLogging())
+                {
+                    Debugger.Log(0, null, message);
+                }
+            }
+
+            public override void WriteLine(string message)
+            {
+                Write(message + Environment.NewLine);
+            }
+        }
+    }
+}

--- a/src/ProjectSystemDogfoodSetup/VisualStudio/Packaging/DogfoodProjectSystemPackage.cs
+++ b/src/ProjectSystemDogfoodSetup/VisualStudio/Packaging/DogfoodProjectSystemPackage.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Threading;
+using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.Diagnostics
+{
+    /// <summary>
+    ///     Registers a trace listener to the CPS trace source that writes to the debugger.
+    /// </summary>
+    [PackageRegistration(AllowsBackgroundLoading = true, RegisterUsing = RegistrationMethod.CodeBase, UseManagedResourcesOnly = true)]
+    [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExists_string, PackageAutoLoadFlags.BackgroundLoad)]
+    internal partial class DogfoodProjectSystemPackage : AsyncPackage
+    {
+        protected override Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+        {
+            RegisterTraceListener();
+            return Task.CompletedTask;
+        }
+
+        private void RegisterTraceListener()
+        {
+            // There's no public API registering a trace listener for a 
+            // non-public trace source, so we need to use reflection
+            string assemblyName = typeof(AppliesToAttribute).Assembly.FullName;
+
+            Type type = Type.GetType($"Microsoft.VisualStudio.ProjectSystem.TraceUtilities, {assemblyName}");
+            FieldInfo field = type.GetField("Source", BindingFlags.NonPublic | BindingFlags.Static);
+
+            TraceSource source = (TraceSource)field.GetValue(null);
+
+            source.Switch.Level = SourceLevels.Warning;
+            source.Listeners.Add(new DebuggerTraceListener());
+        }
+    }
+}

--- a/src/ProjectSystemDogfoodSetup/source.extension.vsixmanifest
+++ b/src/ProjectSystemDogfoodSetup/source.extension.vsixmanifest
@@ -16,5 +16,6 @@
   </Dependencies>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="Dogfood.pkgdef" />
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
   </Assets>
 </PackageManifest>


### PR DESCRIPTION
Register a CPS trace listener that listens to CPS events and writes them to the Debugger output.

Make note this is currently blocked on a PR to the CPS code base where I've turned on TRACE for their assemblies.