### PR TITLE
Fix implicit project properties store

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/ImplicitProjectPropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/ImplicitProjectPropertiesProviderTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             {
                 new ImplicitProjectPropertiesProvider(null,
                                                       IProjectInstancePropertiesProviderFactory.Create(),
-                                                      new ImplicitProjectPropertiesStore<string, string>(),
+                                                      new ImplicitProjectPropertiesStore<string, string>(unconfiguredProject),
                                                       unconfiguredProject);
             });
         }
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             {
                 new ImplicitProjectPropertiesProvider(delegateProvider,
                                                       null,
-                                                      new ImplicitProjectPropertiesStore<string, string>(),
+                                                      new ImplicitProjectPropertiesStore<string, string>(unconfiguredProject),
                                                       unconfiguredProject);
             });
         }
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             {
                 new ImplicitProjectPropertiesProvider(delegateProvider,
                                                       IProjectInstancePropertiesProviderFactory.Create(),
-                                                      new ImplicitProjectPropertiesStore<string, string>(),
+                                                      new ImplicitProjectPropertiesStore<string, string>(IUnconfiguredProjectFactory.Create()),
                                                       null);
             });
         }
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var delegateProperties = delegatePropertiesMock.Object;
             var delegateProvider = IProjectPropertiesProviderFactory.Create(delegateProperties);
-            var propertyStore = new ImplicitProjectPropertiesStore<string, string>();
+            var propertyStore = new ImplicitProjectPropertiesStore<string, string>(unconfiguredProject);
 
             var provider = new ImplicitProjectPropertiesProvider(delegateProvider, instanceProvider, propertyStore, unconfiguredProject);
             var properties = provider.GetProperties("path/to/project.testproj", null, null);
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             var delegateProperties = delegatePropertiesMock.Object;
             var delegateProvider = IProjectPropertiesProviderFactory.Create(delegateProperties);
-            var propertyStore = new ImplicitProjectPropertiesStore<string, string>();
+            var propertyStore = new ImplicitProjectPropertiesStore<string, string>(unconfiguredProject);
 
             var provider = new ImplicitProjectPropertiesProvider(delegateProvider, instanceProvider, propertyStore, unconfiguredProject);
             var properties = provider.GetProperties("path/to/project.testproj", null, null);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/ImplicitProjectPropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/ImplicitProjectPropertiesProviderTests.cs
@@ -41,6 +41,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         }
 
         [Fact]
+        public void Constructor_NullPropertiesStore_ThrowsArgumentNullException()
+        {
+            var delegatePropertiesMock = IProjectPropertiesFactory
+                .MockWithPropertyAndValue("ProjectGuid", "7259e9ef-87d1-45a5-95c6-3a8432d23776");
+
+            var delegateProperties = delegatePropertiesMock.Object;
+            var delegateProvider = IProjectPropertiesProviderFactory.Create(delegateProperties);
+
+            Assert.Throws<ArgumentNullException>("propertyStore", () =>
+            {
+                new ImplicitProjectPropertiesProvider(delegateProvider,
+                                                      IProjectInstancePropertiesProviderFactory.Create(),
+                                                      null,
+                                                      IUnconfiguredProjectFactory.Create());
+            });
+        }
+
+        [Fact]
         public void Constructor_NullUnconfiguredProject_ThrowsArgumentNullException()
         {
             var delegatePropertiesMock = IProjectPropertiesFactory

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/ImplicitProjectPropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/ImplicitProjectPropertiesProviderTests.cs
@@ -41,24 +41,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         }
 
         [Fact]
-        public void Constructor_NullPropertiesStore_ThrowsArgumentNullException()
-        {
-            var delegatePropertiesMock = IProjectPropertiesFactory
-                .MockWithPropertyAndValue("ProjectGuid", "7259e9ef-87d1-45a5-95c6-3a8432d23776");
-
-            var delegateProperties = delegatePropertiesMock.Object;
-            var delegateProvider = IProjectPropertiesProviderFactory.Create(delegateProperties);
-
-            Assert.Throws<ArgumentNullException>("propertyStore", () =>
-            {
-                new ImplicitProjectPropertiesProvider(delegateProvider,
-                                                      IProjectInstancePropertiesProviderFactory.Create(),
-                                                      null,
-                                                      IUnconfiguredProjectFactory.Create());
-            });
-        }
-
-        [Fact]
         public void Constructor_NullUnconfiguredProject_ThrowsArgumentNullException()
         {
             var delegatePropertiesMock = IProjectPropertiesFactory

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ImplicitProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ImplicitProjectPropertiesProvider.cs
@@ -35,7 +35,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             UnconfiguredProject unconfiguredProject)
             : base(provider, instanceProvider, unconfiguredProject)
         {
-            Requires.NotNull(propertyStore, nameof(propertyStore));
             _propertyStore = propertyStore;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ImplicitProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ImplicitProjectPropertiesProvider.cs
@@ -9,14 +9,14 @@ using System.Threading.Tasks;
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {
     /// <summary>
-    /// Provides project properties that normally should not live in the project file but may be
-    /// written from an external source (e.g. the solution file). This provider avoids writing
-    /// these properties to the project file, but if they are already present there, it updates
+    /// Provides project properties that normally should not live in the project file but may be 
+    /// written from an external source (e.g. the solution file). This provider avoids writing 
+    /// these properties to the project file, but if they are already present there, it updates 
     /// the value to keep in sync with the external source.
     /// Values that are not written are held in memory so they can be read for the lifetime of this
-    /// provider. If the property is changed after loading the project file, the file may be out of
-    /// sync until a full project reload occurs. Specifically, if provider is managing property in
-    /// memory, and a property is added the project file, all operations ignore the value in the
+    /// provider. If the property is changed after loading the project file, the file may be out of 
+    /// sync until a full project reload occurs. Specifically, if provider is managing property in 
+    /// memory, and a property is added the project file, all operations ignore the value in the 
     /// project file until this property is deleted or a full reload of the project system occurs.
     /// </summary>
     [Export("ImplicitProjectFile", typeof(IProjectPropertiesProvider))]
@@ -35,6 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             UnconfiguredProject unconfiguredProject)
             : base(provider, instanceProvider, unconfiguredProject)
         {
+            Requires.NotNull(propertyStore, nameof(propertyStore));
             _propertyStore = propertyStore;
         }
 
@@ -58,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             /// <summary>
             /// If a property exists in the delegated properties object, then pass the set
-            /// through (overwrite). Otherwise manage the value in memory in this properties
+            /// through (overwrite). Otherwise manage the value in memory in this properties 
             /// object.
             /// </summary>
             public override async Task SetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IReadOnlyDictionary<string, string> dimensionalConditions = null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ImplicitProjectPropertiesStore.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ImplicitProjectPropertiesStore.cs
@@ -12,10 +12,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     /// </summary>
     [Export(typeof(ImplicitProjectPropertiesStore<,>))]
     [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
-    [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Host)]
     internal class ImplicitProjectPropertiesStore<T1, T2> : ConcurrentDictionary<T1, T2>
     {
+        // We import UnconfiguredProject here to ensure that we're loaded into the UnconfiguredProject scope.
+        // However, we don't need the project for anything.
         [ImportingConstructor]
-        public ImplicitProjectPropertiesStore() { }
+        public ImplicitProjectPropertiesStore(UnconfiguredProject project) { }
     }
 }


### PR DESCRIPTION
`ProjectSystemContractAttribute` doesn't actually do anything in terms of determining what scope a component lives at. Reverted the addition of it to go back to importing an `UnconfiguredProject`. Actually fixes #470.