### PR TITLE
Add methods to allow updating profiles prgrammatically

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider.cs
@@ -26,6 +26,36 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
         // Blocks until at least one snapshot has been generated.
         Task<ILaunchSettings> WaitForFirstSnapshot(int timeout);
+
+        /// <summary>
+        /// Adds the given profile to the list and saves to disk. If a profile with the same 
+        /// name exists (case sensitive), it will be replaced with the new profile. If addToFront is
+        /// true the profile will be the first one in the list. This is useful since quite often callers want
+        /// their just added profile to be listed first in the start menu. 
+        /// </summary>
+        Task AddOrUpdateProfileAsync(ILaunchProfile profile, bool addToFront);
+
+        /// <summary>
+        /// Removes the specified profile from the list and saves to disk.
+        /// </summary>
+        Task RemoveProfileAsync(string profileName);
+
+        /// <summary>
+        /// Adds or updates the global settings represented by settingName. Saves the 
+        /// updated settings to disk. Note that the settings object must be serializable.
+        /// </summary>
+        Task AddOrUpdateGlobalSettingAsync(string settingName, object settingContent);
+
+        /// <summary>
+        /// Removes the specified global setting and saves the settings to disk
+        /// </summary>
+        Task RemoveGlobalSettingAsync(string settingName);
+
+        /// <summary>
+        /// Sets the active profile. This just sets te propery it does not validate that the setting matches an
+        /// existing profile
+        /// </summary>
+        Task SetActiveProfileAsync(string profileName);
     }
 }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider.cs
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         Task RemoveGlobalSettingAsync(string settingName);
 
         /// <summary>
-        /// Sets the active profile. This just sets te propery it does not validate that the setting matches an
+        /// Sets the active profile. This just sets the property it does not validate that the setting matches an
         /// existing profile
         /// </summary>
         Task SetActiveProfileAsync(string profileName);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettings.cs
@@ -6,10 +6,8 @@ using System.Linq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
-
     internal class LaunchSettings : ILaunchSettings
     {
-
         /// <summary>
         /// Represents the current set of launch settings. Creation from an existing set of profiles. 
         /// </summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettings.cs
@@ -38,11 +38,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             _activeProfileName = activeProfile;
         }
 
+        public LaunchSettings()
+        {
+            Profiles = ImmutableList<ILaunchProfile>.Empty;
+            GlobalSettings = ImmutableDictionary<string, object>.Empty;
+        }
+
         private string  _activeProfileName { get; } 
 
         public ImmutableList<ILaunchProfile> Profiles { get; }
 
-        public ImmutableDictionary<string, object> GlobalSettings {get;}
+        public ImmutableDictionary<string, object> GlobalSettings { get; }
 
         public object GetGlobalSetting(string settingName)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -723,7 +723,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             }
             else
             {
-                // Asertion index will be set to the current count (end of list) if an existing item was not found otherwise
+                // Insertion index will be set to the current count (end of list) if an existing item was not found otherwise
                 // it will point to where the previous one was found
                 profiles = profiles.Insert(insertionIndex, new LaunchProfile(profile));
             }
@@ -800,7 +800,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         /// <summary>
-        /// Sets the active profile. This just sets te propery it does not validate that the setting matches an
+        /// Sets the active profile. This just sets the property it does not validate that the setting matches an
         /// existing profile
         /// </summary>
         public async Task SetActiveProfileAsync(string profileName)
@@ -808,6 +808,5 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var props = await CommonProjectServices.ActiveConfiguredProjectProperties.GetProjectDebuggerPropertiesAsync().ConfigureAwait(false);
             await props.ActiveDebugProfile.SetValueAsync(profileName).ConfigureAwait(true);
         }
-
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -84,6 +84,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         // Tracks when we last read or wrote to the file. Prevents picking up needless changes
         protected DateTime LastSettingsFileSyncTime { get; set; }
 
+        protected int WaitForFirstSnapshotDelay = 5000; // 5 seconds
+
         private TaskCompletionSource<bool> _firstSnapshotCompletionSource = new TaskCompletionSource<bool>();
 
         protected IDisposable _projectRuleSubscriptionLink {get; set;}
@@ -279,7 +281,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             }
             catch (Exception ex)
             {
-
                 // Errors are added as error list entries. We don't want to throw out of here
                 // However, if we have never created a snapshot it means there is some error in the file and we want
                 // to have the user see that, so we add a dummy profile which will bind to an existing debugger which will
@@ -683,5 +684,130 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             await _firstSnapshotCompletionSource.Task.TryWaitForCompleteOrTimeout(timeout).ConfigureAwait(false);
             return CurrentSnapshot;
         }
+
+        /// <summary>
+        /// Adds the given profile to the list and saves to disk. If a profile with the same 
+        /// name exists (case sensitive), it will be replaced with the new profile. If addToFront is
+        /// true the profile will be the first one in the list. This is useful since quite often callers want
+        /// their just added profile to be listed first in the start menu. If addToFront is false but there is
+        /// an existing profile, the new one will be inserted at the same location rather than at the end.
+        /// </summary>
+        public async Task AddOrUpdateProfileAsync(ILaunchProfile profile, bool addToFront)
+        {
+            var currentSettings = await GetSnapshotThrowIfErrors().ConfigureAwait(false);
+            ILaunchProfile existingProfile = null;
+            int insertionIndex = 0;
+            foreach (var p in currentSettings.Profiles)
+            {
+                if (LaunchProfile.IsSameProfileName(p.Name, profile.Name))
+                {
+                    existingProfile = p;
+                    break;
+                }
+                insertionIndex++;
+            }
+
+            ImmutableList<ILaunchProfile> profiles;
+            if (existingProfile != null)
+            {
+                profiles = currentSettings.Profiles.Remove(existingProfile);
+            }
+            else
+            {
+                profiles = currentSettings.Profiles;
+            }
+
+            if (addToFront)
+            {
+                profiles = profiles.Insert(0, new LaunchProfile(profile));
+            }
+            else
+            {
+                // Asertion index will be set to the current count (end of list) if an existing item was not found otherwise
+                // it will point to where the previous one was found
+                profiles = profiles.Insert(insertionIndex, new LaunchProfile(profile));
+            }
+
+            var newSnapshot = new LaunchSettings(profiles, currentSettings?.GlobalSettings, currentSettings?.ActiveProfile?.Name);
+            await UpdateAndSaveSettingsAsync(newSnapshot).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Removes the specified profile from the list and saves to disk.
+        /// </summary>
+        public async Task RemoveProfileAsync(string profileName)
+        {
+            var currentSettings = await GetSnapshotThrowIfErrors().ConfigureAwait(false);
+            var existingProfile = currentSettings.Profiles.FirstOrDefault(p => LaunchProfile.IsSameProfileName(p.Name, profileName));
+            if (existingProfile != null)
+            {
+                var profiles = currentSettings.Profiles.Remove(existingProfile);
+                var newSnapshot = new LaunchSettings(profiles, currentSettings.GlobalSettings, currentSettings.ActiveProfile?.Name);
+                await UpdateAndSaveSettingsAsync(newSnapshot).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Adds or updates the global settings represented by settingName. Saves the 
+        /// updated settings to disk. Note that the settings object must be serializable.
+        /// </summary>
+        public async Task AddOrUpdateGlobalSettingAsync(string settingName, object settingContent)
+        {
+            var currentSettings = await GetSnapshotThrowIfErrors().ConfigureAwait(false);
+            ImmutableDictionary<string, object> globalSettings = ImmutableDictionary<string, object>.Empty;
+            object currentValue;
+            if (currentSettings.GlobalSettings.TryGetValue(settingName, out currentValue))
+            {
+                globalSettings = currentSettings.GlobalSettings.Remove(settingName);
+            }
+            else
+            {
+                globalSettings = currentSettings.GlobalSettings;
+            }
+
+            var newSnapshot = new LaunchSettings(currentSettings.Profiles, globalSettings.Add(settingName, settingContent), currentSettings.ActiveProfile?.Name);
+            await UpdateAndSaveSettingsAsync(newSnapshot).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Removes the specified global setting and saves the settings to disk
+        /// </summary>
+        public async Task RemoveGlobalSettingAsync(string settingName)
+        {
+            var currentSettings = await GetSnapshotThrowIfErrors().ConfigureAwait(false);
+            object currentValue;
+            if(currentSettings.GlobalSettings.TryGetValue(settingName, out currentValue))
+            {
+                var globalSettings = currentSettings.GlobalSettings.Remove(settingName);
+                var newSnapshot = new LaunchSettings(currentSettings.Profiles, globalSettings, currentSettings.ActiveProfile?.Name);
+                await UpdateAndSaveSettingsAsync(newSnapshot).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Helper retrieves the current snapshot (waiting up to 5s) and if there were errors in the launchsettings.json file
+        /// or there isn't a snapshot, it throws an error. There should always be a snapshot of some kind returned
+        /// </summary>
+        public async Task<ILaunchSettings> GetSnapshotThrowIfErrors()
+        {
+            var currentSettings = await WaitForFirstSnapshot(WaitForFirstSnapshotDelay).ConfigureAwait(false);
+            if (currentSettings == null || (currentSettings.Profiles.Count == 1 && string.Equals(currentSettings.Profiles[0].CommandName, LaunchSettingsProvider.ErrorProfileCommandName, StringComparison.Ordinal)))
+            {
+                throw new Exception(string.Format(Resources.JsonErrorNeedToBeCorrected, LaunchSettingsFile));
+            }
+
+            return currentSettings;
+        }
+
+        /// <summary>
+        /// Sets the active profile. This just sets te propery it does not validate that the setting matches an
+        /// existing profile
+        /// </summary>
+        public async Task SetActiveProfileAsync(string profileName)
+        {
+            var props = await CommonProjectServices.ActiveConfiguredProjectProperties.GetProjectDebuggerPropertiesAsync().ConfigureAwait(false);
+            await props.ActiveDebugProfile.SetValueAsync(profileName).ConfigureAwait(true);
+        }
+
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
@@ -79,6 +79,15 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Errors in &apos;{0}&apos; need to be corrected before applying changes..
+        /// </summary>
+        internal static string JsonErrorNeedToBeCorrected {
+            get {
+                return ResourceManager.GetString("JsonErrorNeedToBeCorrected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error reading the launch settings file. This error will need to be corrected in order to debug this project. &apos;{0}&apos; .
         /// </summary>
         internal static string JsonErrorReadingLaunchSettings {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
@@ -113,4 +113,7 @@
   <data name="NoActionProfileName" xml:space="preserve">
     <value>Start</value>
   </data>
+  <data name="JsonErrorNeedToBeCorrected" xml:space="preserve">
+    <value>Errors in '{0}' need to be corrected before applying changes.</value>
+  </data>
 </root>


### PR DESCRIPTION
Added a few methods to the LaunchSettingsProvider which allows web projects (and others ) to add or update the existing set of profiles. This is needed so that web projects can add an IIS Express profile and provide the additional settings needed by it.


@srivatsn 