### PR TITLE
Add dependency on MinShell

### DIFF
--- a/src/VsixV3/EditorsPackage/Microsoft.VisualStudio.Editors.swr
+++ b/src/VsixV3/EditorsPackage/Microsoft.VisualStudio.Editors.swr
@@ -13,3 +13,7 @@ vs.localizedResources
 
 vs.payloads
   vs.payload source=$(OutputPath)\VisualStudioEditorsSetup.vsix
+
+# Needed so VSIXInstaller is around on uninstall
+vs.dependencies
+  vs.dependency id=Microsoft.VisualStudio.MinShell

--- a/src/VsixV3/EditorsPackage/Microsoft.VisualStudio.Editors.vsmanproj
+++ b/src/VsixV3/EditorsPackage/Microsoft.VisualStudio.Editors.vsmanproj
@@ -10,6 +10,8 @@
     <OutputPath>$(OutDir)\VsixV3</OutputPath>
     <IsPackage>true</IsPackage>
     <UseVisualStudioVersion>true</UseVisualStudioVersion>
+    <FinalizeValidate>false</FinalizeValidate>
+    <ValidateManifest>false</ValidateManifest>
   </PropertyGroup>
 
   <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildVersion)\build\MicroBuild.Core.props" />
@@ -22,4 +24,6 @@
   <ItemGroup>
     <MergeManifest Include="$(OutputPath)\Microsoft.VisualStudio.Editors.json" />
   </ItemGroup>
+
+  <Target Name="ValidateManifest" />
 </Project>

--- a/src/VsixV3/ProjectSystemPackage/Microsoft.VisualStudio.ProjectSystem.Managed.swr
+++ b/src/VsixV3/ProjectSystemPackage/Microsoft.VisualStudio.ProjectSystem.Managed.swr
@@ -13,3 +13,7 @@ vs.localizedResources
 
 vs.payloads
   vs.payload source=$(OutputPath)\ProjectSystem.vsix
+
+# Needed so VSIXInstaller is around on uninstall
+vs.dependencies
+  vs.dependency id=Microsoft.VisualStudio.MinShell

--- a/src/VsixV3/ProjectSystemPackage/Microsoft.VisualStudio.ProjectSystem.Managed.vsmanproj
+++ b/src/VsixV3/ProjectSystemPackage/Microsoft.VisualStudio.ProjectSystem.Managed.vsmanproj
@@ -9,6 +9,8 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <OutputPath>$(OutDir)\VsixV3</OutputPath>
     <IsPackage>true</IsPackage>
+    <FinalizeValidate>false</FinalizeValidate>
+    <ValidateManifest>false</ValidateManifest>
   </PropertyGroup>
 
   <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildVersion)\build\MicroBuild.Core.props" />
@@ -23,4 +25,6 @@
     <MergeManifest Include="$(OutputPath)\Microsoft.VisualStudio.ProjectSystem.Managed.json" />
     <MergeManifest Include="$(OutputPath)\Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles.json" />
   </ItemGroup>
+
+  <Target Name="ValidateManifest" />
 </Project>


### PR DESCRIPTION
Add dependency on MinShell and disable package validation as MinShell doesn't exist in the repository.

Without this dependency VSIXInstaller may not be around on uninstall, causing it to fail