### PR TITLE
Implicit project file

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ImplicitProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ImplicitProjectPropertiesProvider.cs
@@ -21,6 +21,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     /// </summary>
     [Export("ImplicitProjectFile", typeof(IProjectPropertiesProvider))]
     [Export(typeof(IProjectPropertiesProvider))]
+    [Export("ImplicitProjectFile", typeof(IProjectInstancePropertiesProvider))]
+    [Export(typeof(IProjectInstancePropertiesProvider))]
     [ExportMetadata("Name", "ImplicitProjectFile")]
     [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
     internal class ImplicitProjectPropertiesProvider : DelegatedProjectPropertiesProviderBase

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ProjectFileInterceptedProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ProjectFileInterceptedProjectPropertiesProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     [Export("ProjectFileWithInterception", typeof(IProjectInstancePropertiesProvider))]
     [Export(typeof(IProjectInstancePropertiesProvider))]
     [ExportMetadata("Name", "ProjectFileWithInterception")]
-    [AppliesTo(ProjectCapability.AlwaysAvailable)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
     internal sealed class ProjectFileInterceptedProjectPropertiesProvider : InterceptedProjectPropertiesProviderBase
     {
         [ImportingConstructor]


### PR DESCRIPTION
- Fix "there is no project properties provider for 'ImplictProjectFile'
- ProjectFileWithInterception should only be applied to C# and VB