### PR TITLE
Hide a bunch of APIs that arent intended to be public

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AnalyzerDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AnalyzerDependencyNode.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.Imaging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    public class AnalyzerDependencyNode : DependencyNode
+    internal class AnalyzerDependencyNode : DependencyNode
     {
         public AnalyzerDependencyNode(DependencyNodeId id,
                                       ProjectTreeFlags flags,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AssemblyDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AssemblyDependencyNode.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.Imaging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    public class AssemblyDependencyNode : DependencyNode
+    internal class AssemblyDependencyNode : DependencyNode
     {
         public AssemblyDependencyNode(DependencyNodeId id,
                                       ProjectTreeFlags flags,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ComDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ComDependencyNode.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.Imaging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    public class ComDependencyNode : DependencyNode
+    internal class ComDependencyNode : DependencyNode
     {
         public ComDependencyNode(DependencyNodeId id,
                                  ProjectTreeFlags flags,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesChange.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesChange.cs
@@ -5,7 +5,7 @@ using System.Collections.Immutable;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    public class DependenciesChange
+    internal class DependenciesChange
     {
         public DependenciesChange()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProjectContextProvider.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     /// </summary>
     [Export(typeof(IDependenciesGraphProjectContextProvider))]
     [AppliesTo(ProjectCapability.DependenciesTree)]
-    public class DependenciesGraphProjectContextProvider : IDependenciesGraphProjectContextProvider
+    internal class DependenciesGraphProjectContextProvider : IDependenciesGraphProjectContextProvider
     {
         [ImportingConstructor]
         public DependenciesGraphProjectContextProvider(IProjectExportProvider projectExportProvider, 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
@@ -8,7 +8,7 @@ using Microsoft.VisualStudio.Imaging.Interop;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    public class DependencyNode : IDependencyNode
+    internal class DependencyNode : IDependencyNode
     {
         /// <summary>
         /// The set of flags common to all Reference nodes.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageAnalyzerAssemblyDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageAnalyzerAssemblyDependencyNode.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.Imaging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    public class PackageAnalyzerAssemblyDependencyNode : DependencyNode
+    internal class PackageAnalyzerAssemblyDependencyNode : DependencyNode
     {
         public PackageAnalyzerAssemblyDependencyNode(DependencyNodeId id,
                                              string caption,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageAssemblyDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageAssemblyDependencyNode.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.Imaging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    public class PackageAssemblyDependencyNode : DependencyNode
+    internal class PackageAssemblyDependencyNode : DependencyNode
     {
         public PackageAssemblyDependencyNode(DependencyNodeId id,
                                              string caption,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageDependencyNode.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.Imaging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    public class PackageDependencyNode : DependencyNode
+    internal class PackageDependencyNode : DependencyNode
     {
         public PackageDependencyNode(DependencyNodeId id,
                                      string caption,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageFrameworkAssembliesDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageFrameworkAssembliesDependencyNode.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.Imaging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    public class PackageFrameworkAssembliesDependencyNode : DependencyNode
+    internal class PackageFrameworkAssembliesDependencyNode : DependencyNode
     {
         public PackageFrameworkAssembliesDependencyNode(
                                              DependencyNodeId id,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageUnknownDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageUnknownDependencyNode.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.Imaging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    public class PackageUnknownDependencyNode : DependencyNode
+    internal class PackageUnknownDependencyNode : DependencyNode
     {
         public PackageUnknownDependencyNode(
                                      DependencyNodeId id,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ProjectDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ProjectDependencyNode.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.Imaging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    public class ProjectDependencyNode : DependencyNode
+    internal class ProjectDependencyNode : DependencyNode
     {
         public ProjectDependencyNode(DependencyNodeId id,
                                      ProjectTreeFlags flags,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SdkDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SdkDependencyNode.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.Imaging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    public class SdkDependencyNode : DependencyNode
+    internal class SdkDependencyNode : DependencyNode
     {
         public SdkDependencyNode(DependencyNodeId id,
                                  ProjectTreeFlags flags,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SharedProjectDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SharedProjectDependencyNode.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.Imaging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    public class SharedProjectDependencyNode : DependencyNode
+    internal class SharedProjectDependencyNode : DependencyNode
     {
         public SharedProjectDependencyNode(DependencyNodeId id,
                                            ProjectTreeFlags flags,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SubTreeRootDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SubTreeRootDependencyNode.cs
@@ -4,7 +4,7 @@ using Microsoft.VisualStudio.Imaging.Interop;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    public class SubTreeRootDependencyNode : DependencyNode
+    internal class SubTreeRootDependencyNode : DependencyNode
     {
         public SubTreeRootDependencyNode(string providerType,
                                          string caption,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/RelayCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/RelayCommand.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UI
     /// CanExecute handlers. If no CanExecute is specified it returns true in the CanExecute
     /// method.
     /// </summary>
-    public class RelayCommand : ICommand
+    internal class RelayCommand : ICommand
     {
         /// <summary>
         /// Creates a new command that is always enabled

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IJsonSection.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IJsonSection.cs
@@ -7,7 +7,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     /// <summary>
     /// Used to get to the JsonString exported attribute by importers of ILaunchSettingsSerializationProvider
     /// </summary>
-    public interface IJsonSection
+    internal interface IJsonSection
     {
         string JsonSection { get; }
         Type SerializationType { get; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ICreateFileFromTemplateService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ICreateFileFromTemplateService.cs
@@ -7,7 +7,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     /// <summary>
     /// This service creates a file from a given file template.
     /// </summary>
-    public interface ICreateFileFromTemplateService
+    internal interface ICreateFileFromTemplateService
     {
         /// <summary>
         /// Create a file with the given template file and add it to the parent node.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ExportInterceptingPropertyValueProviderAttribute.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ExportInterceptingPropertyValueProviderAttribute.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     /// </summary>
     [MetadataAttribute]
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
-    public sealed class ExportInterceptingPropertyValueProviderAttribute : ExportAttribute
+    internal sealed class ExportInterceptingPropertyValueProviderAttribute : ExportAttribute
     {
         public string PropertyName { get; }
 
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         }
     }
 
-    public enum ExportInterceptingPropertyValueProviderFile
+    internal enum ExportInterceptingPropertyValueProviderFile
     {
         ProjectFile,
         UserFile,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/IInterceptingPropertyValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/IInterceptingPropertyValueProvider.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     /// A project property provider that intercepts all the callbacks for a specific property name
     /// on the default <see cref="IProjectPropertiesProvider"/> for validation and/or transformation of the property value.
     /// </summary>
-    public interface IInterceptingPropertyValueProvider
+    internal interface IInterceptingPropertyValueProvider
     {
         /// <summary>
         /// Validate and/or transform the given evaluated property value.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/IInterceptingPropertyValueProviderMetadata.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/IInterceptingPropertyValueProviderMetadata.cs
@@ -5,7 +5,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     /// <summary>
     /// Metadata mapping interface for the <see cref="ExportInterceptingPropertyValueProviderAttribute"/>.
     /// </summary>
-    public interface IInterceptingPropertyValueProviderMetadata
+    internal interface IInterceptingPropertyValueProviderMetadata
     {
         string PropertyName { get; }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/StringExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/StringExtensions.cs
@@ -5,7 +5,7 @@
     /// <summary>
     /// Extensions to the string class.
     ///</summary>
-    public static class StringExtensions
+    internal static class StringExtensions
     {
 
         /// <summary>


### PR DESCRIPTION
We are going to create NuGet packages for the project system dlls and so we need to make sure the public APIs are really meant to be public. I've flipped a bunch of stuff to be internal in this PR. The only APIs that are public now are:

![image](https://cloud.githubusercontent.com/assets/20570/18221293/186cb7ee-7130-11e6-87c5-b2d18123f93c.png)

@BillHiebert @abpiskunov  does this sound like the right set?

@dotnet/project-system 