### PR TITLE
Update Microbuild version

### DIFF
--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -40,7 +40,7 @@
 
   <!-- settings for strong name signing -->
   <PropertyGroup>
-    <MicroBuildSigningLibraryV2>$(BUILD_ARTIFACTSTAGINGDIRECTORY)\MicroBuild\Plugins\MicroBuild.Plugins.Signing.1.0.221\build\MicroBuild.Signing.dll</MicroBuildSigningLibraryV2>
+    <MicroBuildSigningLibraryV2>$(BUILD_ARTIFACTSTAGINGDIRECTORY)\MicroBuild\Plugins\MicroBuild.Plugins.Signing.1.0.227\build\MicroBuild.Signing.dll</MicroBuildSigningLibraryV2>
     <MicroBuildSigningLibrary Condition="Exists('$(MicroBuildSigningLibraryV2)')">$(MicroBuildSigningLibraryV2)</MicroBuildSigningLibrary>
     <ShouldSignBuild Condition="'$(RunningInMicroBuild)' == 'true' AND '$(SignType)' == 'real'">true</ShouldSignBuild>
     <StrongNameCertificate Condition="'$(StrongNameCertificate)' == ''">MicrosoftShared</StrongNameCertificate>


### PR DESCRIPTION
This is a temporary fix to enable us to continue building in Microbuild

This is becoming a constant issue. I will look into other ways so that we dont depend on the version number. I think Roslyn does it but it is a little complicated.

Tagging @srivatsn @davkean for review