### PR TITLE
Revert "Add dependency on MinShell"

### DIFF
--- a/src/VsixV3/EditorsPackage/Microsoft.VisualStudio.Editors.swr
+++ b/src/VsixV3/EditorsPackage/Microsoft.VisualStudio.Editors.swr
@@ -13,7 +13,3 @@ vs.localizedResources
 
 vs.payloads
   vs.payload source=$(OutputPath)\VisualStudioEditorsSetup.vsix
-
-# Needed so VSIXInstaller is around on uninstall
-vs.dependencies
-  vs.dependency id=Microsoft.VisualStudio.MinShell


### PR DESCRIPTION
Reverts dotnet/roslyn-project-system#546
Looks like we can't depend on MinShell without changing some validation logic in microBuild itself