### PR TITLE
Fix design time build.

### DIFF
--- a/src/Targets/Microsoft.CSharp.DesignTime.targets
+++ b/src/Targets/Microsoft.CSharp.DesignTime.targets
@@ -34,7 +34,7 @@
     <Target Name="CompileDesignTime"
             Returns="@(_CompilerCommandLineArgs)"
             DependsOnTargets="_CheckCompileDesignTimePrerequisite;Compile"
-            Condition="'$(IsCrossTargetingBuild)' == 'false'"
+            Condition="'$(IsCrossTargetingBuild)' != 'true'"
           >
 
       <ItemGroup>

--- a/src/Targets/Microsoft.VisualBasic.DesignTime.targets
+++ b/src/Targets/Microsoft.VisualBasic.DesignTime.targets
@@ -34,7 +34,7 @@
     <Target Name="CompileDesignTime"
             Returns="@(_CompilerCommandLineArgs)"
             DependsOnTargets="_CheckCompileDesignTimePrerequisite;Compile"
-            Condition="'$(IsCrossTargetingBuild)' == 'false'"
+            Condition="'$(IsCrossTargetingBuild)' != 'true'"
           >
 
       <ItemGroup>


### PR DESCRIPTION
 IsCrossTargeting is only defined in the outer build as true and is empty in the inner build. The condition was incorrect. Fixing this causing intellisense to come back again

@dotnet/project-system 