### PR TITLE
Minor fixes: use ProjectCapability for graph provider;hide more public interfaces;use generic EventHandler

### DIFF
--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -27,6 +27,13 @@
     </ProjectReference>
   </ItemDefinitionGroup>
 
+  <!-- This is a workaround for build failures in WPT branch, like:
+       "Menus.vsct(18,11): error VSCT1118: File not found: Unable to locate 'stdidcmd.h' on the include paths provided"
+  --> 
+  <ItemGroup>
+    <VSCTIncludePath Include="$(VSSDK150Install)\VisualStudioIntegration\Common\Inc" />
+  </ItemGroup>
+
   <!-- This file is imported by all projects at the end of the project files -->
   <!-- Update common properties -->
   <PropertyGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectDependenciesSubTreeProviderMock.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectDependenciesSubTreeProviderMock.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
-using System;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectDependenciesSubTreeProviderMock.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectDependenciesSubTreeProviderMock.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
+using System;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
@@ -40,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// <summary>
         /// Raised when provider's dependencies changed 
         /// </summary>
-        public event DependenciesChangedEventHandler DependenciesChanged;
+        public event EventHandler<DependenciesChangedEventArgs> DependenciesChanged;
 
         private void FireDependenciesChanged()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProjectContextProvider.cs
@@ -130,12 +130,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// <summary>
         /// Gets called when context (projec dependencies) change
         /// </summary>
-        public event ProjectContextEventHandler ProjectContextChanged;
+        public event EventHandler<ProjectContextEventArgs> ProjectContextChanged;
 
         /// <summary>
         /// Gets called when project unloads to notify GraphProvider to release
         /// any data associated with the project.
         /// </summary>
-        public event ProjectContextEventHandler ProjectContextUnloaded;
+        public event EventHandler<ProjectContextEventArgs> ProjectContextUnloaded;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProvider.cs
@@ -22,8 +22,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     /// <summary>
     /// Provides actual dependencies nodes under Dependencies\[DependencyType]\[TopLevel]\[....] sub nodes. 
     /// </summary>
-    [GraphProvider(Name = "Microsoft.VisualStudio.ProjectSystem.VS.Tree.DependenciesNodeGraphProvider", 
-                   ProjectCapability = "DependenciesTree")]
+    [GraphProvider(Name = "Microsoft.VisualStudio.ProjectSystem.VS.Tree.DependenciesNodeGraphProvider")]
+                   // TODO uncomment when build agents have new build ProjectCapability = "DependenciesTree")]
     internal class DependenciesGraphProvider : OnceInitializedOnceDisposedAsync, IGraphProvider
     {
         private readonly GraphCommand ContainsGraphCommand = new GraphCommand(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProvider.cs
@@ -22,10 +22,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     /// <summary>
     /// Provides actual dependencies nodes under Dependencies\[DependencyType]\[TopLevel]\[....] sub nodes. 
     /// </summary>
-    [GraphProvider(Name = "Microsoft.VisualStudio.ProjectSystem.VS.Tree.DependenciesNodeGraphProvider")]
-    // TODO We are adding a way to filter GraphProviders by capability instead of ProjectKind. Specify 
-    // capability when change is ready.
-    //      ProjectKind = ProjectSystemPackage.ProjectTypeGuidStringWithParentheses)]
+    [GraphProvider(Name = "Microsoft.VisualStudio.ProjectSystem.VS.Tree.DependenciesNodeGraphProvider", 
+                   ProjectCapability = "DependenciesTree")]
     internal class DependenciesGraphProvider : OnceInitializedOnceDisposedAsync, IGraphProvider
     {
         private readonly GraphCommand ContainsGraphCommand = new GraphCommand(
@@ -548,6 +546,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 try
                 {
                     var value = id.GetNestedValueByName<Uri>(idPartName);
+
+                    // for idPartName == CodeGraphNodeIdName.File it can be null, avoid unnecessary exception
+                    if (value == null)
+                    {
+                        return null;
+                    }
 
                     // Assembly and File are represented by a Uri, extract LocalPath string from Uri
                     return (value.IsAbsoluteUri ? value.LocalPath : value.ToString()).Trim('/');

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -875,12 +875,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// <summary>
         /// Gets called when dependencies change
         /// </summary>
-        public event ProjectContextEventHandler ProjectContextChanged;
+        public event EventHandler<ProjectContextEventArgs> ProjectContextChanged;
 
         /// <summary>
         /// Gets called when project is unloading and dependencies subtree is disposing
         /// </summary>
-        public event ProjectContextEventHandler ProjectContextUnloaded;
+        public event EventHandler<ProjectContextEventArgs> ProjectContextUnloaded;
 
         #endregion
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesSubTreeProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesSubTreeProviderBase.cs
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// </summary>
         protected ImmutableHashSet<string> ResolvedReferenceRuleNames = Empty.OrdinalIgnoreCaseStringSet;
 
-        public event DependenciesChangedEventHandler DependenciesChanged;
+        public event EventHandler<DependenciesChangedEventArgs> DependenciesChanged;
 
         private IDependencyNode _rootNode;
         public IDependencyNode RootNode
@@ -502,12 +502,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                                         IProjectCatalogSnapshot,
                                                         IProjectSharedFoldersSnapshot>> e)
         {
-            DependenciesChanged?.Invoke(this, 
-                                        new DependenciesChangedEventArgs(
-                                                this, 
-                                                changes, 
-                                                e.Value.Item2, 
-                                                e.DataSourceVersions));
+            DependenciesChanged(this, 
+                                new DependenciesChangedEventArgs(
+                                        this, 
+                                        changes, 
+                                        e.Value.Item2, 
+                                        e.DataSourceVersions));
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependenciesGraphProjectContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependenciesGraphProjectContext.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     /// node and it's first children sub nodes associated with dependency types are regular IProjectTree nodes, but 
     /// then actual dependencies under them will be dynamic graph nodes for perf reasons.
     /// </summary>
-    public interface IDependenciesGraphProjectContext
+    internal interface IDependenciesGraphProjectContext
     {
         /// <summary>
         /// Returns a dependencies node sub tree provider for given dependency provider type.
@@ -37,17 +37,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// <summary>
         /// Gets called when dependencies change
         /// </summary>
-        event ProjectContextEventHandler ProjectContextChanged;
+        event EventHandler<ProjectContextEventArgs> ProjectContextChanged;
 
         /// <summary>
         /// Gets called when project is unloading and dependencies subtree is disposing
         /// </summary>
-        event ProjectContextEventHandler ProjectContextUnloaded;
+        event EventHandler<ProjectContextEventArgs> ProjectContextUnloaded;
     }
 
-    public delegate void ProjectContextEventHandler(object sender, ProjectContextEventArgs e);
-
-    public class ProjectContextEventArgs : EventArgs
+    internal class ProjectContextEventArgs : EventArgs
     {
         public ProjectContextEventArgs(IDependenciesGraphProjectContext context)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependenciesGraphProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependenciesGraphProjectContextProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
@@ -8,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     /// Global scope contract that provides information about project level 
     /// dependencies graph contexts.
     /// </summary>
-    public interface IDependenciesGraphProjectContextProvider
+    internal interface IDependenciesGraphProjectContextProvider
     {
         /// <summary>
         /// Returns an unconfigured project level contexts for given project file path.
@@ -24,12 +25,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// <summary>
         /// Gets called when dependencies change
         /// </summary>
-        event ProjectContextEventHandler ProjectContextChanged;
+        event EventHandler<ProjectContextEventArgs> ProjectContextChanged;
 
         /// <summary>
         /// Gets called when project unloads to notify GraphProvider to release
         /// any data associated with the project.
         /// </summary>
-        event ProjectContextEventHandler ProjectContextUnloaded;
+        event EventHandler<ProjectContextEventArgs> ProjectContextUnloaded;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IProjectDependenciesSubTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IProjectDependenciesSubTreeProvider.cs
@@ -62,10 +62,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// <summary>
         /// Raised when provider's dependencies changed 
         /// </summary>
-        event DependenciesChangedEventHandler DependenciesChanged;
+        event EventHandler<DependenciesChangedEventArgs> DependenciesChanged;
     }
-
-    public delegate void DependenciesChangedEventHandler(object sender, DependenciesChangedEventArgs e);
 
     public class DependenciesChangedEventArgs
     {


### PR DESCRIPTION
- use ProjectCapability for GraphProvider (assuming everyone is on WPT now)
- use generic EventHandler #454 
- hide more APIs