### PR TITLE
Enable seamless reload and globbing capabilities

### DIFF
--- a/src/Targets/Microsoft.Managed.DesignTime.targets
+++ b/src/Targets/Microsoft.Managed.DesignTime.targets
@@ -13,16 +13,15 @@
     <DefineCommonReferenceSchemas>false</DefineCommonReferenceSchemas>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
 
-    <ManagedXamlResourcesDirectory Condition="$(ManagedXamlResourcesDirectory) == ''">$(MSBuildThisFileDirectory)
-    </ManagedXamlResourcesDirectory>
+    <ManagedXamlResourcesDirectory Condition="$(ManagedXamlResourcesDirectory) == ''">$(MSBuildThisFileDirectory)</ManagedXamlResourcesDirectory>
   </PropertyGroup>
 
   <!-- Project Capabilities -->
   <ItemGroup>
     <ProjectCapability Include="AppDesigner"/>
     <ProjectCapability Include="ManagedLang"/> <!-- Temporary: See https://github.com/dotnet/roslyn-project-system/issues/47 -->
-    <!--<ProjectCapability Include="HandlesOwnReload"/>--><!--Temporary as it requires a CPS change to work-->
-    
+    <ProjectCapability Include="HandlesOwnReload"/>
+    <ProjectCapability Include="UseFileGlobs"/>
     <!-- DependenciesTree capability lights up a Dependencies tree node and it's sub node providers-->
     <ProjectCapability Include="DependenciesTree" />
 


### PR DESCRIPTION
Also fix an issue with the path to the rules having an extra newline that causes the rules to not get loaded.

@dotnet/project-system 