### PR TITLE
Ensure that TargetFrameworkProjectConfigurationDimensionProvider gets…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configurations/TargetFrameworkProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configurations/TargetFrameworkProjectConfigurationDimensionProvider.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
     /// Provides "TargetFramework" project configuration dimension and values.
     /// </summary>
     [Export(typeof(IProjectConfigurationDimensionsProvider))]
-    [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
+    [AppliesTo(ProjectCapabilities.ProjectConfigurationsInferredFromUsage)]
     internal class TargetFrameworkProjectConfigurationDimensionProvider : IProjectConfigurationDimensionsProvider
     {
         internal const string TargetFrameworkPropertyName = "TargetFramework";


### PR DESCRIPTION
… loaded with ImplicitProjectConfigurationsService by adding the matching capability