### PR TITLE
XProj Migration Testing

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.VisualStudio.Packaging;
 using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.Collections.Generic;
@@ -98,7 +99,132 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
             Assert.Equal(0, loggedMessages.Count);
         }
 
-        private Tuple<string, string, string> CreateTempProjectLocation()
+        [Fact]
+        public void MigrateXprojProjectFactory_MigrateOutput_LoggedCorrectly()
+        {
+            var projectDirectory = @"C:\Test";
+            var xproj = @"C:\Test\XprojMigrationTests.xproj";
+
+            // Runner returns valid response, standard exit code
+            var procRunner = ProcessRunnerFactory.ImplementRunner(pr =>
+            {
+                Assert.Equal("dotnet.exe", pr.FileName);
+                Assert.Equal("migrate -s -p \"C:\\Test\" -x \"C:\\Test\\XprojMigrationTests.xproj\"", pr.Arguments);
+            }, outputText: "Standard Output", errorText: "Standard Error");
+            var migrator = new MigrateXprojProjectFactory(procRunner);
+
+            var loggedMessages = new List<LogMessage>();
+            var logger = IVsUpgradeLoggerFactory.CreateLogger(loggedMessages);
+
+            Assert.True(migrator.MigrateProject(projectDirectory, xproj, "XprojMigrationTests", logger));
+            Assert.Equal(2, loggedMessages.Count);
+            Assert.Equal(new LogMessage
+            {
+                File = xproj,
+                Level = (uint)__VSUL_ERRORLEVEL.VSUL_INFORMATIONAL,
+                Message = "Standard Output",
+                Project = "XprojMigrationTests"
+            }, loggedMessages[0]);
+            Assert.Equal(new LogMessage
+            {
+                File = xproj,
+                Level = (uint)__VSUL_ERRORLEVEL.VSUL_WARNING,
+                Message = "Standard Error",
+                Project = "XprojMigrationTests"
+            }, loggedMessages[1]);
+        }
+
+        [Fact]
+        public void MigrateXprojProjectFactory_MigrateError_ReturnsFalse()
+        {
+            var projectDirectory = @"C:\Test";
+            var xproj = @"C:\Test\XprojMigrationTests.xproj";
+
+            // Runner returns valid response, standard exit code
+            var procRunner = ProcessRunnerFactory.ImplementRunner(pr =>
+            {
+                Assert.Equal("dotnet.exe", pr.FileName);
+                Assert.Equal("migrate -s -p \"C:\\Test\" -x \"C:\\Test\\XprojMigrationTests.xproj\"", pr.Arguments);
+            }, exitCode: VSConstants.E_FAIL);
+            var migrator = new MigrateXprojProjectFactory(procRunner);
+
+            var loggedMessages = new List<LogMessage>();
+            var logger = IVsUpgradeLoggerFactory.CreateLogger(loggedMessages);
+            Assert.False(migrator.MigrateProject(projectDirectory, xproj, "XprojMigrationTests", logger));
+            Assert.Equal(1, loggedMessages.Count);
+            Assert.Equal(new LogMessage
+            {
+                Level = (uint)__VSUL_ERRORLEVEL.VSUL_ERROR,
+                Project = "XprojMigrationTests",
+                File = xproj,
+                Message = $"Failed to migrate XProj project XprojMigrationTests. 'dotnet migrate -s -p \"{projectDirectory}\" -x \"{xproj}\"' exited with error code {VSConstants.E_FAIL}."
+            }, loggedMessages[0]);
+        }
+
+        [Fact]
+        public void MigrateXprojProjectFactory_ValidCsproj_FindsCsproj()
+        {
+            var tuple = CreateTempProjectLocation();
+            var xproj = tuple.Item2;
+            var projectDir = tuple.Item4;
+            var csproj = Path.Combine(projectDir, "XprojMigrationTests.csproj");
+
+            File.Create(csproj).Dispose();
+
+            var loggedMessages = new List<LogMessage>();
+            var logger = IVsUpgradeLoggerFactory.CreateLogger(loggedMessages);
+            var migrator = new MigrateXprojProjectFactory(ProcessRunnerFactory.CreateRunner());
+
+            Assert.Equal(csproj, migrator.GetCsproj(projectDir, "XprojMigrationTests", xproj, logger));
+            Assert.Equal(0, loggedMessages.Count);
+        }
+
+        [Fact]
+        public void MigrateXprojProjectFactory_NoCsproj_LogsError()
+        {
+            var tuple = CreateTempProjectLocation();
+            var xproj = tuple.Item2;
+            var projectDir = tuple.Item4;
+            var csproj = Path.Combine(projectDir, "XprojMigrationTests.csproj");
+
+            var loggedMessages = new List<LogMessage>();
+            var logger = IVsUpgradeLoggerFactory.CreateLogger(loggedMessages);
+            var migrator = new MigrateXprojProjectFactory(ProcessRunnerFactory.CreateRunner());
+
+            Assert.Equal("", migrator.GetCsproj(projectDir, "XprojMigrationTests", xproj, logger));
+            Assert.Equal(1, loggedMessages.Count);
+            Assert.Equal(new LogMessage
+            {
+                Level = (uint)__VSUL_ERRORLEVEL.VSUL_ERROR,
+                Project = "XprojMigrationTests",
+                File = xproj,
+                Message = $"Expected to find migrated cpsroj in {projectDir}, but did not find any."
+            }, loggedMessages[0]);
+        }
+
+        [Fact]
+        public void MigrateXprojProjectFactory_ValidProject_IsUpgradable()
+        {
+            var tuple = CreateTempProjectLocation();
+            var xproj = tuple.Item2;
+
+            var loggedMessages = new List<LogMessage>();
+            var logger = IVsUpgradeLoggerFactory.CreateLogger(loggedMessages);
+            int upgradeRequired;
+            Guid newProjectFactory;
+            uint capabilityFlags;
+
+            var migrator = new MigrateXprojProjectFactory(ProcessRunnerFactory.CreateRunner());
+
+            Assert.Equal(VSConstants.S_OK,
+                migrator.UpgradeProject_CheckOnly(xproj, logger, out upgradeRequired, out newProjectFactory, out capabilityFlags));
+            Assert.Equal((int)__VSPPROJECTUPGRADEVIAFACTORYREPAIRFLAGS.VSPUVF_PROJECT_ONEWAYUPGRADE, upgradeRequired);
+            Assert.Equal(Guid.Parse(CSharpProjectSystemPackage.ProjectTypeGuid), newProjectFactory);
+            Assert.Equal((uint)(__VSPPROJECTUPGRADEVIAFACTORYFLAGS.PUVFF_BACKUPSUPPORTED | __VSPPROJECTUPGRADEVIAFACTORYFLAGS.PUVFF_COPYBACKUP),
+                capabilityFlags);
+        }
+
+        private Tuple<string, string, string, string> CreateTempProjectLocation()
         {
             var directory = Path.Combine(Path.GetTempPath(), $"XprojMigrationTests_{Guid.NewGuid().ToString()}");
             Directory.CreateDirectory(directory);
@@ -109,7 +235,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
             var projectJson = Path.Combine(directory, "project.json");
             File.Create(projectJson).Dispose();
 
-            return Tuple.Create(backupDirectory, xproj, projectJson);
+            return Tuple.Create(backupDirectory, xproj, projectJson, directory);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
@@ -1,13 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.VisualStudio.Shell.Interop;
-using Moq;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
@@ -108,9 +105,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
             var backupDirectory = Path.Combine(directory, "backup");
             Directory.CreateDirectory(backupDirectory);
             var xproj = Path.Combine(directory, "XprojMigrationTests.xproj");
-            File.Create(xproj);
+            File.Create(xproj).Dispose();
             var projectJson = Path.Combine(directory, "project.json");
-            File.Create(projectJson);
+            File.Create(projectJson).Dispose();
 
             return Tuple.Create(backupDirectory, xproj, projectJson);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Xunit;
@@ -13,27 +15,35 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
     [ProjectSystemTrait]
     public class MigrateXprojProjectFactoryTests
     {
+        private static readonly string RootLocation = @"C:\Temp";
+        private static readonly string ProjectName = "XprojMigrationTests";
+        private static readonly string XprojLocation = Path.Combine(RootLocation, $"{ProjectName}.xproj");
+        private static readonly string ProjectJsonLocation = Path.Combine(RootLocation, "project.json");
+        private static readonly string BackupLocation = Path.Combine(RootLocation, "Backup");
+
         [Fact]
         public void MigrateXprojProjectFactory_NullProcessRunner_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>("runner", () => new MigrateXprojProjectFactory(null));
+            Assert.Throws<ArgumentNullException>("runner", () => new MigrateXprojProjectFactory(null, new IFileSystemMock()));
+        }
+
+        [Fact]
+        public void MigrateXprojProjectFactory_NullFileSystem_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("fileSystem", () => new MigrateXprojProjectFactory(ProcessRunnerFactory.CreateRunner(), null));
         }
 
         [Fact]
         public void MigrateXprojProjectFactory_ValidArgs_BackupsCorrectly()
         {
-            var tuple = CreateTempProjectLocation();
-            var backupDirectory = tuple.Item1;
-            var xproj = tuple.Item2;
-            var projectJson = tuple.Item3;
-
             var procRunner = ProcessRunnerFactory.CreateRunner();
-            var migrator = new MigrateXprojProjectFactory(procRunner);
+            var fileSystem = CreateFileSystem();
+            var migrator = new MigrateXprojProjectFactory(procRunner, fileSystem);
 
             var loggedMessages = new List<LogMessage>();
             var logger = IVsUpgradeLoggerFactory.CreateLogger(loggedMessages);
 
-            Assert.True(migrator.BackupProject(backupDirectory, xproj, "XprojMigrationTests", logger));
+            Assert.True(migrator.BackupProject(BackupLocation, XprojLocation, "XprojMigrationTests", logger));
 
             // We expect 2 informational messages about what files were backed up.
             Assert.Equal(2, loggedMessages.Count);
@@ -44,90 +54,75 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
             });
 
             // The first message should be about the old xproj, the second about the project.json
-            Assert.Equal(xproj, loggedMessages[0].File);
-            Assert.Equal(projectJson, loggedMessages[1].File);
-            Assert.Equal($"Backing up {xproj} to {Path.Combine(backupDirectory, "XprojMigrationTests.xproj")}.", loggedMessages[0].Message);
-            Assert.Equal($"Backing up {projectJson} to {Path.Combine(backupDirectory, "project.json")}.", loggedMessages[1].Message);
+            var xprojBackedUp = Path.Combine(BackupLocation, "XprojMigrationTests.xproj");
+            var projectJsonBackedUp = Path.Combine(BackupLocation, "project.json");
+
+            Assert.Equal(XprojLocation, loggedMessages[0].File);
+            Assert.Equal(ProjectJsonLocation, loggedMessages[1].File);
+            Assert.Equal($"Backing up {XprojLocation} to {xprojBackedUp}.", loggedMessages[0].Message);
+            Assert.Equal($"Backing up {ProjectJsonLocation} to {projectJsonBackedUp}.", loggedMessages[1].Message);
 
             // Finally, assert that there actually are backup files in the backup directory
-            var backedUpFiles = Directory.GetFiles(backupDirectory);
+            var backedUpFiles = fileSystem.EnumerateFiles(BackupLocation, "*", SearchOption.TopDirectoryOnly);
             Assert.Equal(2, backedUpFiles.Count());
-            Assert.True(backedUpFiles.Any(file => file.EndsWith("project.json")));
-            Assert.True(backedUpFiles.Any(file => file.EndsWith("XprojMigrationTests.xproj")));
+            Assert.True(backedUpFiles.Contains(xprojBackedUp));
+            Assert.True(backedUpFiles.Contains(projectJsonBackedUp));
         }
 
         [Fact]
         public void MigrateXprojProjectFactory_NonExistantProjectJson_DoesNotBackUp()
         {
-            var backupDirectory = @"C:\NonExistent";
-            var xproj = @"C:\NonExistent\XprojMigrationTests.xproj";
-            var projectJson = @"C:\NonExistent\project.json";
-
             var procRunner = ProcessRunnerFactory.CreateRunner();
-            var migrator = new MigrateXprojProjectFactory(procRunner);
+            var migrator = new MigrateXprojProjectFactory(procRunner, CreateFileSystem(false));
 
             var loggedMessages = new List<LogMessage>();
             var logger = IVsUpgradeLoggerFactory.CreateLogger(loggedMessages);
 
-            Assert.False(migrator.BackupProject(backupDirectory, xproj, "XprojMigrationTests", logger));
+            Assert.False(migrator.BackupProject(BackupLocation, XprojLocation, "XprojMigrationTests", logger));
 
             Assert.Equal(1, loggedMessages.Count);
             Assert.Equal((uint)__VSUL_ERRORLEVEL.VSUL_ERROR, loggedMessages[0].Level);
             Assert.Equal("XprojMigrationTests", loggedMessages[0].Project);
-            Assert.Equal(projectJson, loggedMessages[0].File);
-            Assert.Equal($"Failed to migrate XProj project XprojMigrationTests. Could not find project.json at {projectJson}.", loggedMessages[0].Message);
+            Assert.Equal(ProjectJsonLocation, loggedMessages[0].File);
+            Assert.Equal($"Failed to migrate XProj project XprojMigrationTests. Could not find project.json at {ProjectJsonLocation}.", loggedMessages[0].Message);
         }
 
         [Fact]
         public void MigrateXprojProjectFactory_ValidPaths_CallMigrateCorrectly()
         {
-            var projectDirectory = @"C:\Test";
-            var xproj = @"C:\Test\XprojMigrationTests.xproj";
-
             // Runner returns valid response, standard exit code
-            var procRunner = ProcessRunnerFactory.ImplementRunner(pr =>
-            {
-                Assert.Equal("dotnet.exe", pr.FileName);
-                Assert.Equal("migrate -s -p \"C:\\Test\" -x \"C:\\Test\\XprojMigrationTests.xproj\"", pr.Arguments);
-            });
-            var migrator = new MigrateXprojProjectFactory(procRunner);
+            var procRunner = ProcessRunnerFactory.ImplementRunner(ProcessVerifier);
+            var migrator = new MigrateXprojProjectFactory(procRunner, CreateFileSystem(false));
 
             var loggedMessages = new List<LogMessage>();
             var logger = IVsUpgradeLoggerFactory.CreateLogger(loggedMessages);
 
-            Assert.True(migrator.MigrateProject(projectDirectory, xproj, "XprojMigrationTests", logger));
+            Assert.True(migrator.MigrateProject(RootLocation, XprojLocation, "XprojMigrationTests", logger));
             Assert.Equal(0, loggedMessages.Count);
         }
 
         [Fact]
         public void MigrateXprojProjectFactory_MigrateOutput_LoggedCorrectly()
         {
-            var projectDirectory = @"C:\Test";
-            var xproj = @"C:\Test\XprojMigrationTests.xproj";
-
             // Runner returns valid response, standard exit code
-            var procRunner = ProcessRunnerFactory.ImplementRunner(pr =>
-            {
-                Assert.Equal("dotnet.exe", pr.FileName);
-                Assert.Equal("migrate -s -p \"C:\\Test\" -x \"C:\\Test\\XprojMigrationTests.xproj\"", pr.Arguments);
-            }, outputText: "Standard Output", errorText: "Standard Error");
-            var migrator = new MigrateXprojProjectFactory(procRunner);
+            var procRunner = ProcessRunnerFactory.ImplementRunner(ProcessVerifier, outputText: "Standard Output", errorText: "Standard Error");
+            var migrator = new MigrateXprojProjectFactory(procRunner, CreateFileSystem(false));
 
             var loggedMessages = new List<LogMessage>();
             var logger = IVsUpgradeLoggerFactory.CreateLogger(loggedMessages);
 
-            Assert.True(migrator.MigrateProject(projectDirectory, xproj, "XprojMigrationTests", logger));
+            Assert.True(migrator.MigrateProject(RootLocation, XprojLocation, "XprojMigrationTests", logger));
             Assert.Equal(2, loggedMessages.Count);
             Assert.Equal(new LogMessage
             {
-                File = xproj,
+                File = XprojLocation,
                 Level = (uint)__VSUL_ERRORLEVEL.VSUL_INFORMATIONAL,
                 Message = "Standard Output",
                 Project = "XprojMigrationTests"
             }, loggedMessages[0]);
             Assert.Equal(new LogMessage
             {
-                File = xproj,
+                File = XprojLocation,
                 Level = (uint)__VSUL_ERRORLEVEL.VSUL_WARNING,
                 Message = "Standard Error",
                 Project = "XprojMigrationTests"
@@ -137,76 +132,64 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         [Fact]
         public void MigrateXprojProjectFactory_MigrateError_ReturnsFalse()
         {
-            var projectDirectory = @"C:\Test";
-            var xproj = @"C:\Test\XprojMigrationTests.xproj";
-
             // Runner returns valid response, standard exit code
-            var procRunner = ProcessRunnerFactory.ImplementRunner(pr =>
-            {
-                Assert.Equal("dotnet.exe", pr.FileName);
-                Assert.Equal("migrate -s -p \"C:\\Test\" -x \"C:\\Test\\XprojMigrationTests.xproj\"", pr.Arguments);
-            }, exitCode: VSConstants.E_FAIL);
-            var migrator = new MigrateXprojProjectFactory(procRunner);
+            var procRunner = ProcessRunnerFactory.ImplementRunner(ProcessVerifier, exitCode: VSConstants.E_FAIL);
+            var migrator = new MigrateXprojProjectFactory(procRunner, CreateFileSystem(false));
 
             var loggedMessages = new List<LogMessage>();
             var logger = IVsUpgradeLoggerFactory.CreateLogger(loggedMessages);
-            Assert.False(migrator.MigrateProject(projectDirectory, xproj, "XprojMigrationTests", logger));
+            Assert.False(migrator.MigrateProject(RootLocation, XprojLocation, "XprojMigrationTests", logger));
             Assert.Equal(1, loggedMessages.Count);
             Assert.Equal(new LogMessage
             {
                 Level = (uint)__VSUL_ERRORLEVEL.VSUL_ERROR,
                 Project = "XprojMigrationTests",
-                File = xproj,
-                Message = $"Failed to migrate XProj project XprojMigrationTests. 'dotnet migrate -s -p \"{projectDirectory}\" -x \"{xproj}\"' exited with error code {VSConstants.E_FAIL}."
+                File = XprojLocation,
+                Message = $"Failed to migrate XProj project XprojMigrationTests. 'dotnet migrate -s -p \"{RootLocation}\" -x \"{XprojLocation}\"' exited with error code {VSConstants.E_FAIL}."
             }, loggedMessages[0]);
         }
 
         [Fact]
         public void MigrateXprojProjectFactory_ValidCsproj_FindsCsproj()
         {
-            var tuple = CreateTempProjectLocation();
-            var xproj = tuple.Item2;
-            var projectDir = tuple.Item4;
-            var csproj = Path.Combine(projectDir, "XprojMigrationTests.csproj");
+            var csproj = Path.Combine(RootLocation, "XprojMigrationTests.csproj");
+            var fileSystem = CreateFileSystem();
 
-            File.Create(csproj).Dispose();
+            fileSystem.Create(csproj);
 
             var loggedMessages = new List<LogMessage>();
             var logger = IVsUpgradeLoggerFactory.CreateLogger(loggedMessages);
-            var migrator = new MigrateXprojProjectFactory(ProcessRunnerFactory.CreateRunner());
+            var migrator = new MigrateXprojProjectFactory(ProcessRunnerFactory.CreateRunner(), fileSystem);
 
-            Assert.Equal(csproj, migrator.GetCsproj(projectDir, "XprojMigrationTests", xproj, logger));
+            Assert.Equal(csproj, migrator.GetCsproj(RootLocation, "XprojMigrationTests", XprojLocation, logger));
             Assert.Equal(0, loggedMessages.Count);
         }
 
         [Fact]
         public void MigrateXprojProjectFactory_NoCsproj_LogsError()
         {
-            var tuple = CreateTempProjectLocation();
-            var xproj = tuple.Item2;
-            var projectDir = tuple.Item4;
-            var csproj = Path.Combine(projectDir, "XprojMigrationTests.csproj");
+            var csproj = Path.Combine(RootLocation, "XprojMigrationTests.csproj");
+            var fileSystem = CreateFileSystem();
 
             var loggedMessages = new List<LogMessage>();
             var logger = IVsUpgradeLoggerFactory.CreateLogger(loggedMessages);
-            var migrator = new MigrateXprojProjectFactory(ProcessRunnerFactory.CreateRunner());
+            var migrator = new MigrateXprojProjectFactory(ProcessRunnerFactory.CreateRunner(), fileSystem);
 
-            Assert.Equal("", migrator.GetCsproj(projectDir, "XprojMigrationTests", xproj, logger));
+            Assert.Equal("", migrator.GetCsproj(RootLocation, "XprojMigrationTests", XprojLocation, logger));
             Assert.Equal(1, loggedMessages.Count);
             Assert.Equal(new LogMessage
             {
                 Level = (uint)__VSUL_ERRORLEVEL.VSUL_ERROR,
                 Project = "XprojMigrationTests",
-                File = xproj,
-                Message = $"Expected to find migrated cpsroj in {projectDir}, but did not find any."
+                File = XprojLocation,
+                Message = $"Expected to find migrated cpsroj in {RootLocation}, but did not find any."
             }, loggedMessages[0]);
         }
 
         [Fact]
         public void MigrateXprojProjectFactory_ValidProject_IsUpgradable()
         {
-            var tuple = CreateTempProjectLocation();
-            var xproj = tuple.Item2;
+            var fileSystem = CreateFileSystem();
 
             var loggedMessages = new List<LogMessage>();
             var logger = IVsUpgradeLoggerFactory.CreateLogger(loggedMessages);
@@ -214,28 +197,63 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
             Guid newProjectFactory;
             uint capabilityFlags;
 
-            var migrator = new MigrateXprojProjectFactory(ProcessRunnerFactory.CreateRunner());
+            var migrator = new MigrateXprojProjectFactory(ProcessRunnerFactory.CreateRunner(), fileSystem);
 
             Assert.Equal(VSConstants.S_OK,
-                migrator.UpgradeProject_CheckOnly(xproj, logger, out upgradeRequired, out newProjectFactory, out capabilityFlags));
+                migrator.UpgradeProject_CheckOnly(XprojLocation, logger, out upgradeRequired, out newProjectFactory, out capabilityFlags));
             Assert.Equal((int)__VSPPROJECTUPGRADEVIAFACTORYREPAIRFLAGS.VSPUVF_PROJECT_ONEWAYUPGRADE, upgradeRequired);
             Assert.Equal(Guid.Parse(CSharpProjectSystemPackage.ProjectTypeGuid), newProjectFactory);
             Assert.Equal((uint)(__VSPPROJECTUPGRADEVIAFACTORYFLAGS.PUVFF_BACKUPSUPPORTED | __VSPPROJECTUPGRADEVIAFACTORYFLAGS.PUVFF_COPYBACKUP),
                 capabilityFlags);
         }
 
-        private Tuple<string, string, string, string> CreateTempProjectLocation()
+        [Fact]
+        public void MigrateXprojProjectFactory_E2E_Works()
         {
-            var directory = Path.Combine(Path.GetTempPath(), $"XprojMigrationTests_{Guid.NewGuid().ToString()}");
-            Directory.CreateDirectory(directory);
-            var backupDirectory = Path.Combine(directory, "backup");
-            Directory.CreateDirectory(backupDirectory);
-            var xproj = Path.Combine(directory, "XprojMigrationTests.xproj");
-            File.Create(xproj).Dispose();
-            var projectJson = Path.Combine(directory, "project.json");
-            File.Create(projectJson).Dispose();
+            var fileSystem = CreateFileSystem();
+            var csproj = Path.Combine(BackupLocation, $"{ProjectName}.csproj");
+            var processRunner = ProcessRunnerFactory.ImplementRunner(pInfo =>
+            {
+                ProcessVerifier(pInfo);
+                fileSystem.Create(csproj);
+            });
 
-            return Tuple.Create(backupDirectory, xproj, projectJson, directory);
+            string outCsproj;
+            int upgradeRequired;
+            Guid newProjectFactory;
+
+            var loggedMessages = new List<LogMessage>();
+            var logger = IVsUpgradeLoggerFactory.CreateLogger(loggedMessages);
+
+            var migrator = new MigrateXprojProjectFactory(processRunner, fileSystem);
+
+            Assert.Equal(VSConstants.S_OK, migrator.UpgradeProject(XprojLocation, 0, BackupLocation, out outCsproj, logger, out upgradeRequired, out newProjectFactory));
+            Assert.True(fileSystem.FileExists(csproj));
+            Assert.True(fileSystem.FileExists(Path.Combine(BackupLocation, $"{ProjectName}.csproj")));
+            Assert.True(fileSystem.FileExists(Path.Combine(BackupLocation, "project.json")));
+            Assert.Equal(csproj, outCsproj);
+            Assert.Equal((int)__VSPPROJECTUPGRADEVIAFACTORYREPAIRFLAGS.VSPUVF_PROJECT_ONEWAYUPGRADE, upgradeRequired);
+            Assert.Equal(Guid.Parse(CSharpProjectSystemPackage.ProjectTypeGuid), newProjectFactory);
+        }
+
+        private void ProcessVerifier(ProcessStartInfo info)
+        {
+            Assert.Equal("dotnet.exe", info.FileName);
+            Assert.Equal($"migrate -s -p \"{RootLocation}\" -x \"{XprojLocation}\"", info.Arguments);
+        }
+
+        private IFileSystem CreateFileSystem(bool withEntries = true)
+        {
+            var fileSystem = new IFileSystemMock();
+            if (withEntries)
+            {
+                fileSystem.CreateDirectory(RootLocation);
+                fileSystem.CreateDirectory(BackupLocation);
+                fileSystem.Create(XprojLocation);
+                fileSystem.Create(ProjectJsonLocation);
+            }
+
+            return fileSystem;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.ProjectSystem.VS;
 using Microsoft.VisualStudio.ProjectSystem.VS.Generators;
 using Microsoft.VisualStudio.ProjectSystem.VS.Xproj;
@@ -45,7 +46,7 @@ namespace Microsoft.VisualStudio.Packaging
 
         protected override Tasks.Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
-            _factory = new MigrateXprojProjectFactory(new ProcessRunner());
+            _factory = new MigrateXprojProjectFactory(new ProcessRunner(), new FileSystem());
             _factory.SetSite(this);
             RegisterProjectFactory(_factory);
             return Tasks.Task.CompletedTask;


### PR DESCRIPTION
This fixes the flaky tests that were removed from yesterdays commit by properly disposing of file system objects, thanks @tannergooding. This also adds more tests for the rest of the migration functionality.

Tagging @dotnet/project-system @srivatsn for review.