### PR TITLE
Made IInterceptingPropertyValueProviderMetadata public to fix #470

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/IInterceptingPropertyValueProviderMetadata.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/IInterceptingPropertyValueProviderMetadata.cs
@@ -5,7 +5,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     /// <summary>
     /// Metadata mapping interface for the <see cref="ExportInterceptingPropertyValueProviderAttribute"/>.
     /// </summary>
-    internal interface IInterceptingPropertyValueProviderMetadata
+    public interface IInterceptingPropertyValueProviderMetadata
     {
         string PropertyName { get; }
     }


### PR DESCRIPTION
As the title says. IInterceptingPropertyValueProviderMetadata needs to be public so TypeBuilder can get at it for MEF importing. Part of the fix for #470.

@srivatsn @davkean 