### PR TITLE
Cross targeting: Projects build all TFMs from VS

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
@@ -42,11 +42,15 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DictionaryEqualityComparer.cs" />
+    <Compile Include="Mocks\ConfiguredProjectFactory.cs" />
     <Compile Include="Mocks\DispatchThread.cs" />
     <Compile Include="Mocks\IProjectLockServiceFactory.cs" />
     <Compile Include="Mocks\IActiveConfiguredProjectFactory.cs" />
     <Compile Include="Mocks\ICreateFileFromTemplateServiceFactory.cs" />
     <Compile Include="Mocks\IFileSystemMock.cs" />
+    <Compile Include="Mocks\IProjectFaultHandlerServiceFactory.cs" />
+    <Compile Include="Mocks\IProjectServicesFactory.cs" />
+    <Compile Include="Mocks\IProjectServiceFactory.cs" />
     <Compile Include="Mocks\ISourceCodeControlIntegrationFactory.cs" />
     <Compile Include="Mocks\IProjectThreadingServiceMock.cs" />
     <Compile Include="Mocks\IFileSystemFactory.cs" />
@@ -79,6 +83,7 @@
     <Compile Include="Mocks\IProjectDesignerServiceFactory.cs" />
     <Compile Include="OrderPrecedenceImportCollectionExtensions.cs" />
     <Compile Include="ProjectSystem\AppDesignerFolderProjectTreePropertiesProviderTests.cs" />
+    <Compile Include="ProjectSystem\Build\TargetFrameworkGlobalBuildPropertyProviderTests.cs" />
     <Compile Include="ProjectSystem\Debug\LaunchProfileDataTests.cs" />
     <Compile Include="ProjectSystem\Debug\LaunchProfileTests.cs" />
     <Compile Include="ProjectSystem\Debug\DebugTokenReplacerTests.cs" />
@@ -114,6 +119,7 @@
   <ItemGroup>
     <Reference Include="WindowsBase" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="..\..\build\Targets\VSL.Imports.targets" />
   <Import Project="..\..\build\Targets\Roslyn.Toolsets.Xunit.targets" />
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ConfiguredProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ConfiguredProjectFactory.cs
@@ -1,16 +1,16 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.VisualStudio.ProjectSystem;
 using Moq;
 
-namespace Microsoft.VisualStudio.ProjectSystem.VS
+namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class ConfiguredProjectFactory
     {
-        public static ConfiguredProject Create(IProjectCapabilitiesScope capabilities = null)
+        public static ConfiguredProject Create(IProjectCapabilitiesScope capabilities = null, ProjectConfiguration projectConfiguration = null)
         {
             var mock = new Mock<ConfiguredProject>();
             mock.Setup(c => c.Capabilities).Returns(capabilities);
+            mock.Setup(c => c.ProjectConfiguration).Returns(projectConfiguration);
             return mock.Object;
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectFaultHandlerServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectFaultHandlerServiceFactory.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal class IProjectFaultHandlerServiceFactory
+    {
+        public static IProjectFaultHandlerService Create()
+        {
+            return Mock.Of<IProjectFaultHandlerService>();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectServiceFactory.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal class IProjectServiceFactory
+    {
+        public static IProjectService Create(IProjectServices services = null)
+        {
+            var mock = new Mock<IProjectService>();
+
+            services = services ?? IProjectServicesFactory.Create(projectService: mock.Object);
+
+            mock.Setup(p => p.Services)
+                   .Returns(services);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectServicesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectServicesFactory.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal class IProjectServicesFactory
+    {
+        public static IProjectServices Create(IProjectThreadingService threadingService = null, IProjectFaultHandlerService faultHandlerService = null, IProjectService projectService = null)
+        {
+            threadingService = threadingService ?? IProjectThreadingServiceFactory.Create();
+            faultHandlerService = faultHandlerService ?? IProjectFaultHandlerServiceFactory.Create();
+
+            var projectServices = new Mock<IProjectServices>();
+            projectServices.Setup(u => u.ThreadingPolicy)
+                               .Returns(threadingService);
+
+            projectServices.Setup(u => u.FaultHandler)
+                .Returns(faultHandlerService);
+
+            projectServices.Setup(u => u.ProjectService)
+                .Returns(projectService);
+
+            return projectServices.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IUnconfiguredProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IUnconfiguredProjectFactory.cs
@@ -9,27 +9,22 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class IUnconfiguredProjectFactory
     {
-        public static UnconfiguredProject Create(object hostObject = null, IEnumerable<string> capabilities = null, string filePath = null)
+        public static UnconfiguredProject Create(object hostObject = null, IEnumerable<string> capabilities = null, string filePath = null, IProjectConfigurationsService projectConfigurationsService = null)
         {
             capabilities = capabilities ?? Enumerable.Empty<string>();
 
-            var threadingService = IProjectThreadingServiceFactory.Create();
-
-            var projectServices = new Mock<IProjectServices>();
-            projectServices.Setup(u => u.ThreadingPolicy)
-                               .Returns(threadingService);
-
-            var service = new Mock<IProjectService>();
-            service.Setup(p => p.Services)
-                   .Returns(projectServices.Object);
+            var service = IProjectServiceFactory.Create();
 
             var unconfiguredProjectServices = new Mock<IUnconfiguredProjectServices>();
             unconfiguredProjectServices.Setup(u => u.HostObject)
                                        .Returns(hostObject);
 
+            unconfiguredProjectServices.Setup(u => u.ProjectConfigurationsService)
+                                       .Returns(projectConfigurationsService);
+
             var unconfiguredProject = new Mock<UnconfiguredProject>();
             unconfiguredProject.Setup(u => u.ProjectService)
-                               .Returns(service.Object);
+                               .Returns(service);
 
             unconfiguredProject.Setup(u => u.Services)
                                .Returns(unconfiguredProjectServices.Object);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Build/TargetFrameworkGlobalBuildPropertyProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Build/TargetFrameworkGlobalBuildPropertyProviderTests.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Build;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    [ProjectSystemTrait]
+    public class TargetFrameworkGlobalBuildPropertyProviderTests
+    {
+        [Fact]
+        public async Task VerifyTargetFrameworkOverrideForCrossTargetingBuild()
+        {
+            var dimensions = Empty.PropertiesMap
+                .Add("Configuration", "Debug")
+                .Add("Platform", "AnyCPU")
+                .Add("TargetFramework", "netcoreapp1.0");
+            var projectConfiguration = new StandardProjectConfiguration("Debug|AnyCPU|netcoreapp1.0", dimensions);
+            var configuredProject = ConfiguredProjectFactory.Create(projectConfiguration: projectConfiguration);
+            var projectService = IProjectServiceFactory.Create();
+            var provider = new TargetFrameworkGlobalBuildPropertyProvider(projectService, configuredProject);
+
+            var properties = await provider.GetGlobalPropertiesAsync(CancellationToken.None);
+            Assert.Equal(1, properties.Count);
+            Assert.Equal("TargetFramework", properties.Keys.First());
+            Assert.Equal(string.Empty, properties.Values.First());
+        }
+
+        [Fact]
+        public async Task VerifyNoTargetFrameworkOverrideForRegularBuild()
+        {
+            var dimensions = Empty.PropertiesMap
+                .Add("Configuration", "Debug")
+                .Add("Platform", "AnyCPU");
+            var projectConfiguration = new StandardProjectConfiguration("Debug|AnyCPU", dimensions);
+            var configuredProject = ConfiguredProjectFactory.Create(projectConfiguration: projectConfiguration);
+            var projectService = IProjectServiceFactory.Create();
+            var provider = new TargetFrameworkGlobalBuildPropertyProvider(projectService, configuredProject);
+
+            var properties = await provider.GetGlobalPropertiesAsync(CancellationToken.None);
+            Assert.Equal(0, properties.Count);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -49,7 +49,6 @@
     <Compile Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Properties\AssemblyAttributes.cs">
       <Link>Properties\AssemblyAttributes.cs</Link>
     </Compile>
-    <Compile Include="Mocks\ConfiguredProjectFactory.cs" />
     <Compile Include="Mocks\IActiveConfiguredProjectSubscriptionServiceFactory.cs" />
     <Compile Include="Mocks\IDebugLaunchProviderFactory.cs" />
     <Compile Include="Mocks\IDebugLaunchProviderMetadataViewFactory.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -35,6 +35,7 @@
     <Compile Include="ProjectSystem\Build\BuildProperty.cs" />
     <Compile Include="CommonConstants.cs" />
     <Compile Include="ProjectSystem\Build\CommandLineDesignTimeBuildPropertiesProvider.cs" />
+    <Compile Include="ProjectSystem\Build\TargetFrameworkGlobalBuildPropertyProvider.cs" />
     <Compile Include="ProjectSystem\ContractNames.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="ProjectSystem\Build\PublishableProjectConfigProvider.cs" />
@@ -109,7 +110,7 @@
     <Compile Include="ProjectSystem\Rules\CompilerCommandLineArgs.cs">
       <DependentUpon>CompilerCommandLineArgs.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\TargetFrameworkProjectConfigurationDimensionProvider.cs" />
+    <Compile Include="ProjectSystem\Configurations\TargetFrameworkProjectConfigurationDimensionProvider.cs" />
     <Compile Include="ProjectSystem\Utilities\EnvironmentHelper.cs" />
     <Compile Include="ProjectSystem\Utilities\DataFlowExtensions\DataFlowExtensionMethodCaller.cs" />
     <Compile Include="ProjectSystem\Utilities\DataFlowExtensions\DataFlowExtensionMethodWrapper.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/TargetFrameworkGlobalBuildPropertyProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/TargetFrameworkGlobalBuildPropertyProvider.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Build
+{
+    /// <summary>
+    /// Build properties provider for cross targeting projects to ensure that they are build for all target frameworks when doing an explicit build, not just the active target framework.
+    /// </summary>
+    /// <remarks>We specify attribute 'Order(Int32.MaxValue)` to ensure that this is the most preferred build properties provider, so it overrides target framework setting from prior providers.</remarks>
+    [ExportBuildGlobalPropertiesProvider(designTimeBuildProperties: false)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
+    [Order(Int32.MaxValue)]
+    internal class TargetFrameworkGlobalBuildPropertyProvider : StaticGlobalPropertiesProviderBase
+    {
+        private readonly ConfiguredProject _configuredProject;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TargetFrameworkGlobalBuildPropertyProvider"/> class.
+        /// </summary>
+        [ImportingConstructor]
+        internal TargetFrameworkGlobalBuildPropertyProvider(IProjectService projectService, ConfiguredProject configuredProject)
+            : base(projectService.Services)
+        {
+            _configuredProject = configuredProject;
+        }
+
+        /// <summary>
+        /// Gets the set of global properties that should apply to the project(s) in this scope.
+        /// </summary>
+        /// <value>A map whose keys are case insensitive.  Never null, but may be empty.</value>
+        public override Task<IImmutableDictionary<string, string>> GetGlobalPropertiesAsync(CancellationToken cancellationToken)
+        {
+            IImmutableDictionary<string, string> properties = Empty.PropertiesMap;
+
+            // Check if this is a cross targeting project, i.e. project configuration has a "TargetFramework" dimension.
+            if (_configuredProject.ProjectConfiguration.Dimensions.ContainsKey(TargetFrameworkProjectConfigurationDimensionProvider.TargetFrameworkPropertyName))
+            {
+                // For a cross targeting project, we want to build for all the targeted frameworks.
+                // Clear out the TargetFramework property from the configuration.
+                properties = properties.Add(TargetFrameworkProjectConfigurationDimensionProvider.TargetFrameworkPropertyName, string.Empty);
+            }
+
+            return Task.FromResult(properties);
+        }
+    }
+}


### PR DESCRIPTION
Ensure that for cross targeting projects we clear out the "TargetFramework" global property during explict builds in VS so that we build for all configurations. We do so by implementing a build-only properties provider that checks if the project configuration specifies "TargetFramework" as a dimension or not, and clear out the TargetFramework property if the dimension exists.

Fixes #504