### PR TITLE
Change ProjectLockFileWatcher to look for project.assets.json as well.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -52,6 +52,7 @@
     </StringProperty>
     <StringProperty Name="OutputName" />
     <StringProperty Name="OutputPath" />
+    <StringProperty Name="BaseIntermediateOutputPath" />
     <EnumProperty Name="OutputType">
         <EnumValue Name="Library" DisplayName="Class Library" />
         <EnumValue Name="exe" DisplayName="Console Application" />


### PR DESCRIPTION
For project with PackageReferences, restore3 will generate a project.assets.json file in the obj directory. Update the lockfilewatcher to look for that if it doesn't find a project.json.

@dotnet/project-system @natidea 