### PR TITLE
Enable repro to build with new installer

### DIFF
--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -63,7 +63,6 @@
     <VisualStudioReferenceAssemblyVersion Condition="'$(VisualStudioReferenceAssemblyVersion)' == ''">$(VisualStudioReferenceMajorVersion).0.0.0</VisualStudioReferenceAssemblyVersion>
     <VisualStudioCodename>Dev$(VisualStudioReferenceMajorVersion)</VisualStudioCodename>
 
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <MinimumVisualStudioVersion>$(VisualStudioVersion)</MinimumVisualStudioVersion>
 
     <VSLToolsPath Condition="'$(VSLToolsPath)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..'))</VSLToolsPath>

--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -365,8 +365,9 @@
 
        ==================================================================================== -->
 
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != '' AND '$(ImportVSSDKTargets)' == 'true'" />
-
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\VSSDK\Microsoft.VsSDK.targets"
+          Condition="'$(ImportVSSDKTargets)' == 'true' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\VSSDK\Microsoft.VsSDK.targets')" />
+  
   <!-- ====================================================================================
 
          Support for in-place modification of the compiled binary.


### PR DESCRIPTION
SDK imports have moved from C:\Program Files (x86)\MSBuild\Microsoft\VisualStudio\v15.0\VSSDK to [VSInstallDir]MSBuild\Microsoft\VisualStudio\v15.0\VSSDK. They have redirect logic that redirects causes them to look in both locations for imports. We were skipping that logic based on setting/using VSToolsPath. 

Directly use the MSBuildExtensionPath32 property so that the redirect kicks in. Also, need to check if the targets exist due to NuGet restore not respecting that same logic: https://github.com/NuGet/Home/issues/3387.

After this change, today's build should work from the command-line.