### PR TITLE
Skip first time setup during migration

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Mocks/ProcessRunnerFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Mocks/ProcessRunnerFactory.cs
@@ -29,8 +29,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
             processMock.Setup(p => p.ExitCode).Returns(exitCode);
 
             // Mock standard output and standard error
-            processMock.Setup(p => p.StandardOutput).Returns(new System.IO.StringReader(outputText));
-            processMock.Setup(p => p.StandardError).Returns(new System.IO.StringReader(errorText));
+            processMock.Setup(p => p.AddOutputDataReceivedHandler(It.IsAny<Action<string>>())).Callback<Action<string>>(h =>
+            {
+                if (!string.IsNullOrWhiteSpace(outputText)) h(outputText);
+            });
+            processMock.Setup(p => p.AddErrorDataReceivedHandler(It.IsAny<Action<string>>())).Callback<Action<string>>(h =>
+            {
+                if (!string.IsNullOrWhiteSpace(errorText)) h(errorText);
+            });
 
             return processMock.Object;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
@@ -240,6 +240,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         {
             Assert.Equal("dotnet.exe", info.FileName);
             Assert.Equal($"migrate -s -x \"{XprojLocation}\" \"{RootLocation}\"", info.Arguments);
+            Assert.True(info.EnvironmentVariables.ContainsKey("DOTNET_SKIP_FIRST_TIME_EXPERIENCE"));
+            Assert.Equal("true", info.EnvironmentVariables["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"]);
         }
 
         private IFileSystem CreateFileSystem(bool withEntries = true)

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
@@ -115,7 +115,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
             // Skip it.
             pInfo.EnvironmentVariables.Add("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "true");
 
-
             var process = _runner.Start(pInfo);
 
             // Create strings to hold the output and error text

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
@@ -109,6 +109,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
             pInfo.UseShellExecute = false;
             pInfo.RedirectStandardError = true;
             pInfo.RedirectStandardOutput = true;
+
+            // First time setup isn't necessary for migration, and causes a long pause with no indication anything is happening.
+            // Skip it.
+            pInfo.EnvironmentVariables.Add("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "true");
+
             var process = _runner.Start(pInfo);
             process.WaitForExit();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/ProcessRunner.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/ProcessRunner.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using System.IO;
 
@@ -36,10 +37,30 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
 
         public virtual int ExitCode => _process.ExitCode;
 
-        // Note: for ease of mocking, these are changed from StreamReader to TextReader, as TextReader exposes all the APIs we need
-        // and can be mocked by Moq.
-        public virtual TextReader StandardOutput => _process.StandardOutput;
+        public virtual void AddOutputDataReceivedHandler(Action<string> handler)
+        {
+            _process.OutputDataReceived += new DataReceivedEventHandler((sender, o) =>
+            {
+                handler(o.Data);
+            });
+        }
 
-        public virtual TextReader StandardError => _process.StandardError;
+        public virtual void AddErrorDataReceivedHandler(Action<string> handler)
+        {
+            _process.ErrorDataReceived += new DataReceivedEventHandler((sender, e) =>
+            {
+                handler(e.Data);
+            });
+        }
+
+        public virtual void BeginOutputReadLine()
+        {
+            _process.BeginOutputReadLine();
+        }
+
+        public virtual void BeginErrorReadLine()
+        {
+            _process.BeginOutputReadLine();
+        }
     }
 }


### PR DESCRIPTION
Package restore isn't needed during migration, so we skip first time setup to save a bunch of time and fix #548. First time setup appears to hang when not running as a shell host.

Tagging @dotnet/project-system @srivatsn for review, /cc @livarcocc.