### PR TITLE
Added an ImplicitProjectPropertiesStore to sit at the UnconfiguredProject level

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/ImplicitProjectPropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/ImplicitProjectPropertiesProviderTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             {
                 new ImplicitProjectPropertiesProvider(null,
                                                       IProjectInstancePropertiesProviderFactory.Create(),
-                                                      new ImplicitProjectPropertiesStore<string, string>(unconfiguredProject),
+                                                      new ImplicitProjectPropertiesStore<string, string>(),
                                                       unconfiguredProject);
             });
         }
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             {
                 new ImplicitProjectPropertiesProvider(delegateProvider,
                                                       null,
-                                                      new ImplicitProjectPropertiesStore<string, string>(unconfiguredProject),
+                                                      new ImplicitProjectPropertiesStore<string, string>(),
                                                       unconfiguredProject);
             });
         }
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             {
                 new ImplicitProjectPropertiesProvider(delegateProvider,
                                                       IProjectInstancePropertiesProviderFactory.Create(),
-                                                      new ImplicitProjectPropertiesStore<string, string>(IUnconfiguredProjectFactory.Create()),
+                                                      new ImplicitProjectPropertiesStore<string, string>(),
                                                       null);
             });
         }
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var delegateProperties = delegatePropertiesMock.Object;
             var delegateProvider = IProjectPropertiesProviderFactory.Create(delegateProperties);
-            var propertyStore = new ImplicitProjectPropertiesStore<string, string>(unconfiguredProject);
+            var propertyStore = new ImplicitProjectPropertiesStore<string, string>();
 
             var provider = new ImplicitProjectPropertiesProvider(delegateProvider, instanceProvider, propertyStore, unconfiguredProject);
             var properties = provider.GetProperties("path/to/project.testproj", null, null);
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var delegateProperties = delegatePropertiesMock.Object;
             var delegateProvider = IProjectPropertiesProviderFactory.Create(delegateProperties);
-            var propertyStore = new ImplicitProjectPropertiesStore<string, string>(unconfiguredProject);
+            var propertyStore = new ImplicitProjectPropertiesStore<string, string>();
 
             var provider = new ImplicitProjectPropertiesProvider(delegateProvider, instanceProvider, propertyStore, unconfiguredProject);
             var properties = provider.GetProperties("path/to/project.testproj", null, null);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/ImplicitProjectPropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/ImplicitProjectPropertiesProviderTests.cs
@@ -10,10 +10,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     {
         [Fact]
         public void Constructor_NullDelegatedProvider_ThrowsArgumentNullException()
-        {            
-            Assert.Throws<ArgumentNullException>("provider", () => 
+        {
+            var unconfiguredProject = IUnconfiguredProjectFactory.Create();
+            Assert.Throws<ArgumentNullException>("provider", () =>
             {
-                new ImplicitProjectPropertiesProvider(null, IProjectInstancePropertiesProviderFactory.Create(), IUnconfiguredProjectFactory.Create());
+                new ImplicitProjectPropertiesProvider(null,
+                                                      IProjectInstancePropertiesProviderFactory.Create(),
+                                                      new ImplicitProjectPropertiesStore<string, string>(unconfiguredProject),
+                                                      unconfiguredProject);
             });
         }
 
@@ -25,13 +29,34 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var delegateProperties = delegatePropertiesMock.Object;
             var delegateProvider = IProjectPropertiesProviderFactory.Create(delegateProperties);
+            var unconfiguredProject = IUnconfiguredProjectFactory.Create();
 
             Assert.Throws<ArgumentNullException>("instanceProvider", () =>
             {
-                new ImplicitProjectPropertiesProvider(delegateProvider, null, IUnconfiguredProjectFactory.Create());
+                new ImplicitProjectPropertiesProvider(delegateProvider,
+                                                      null,
+                                                      new ImplicitProjectPropertiesStore<string, string>(unconfiguredProject),
+                                                      unconfiguredProject);
             });
         }
 
+        [Fact]
+        public void Constructor_NullPropertiesStore_ThrowsArgumentNullException()
+        {
+            var delegatePropertiesMock = IProjectPropertiesFactory
+                .MockWithPropertyAndValue("ProjectGuid", "7259e9ef-87d1-45a5-95c6-3a8432d23776");
+
+            var delegateProperties = delegatePropertiesMock.Object;
+            var delegateProvider = IProjectPropertiesProviderFactory.Create(delegateProperties);
+
+            Assert.Throws<ArgumentNullException>("propertyStore", () =>
+            {
+                new ImplicitProjectPropertiesProvider(delegateProvider,
+                                                      IProjectInstancePropertiesProviderFactory.Create(),
+                                                      null,
+                                                      IUnconfiguredProjectFactory.Create());
+            });
+        }
 
         [Fact]
         public void Constructor_NullUnconfiguredProject_ThrowsArgumentNullException()
@@ -44,7 +69,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             Assert.Throws<ArgumentNullException>("unconfiguredProject", () =>
             {
-                new ImplicitProjectPropertiesProvider(delegateProvider, IProjectInstancePropertiesProviderFactory.Create(), null);
+                new ImplicitProjectPropertiesProvider(delegateProvider,
+                                                      IProjectInstancePropertiesProviderFactory.Create(),
+                                                      new ImplicitProjectPropertiesStore<string, string>(IUnconfiguredProjectFactory.Create()),
+                                                      null);
             });
         }
 
@@ -59,8 +87,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var delegateProperties = delegatePropertiesMock.Object;
             var delegateProvider = IProjectPropertiesProviderFactory.Create(delegateProperties);
+            var propertyStore = new ImplicitProjectPropertiesStore<string, string>(unconfiguredProject);
 
-            var provider = new ImplicitProjectPropertiesProvider(delegateProvider, instanceProvider, unconfiguredProject);
+            var provider = new ImplicitProjectPropertiesProvider(delegateProvider, instanceProvider, propertyStore, unconfiguredProject);
             var properties = provider.GetProperties("path/to/project.testproj", null, null);
 
             // calls delegate above with matching values
@@ -81,8 +110,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var delegateProperties = delegatePropertiesMock.Object;
             var delegateProvider = IProjectPropertiesProviderFactory.Create(delegateProperties);
+            var propertyStore = new ImplicitProjectPropertiesStore<string, string>(unconfiguredProject);
 
-            var provider = new ImplicitProjectPropertiesProvider(delegateProvider, instanceProvider, unconfiguredProject);
+            var provider = new ImplicitProjectPropertiesProvider(delegateProvider, instanceProvider, propertyStore, unconfiguredProject);
             var properties = provider.GetProperties("path/to/project.testproj", null, null);
 
             // does not call the set property on the delegated property above

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/ImplicitProjectPropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/ImplicitProjectPropertiesProviderTests.cs
@@ -41,24 +41,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         }
 
         [Fact]
-        public void Constructor_NullPropertiesStore_ThrowsArgumentNullException()
-        {
-            var delegatePropertiesMock = IProjectPropertiesFactory
-                .MockWithPropertyAndValue("ProjectGuid", "7259e9ef-87d1-45a5-95c6-3a8432d23776");
-
-            var delegateProperties = delegatePropertiesMock.Object;
-            var delegateProvider = IProjectPropertiesProviderFactory.Create(delegateProperties);
-
-            Assert.Throws<ArgumentNullException>("propertyStore", () =>
-            {
-                new ImplicitProjectPropertiesProvider(delegateProvider,
-                                                      IProjectInstancePropertiesProviderFactory.Create(),
-                                                      null,
-                                                      IUnconfiguredProjectFactory.Create());
-            });
-        }
-
-        [Fact]
         public void Constructor_NullUnconfiguredProject_ThrowsArgumentNullException()
         {
             var delegatePropertiesMock = IProjectPropertiesFactory

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -53,6 +53,7 @@
     <Compile Include="ProjectSystem\Properties\DelegatedProjectPropertiesProviderBase.cs" />
     <Compile Include="ProjectSystem\Properties\DelegatedProjectPropertiesBase.cs" />
     <Compile Include="ProjectSystem\Properties\ImplicitProjectPropertiesProvider.cs" />
+    <Compile Include="ProjectSystem\Properties\ImplicitProjectPropertiesStore.cs" />
     <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\ApplicationManifestValueProvider.cs" />
     <Compile Include="ProjectSystem\Properties\RuleExtensions.cs" />
     <Compile Include="ProjectSystem\Properties\RuleDataSourceTypes.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ImplicitProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ImplicitProjectPropertiesProvider.cs
@@ -25,19 +25,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
     internal class ImplicitProjectPropertiesProvider : DelegatedProjectPropertiesProviderBase
     {
-        private readonly ConcurrentDictionary<string, string> _propertyValues = new ConcurrentDictionary<string, string>();
+        private readonly ImplicitProjectPropertiesStore<string, string> _propertyStore;
 
         [ImportingConstructor]
         public ImplicitProjectPropertiesProvider(
             [Import(ContractNames.ProjectPropertyProviders.ProjectFile)] IProjectPropertiesProvider provider,
             [Import(ContractNames.ProjectPropertyProviders.ProjectFile)] IProjectInstancePropertiesProvider instanceProvider,
+            ImplicitProjectPropertiesStore<string, string> propertyStore,
             UnconfiguredProject unconfiguredProject)
             : base(provider, instanceProvider, unconfiguredProject)
         {
+            Requires.NotNull(propertyStore, nameof(propertyStore));
+            _propertyStore = propertyStore;
         }
 
         public override IProjectProperties GetProperties(string file, string itemType, string item)
-            => new ImplicitProjectProperties(DelegatedProvider.GetProperties(file, itemType, item), _propertyValues);
+            => new ImplicitProjectProperties(DelegatedProvider.GetProperties(file, itemType, item), _propertyStore);
 
         /// <summary>
         /// Implementation of IProjectProperties that avoids writing properties unless they

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ImplicitProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ImplicitProjectPropertiesProvider.cs
@@ -9,14 +9,14 @@ using System.Threading.Tasks;
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {
     /// <summary>
-    /// Provides project properties that normally should not live in the project file but may be 
-    /// written from an external source (e.g. the solution file). This provider avoids writing 
-    /// these properties to the project file, but if they are already present there, it updates 
+    /// Provides project properties that normally should not live in the project file but may be
+    /// written from an external source (e.g. the solution file). This provider avoids writing
+    /// these properties to the project file, but if they are already present there, it updates
     /// the value to keep in sync with the external source.
     /// Values that are not written are held in memory so they can be read for the lifetime of this
-    /// provider. If the property is changed after loading the project file, the file may be out of 
-    /// sync until a full project reload occurs. Specifically, if provider is managing property in 
-    /// memory, and a property is added the project file, all operations ignore the value in the 
+    /// provider. If the property is changed after loading the project file, the file may be out of
+    /// sync until a full project reload occurs. Specifically, if provider is managing property in
+    /// memory, and a property is added the project file, all operations ignore the value in the
     /// project file until this property is deleted or a full reload of the project system occurs.
     /// </summary>
     [Export("ImplicitProjectFile", typeof(IProjectPropertiesProvider))]
@@ -35,7 +35,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             UnconfiguredProject unconfiguredProject)
             : base(provider, instanceProvider, unconfiguredProject)
         {
-            Requires.NotNull(propertyStore, nameof(propertyStore));
             _propertyStore = propertyStore;
         }
 
@@ -59,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             /// <summary>
             /// If a property exists in the delegated properties object, then pass the set
-            /// through (overwrite). Otherwise manage the value in memory in this properties 
+            /// through (overwrite). Otherwise manage the value in memory in this properties
             /// object.
             /// </summary>
             public override async Task SetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IReadOnlyDictionary<string, string> dimensionalConditions = null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ImplicitProjectPropertiesStore.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ImplicitProjectPropertiesStore.cs
@@ -12,11 +12,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     /// </summary>
     [Export(typeof(ImplicitProjectPropertiesStore<,>))]
     [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
+    [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Host)]
     internal class ImplicitProjectPropertiesStore<T1, T2> : ConcurrentDictionary<T1, T2>
     {
-        // We import UnconfiguredProject here to ensure that we're loaded into the UnconfiguredProject scope.
-        // However, we don't need the project for anything.
         [ImportingConstructor]
-        public ImplicitProjectPropertiesStore(UnconfiguredProject project) { }
+        public ImplicitProjectPropertiesStore() { }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ImplicitProjectPropertiesStore.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ImplicitProjectPropertiesStore.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using System.ComponentModel.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    /// <summary>
+    /// This class provides a store for the ImplicitProjectPropertiesProvider that sits at the
+    /// UnconfiguredProject scope. This allows implicit properties such as the Project Guid to
+    /// be shared by all configured projects, each of which will get its own <see cref="ImplicitProjectPropertiesProvider"/>.
+    /// </summary>
+    [Export(typeof(ImplicitProjectPropertiesStore<,>))]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
+    internal class ImplicitProjectPropertiesStore<T1, T2> : ConcurrentDictionary<T1, T2>
+    {
+        // We import UnconfiguredProject here to ensure that we're loaded into the UnconfiguredProject scope.
+        // However, we don't need the project for anything.
+        [ImportingConstructor]
+        public ImplicitProjectPropertiesStore(UnconfiguredProject project) { }
+    }
+}


### PR DESCRIPTION
The ImplicitProjectPropertiesProvider sits at the configured project level. However, the project guid is set once per UnconfiguredProject. When a different configuration was used from the initial default configuration, this guid wasn't being retained. This introduced a store that sits at the UnconfiguredProject level that the ImplicitProjectPropertiesProvider imports, sharing properties like the project guid among all configured projects. This fixes #392 when switching build configurations, and should fully fix it.