### PR TITLE
Remove incorrect TargetFramework evaluation check in TF ProjectConfig…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -51,6 +51,7 @@
     <Compile Include="ProjectSystem\Debug\LaunchSettings.cs" />
     <Compile Include="ProjectSystem\Debug\LaunchSettingsData.cs" />
     <Compile Include="ProjectSystem\Debug\LaunchSettingsProvider.cs" />
+    <Compile Include="ProjectSystem\ProjectConfigurationsInferredFromUsageCapabilitiesProvider.cs" />
     <Compile Include="ProjectSystem\LanguageServices\CommandLineParserService.cs" />
     <Compile Include="ProjectSystem\LanguageServices\Handlers\CommandLineItemHandler.cs" />
     <Compile Include="ProjectSystem\LanguageServices\Handlers\MetadataReferenceItemHandler.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configurations/TargetFrameworkProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configurations/TargetFrameworkProjectConfigurationDimensionProvider.cs
@@ -6,6 +6,8 @@ using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Build
 {
@@ -50,27 +52,40 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
             return ImmutableArray.Create(new KeyValuePair<string, IEnumerable<string>>(TargetFrameworkPropertyName, targetFrameworks));
         }
 
+        private string GetProperty(ProjectRootElement projectRoot, string propertyName)
+        {
+            return projectRoot.Properties
+                .Where(p => string.Equals(p.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+                .Select(p => ProjectCollection.Unescape(p.Value)) // it was escaped on the way in, so unescape on the way out.
+                .FirstOrDefault();
+        }
+
         private async Task<ImmutableArray<string>> GetOrderedTargetFrameworksAsync(UnconfiguredProject project)
         {
             Requires.NotNull(project, nameof(project));
 
             using (var access = await _projectLockService.ReadLockAsync())
             {
-                var configuredProject = await project.GetSuggestedConfiguredProjectAsync().ConfigureAwait(false);
-                var msbuildProject = await access.GetProjectAsync(configuredProject).ConfigureAwait(false);
-                
-                // Read the "TargetFrameworks" properties from msbuild project evaluation.
-                var targetFrameworksProperty = msbuildProject.Properties
-                    .Where(p => p.Name.Equals(ConfigurationGeneral.TargetFrameworksProperty, StringComparison.OrdinalIgnoreCase))
-                    .LastOrDefault();
+                var projectRoot = await access.GetProjectXmlAsync(project.FullPath).ConfigureAwait(false);
 
-                if (targetFrameworksProperty == null)
+                // If the project already defines a specific "TargetFramework" to target, then this is not a cross-targeting project and we don't need a target framework dimension.
+                var targetFrameworkProperty = GetProperty(projectRoot, TargetFrameworkPropertyName);
+                if (!string.IsNullOrEmpty(targetFrameworkProperty))
+                {
+                    return ImmutableArray<string>.Empty;
+                }
+
+                // Read the "TargetFrameworks" property from the project file.
+                // TODO: https://github.com/dotnet/roslyn-project-system/issues/547
+                //       We should read the "TargetFrameworks" properties from msbuild project evaluation at unconfigured project level, but there doesn't seem to be a way to do so.
+                var targetFrameworksProperty = GetProperty(projectRoot, ConfigurationGeneral.TargetFrameworksProperty);
+                if (string.IsNullOrEmpty(targetFrameworksProperty))
                 {
                     return ImmutableArray<string>.Empty;
                 }
 
                 // TargetFrameworks contains semicolon delimited list of frameworks, for example "net45;netcoreapp1.0;netstandard1.4"
-                var targetFrameworksValue = targetFrameworksProperty.EvaluatedValue.Split(';').Select(f => f.Trim());
+                var targetFrameworksValue = targetFrameworksProperty.Split(';').Select(f => f.Trim());
 
                 // We need to ensure that we return the target frameworks in the specified order.
                 var targetFrameworksBuilder = ImmutableArray.CreateBuilder<string>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configurations/TargetFrameworkProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configurations/TargetFrameworkProjectConfigurationDimensionProvider.cs
@@ -59,12 +59,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
                 var configuredProject = await project.GetSuggestedConfiguredProjectAsync().ConfigureAwait(false);
                 var msbuildProject = await access.GetProjectAsync(configuredProject).ConfigureAwait(false);
                 
-                // If the project already defines a specific "TargetFramework" to target, then this is not a cross-targeting project and we don't need a target framework dimension.
-                if (msbuildProject.Properties.Any(p => p.Name.Equals(TargetFrameworkPropertyName, StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(p.EvaluatedValue)))
-                {
-                    return ImmutableArray<string>.Empty;
-                }
-
                 // Read the "TargetFrameworks" properties from msbuild project evaluation.
                 var targetFrameworksProperty = msbuildProject.Properties
                     .Where(p => p.Name.Equals(ConfigurationGeneral.TargetFrameworksProperty, StringComparison.OrdinalIgnoreCase))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectConfigurationsInferredFromUsageCapabilitiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectConfigurationsInferredFromUsageCapabilitiesProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Threading;
@@ -11,12 +12,21 @@ namespace Microsoft.VisualStudio.ProjectSystem
     [AppliesTo(ProjectCapabilities.AlwaysApplicable)]
     internal sealed class ProjectConfigurationsInferredFromUsageCapabilitiesProvider : UnconfiguredProjectCapabilitiesProviderBase
     {
-        private static readonly ImmutableHashSet<string> _capabilities = ImmutableHashSet<string>.Empty.Add(ProjectCapabilities.ProjectConfigurationsInferredFromUsage);
+        private readonly ImmutableHashSet<string> _capabilities;
 
         [ImportingConstructor]
-        public ProjectConfigurationsInferredFromUsageCapabilitiesProvider(UnconfiguredProject unconfiguedProject)
-            : base(typeof(ProjectConfigurationsInferredFromUsageCapabilitiesProvider).Name, unconfiguedProject)
+        public ProjectConfigurationsInferredFromUsageCapabilitiesProvider(UnconfiguredProject unconfiguredProject)
+            : base(typeof(ProjectConfigurationsInferredFromUsageCapabilitiesProvider).Name, unconfiguredProject)
         {
+            var capabilities = ImmutableHashSet<string>.Empty;
+            if (unconfiguredProject.FullPath != null &&
+                (unconfiguredProject.FullPath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase) ||
+                unconfiguredProject.FullPath.EndsWith(".vbproj", StringComparison.OrdinalIgnoreCase)))
+            {
+                capabilities = capabilities.Add(ProjectCapabilities.ProjectConfigurationsInferredFromUsage);
+            }
+
+            _capabilities = capabilities;
         }
 
         protected override Task<ImmutableHashSet<string>> GetCapabilitiesAsync(CancellationToken cancellationToken)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectConfigurationsInferredFromUsageCapabilitiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectConfigurationsInferredFromUsageCapabilitiesProvider.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectCapabilitiesProvider))]
+    [AppliesTo(ProjectCapabilities.AlwaysApplicable)]
+    internal sealed class ProjectConfigurationsInferredFromUsageCapabilitiesProvider : UnconfiguredProjectCapabilitiesProviderBase
+    {
+        private static readonly ImmutableHashSet<string> _capabilities = ImmutableHashSet<string>.Empty.Add(ProjectCapabilities.ProjectConfigurationsInferredFromUsage);
+
+        [ImportingConstructor]
+        public ProjectConfigurationsInferredFromUsageCapabilitiesProvider(UnconfiguredProject unconfiguedProject)
+            : base(typeof(ProjectConfigurationsInferredFromUsageCapabilitiesProvider).Name, unconfiguedProject)
+        {
+        }
+
+        protected override Task<ImmutableHashSet<string>> GetCapabilitiesAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_capabilities);
+        }
+    }
+}


### PR DESCRIPTION
…urationDimensionProvider - this property will always be set by our props file during evaluation.

Fixes #539