### PR TITLE
Removed the name and default path elements from XProj factory registration

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.Packaging
 {
     [Guid(PackageGuid)]
     [PackageRegistration(AllowsBackgroundLoading = true, RegisterUsing = RegistrationMethod.CodeBase, UseManagedResourcesOnly = true)]
-    [ProvideProjectFactory(typeof(XprojProjectFactory), "XProj Migration Factory", "#5", "xproj", "xproj", null)]
+    [ProvideProjectFactory(typeof(XprojProjectFactory), null, null, null, null, null)]
     [RemoteCodeGeneratorRegistration(SingleFileGenerators.ResXGuid, SingleFileGenerators.ResXGeneratorName,
         SingleFileGenerators.ResXDescription, ProjectTypeGuidFormatted, GeneratesDesignTimeSource = true)]
     [RemoteCodeGeneratorRegistration(SingleFileGenerators.PublicResXGuid, SingleFileGenerators.PublicResXGeneratorName,

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.resx
@@ -130,12 +130,9 @@
     <value>A project for creating a command-line application that can run on .NET Core on Windows, Linux and MacOS.</value>
   </data>
   <data name="5" xml:space="preserve">
-    <value>XProj Files (*.xproj);*.xproj</value>
-  </data>
-  <data name="6" xml:space="preserve">
     <value>Class Library (.NET Standard)</value>
   </data>
-  <data name="7" xml:space="preserve">
+  <data name="6" xml:space="preserve">
     <value>A project for creating a class library that targets .NET Standard.</value>
   </data>
 </root>


### PR DESCRIPTION
This fixes the XProj Migration factory showing up in the new project dialog. Addresses #466.

Tagging @dotnet/project-system for review.

