### PR TITLE
Add CodeModel support for language service

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -36,6 +36,7 @@
     <Compile Include="Input\VisualStudioStandard97CommandId.cs" />
     <Compile Include="ProjectSystem\VS\Debug\ConsoleDebugTargetsProvider.cs" />
     <Compile Include="ProjectSystem\VS\Debug\ErrorProfileDebugTargetsProvider.cs" />
+    <Compile Include="ProjectSystem\VS\LanguageServices\ProjectContextCodeModelProvider.cs" />
     <Compile Include="ProjectSystem\VS\LanguageServices\VsContainedLanguageComponentsFactoryBase.cs" />
     <Compile Include="ProjectSystem\VS\LanguageServices\IVsContainedLanguageComponentsFactory.cs" />
     <Compile Include="Packaging\ManagedProjectSystemPackage.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ProjectContextCodeModelProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ProjectContextCodeModelProvider.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using EnvDTE;
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
+{
+    /// <summary>
+    ///     Adapts CPS's <see cref="ICodeModelProvider"/> and <see cref="IProjectCodeModelProvider"/> to Roslyn's <see cref="ICodeModelFactory"/> implementation.
+    /// </summary>
+    [Export(typeof(ICodeModelProvider))]
+    [Export(typeof(IProjectCodeModelProvider))]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicLanguageService)]
+    internal class ProjectContextCodeModelProvider : ICodeModelProvider, IProjectCodeModelProvider
+    {
+        private readonly ICodeModelFactory _codeModelFactory;
+        private readonly ILanguageServiceHost _languageServiceHost;
+
+        [ImportingConstructor]
+        public ProjectContextCodeModelProvider(ICodeModelFactory codeModelFactory, ILanguageServiceHost languageServiceHost)
+        {
+            Requires.NotNull(codeModelFactory, nameof(codeModelFactory));
+            Requires.NotNull(languageServiceHost, nameof(languageServiceHost));
+
+            _codeModelFactory = codeModelFactory;
+            _languageServiceHost = languageServiceHost;
+        }
+
+        public CodeModel GetCodeModel(Project project)
+        {
+            Requires.NotNull(project, nameof(project));
+
+            IWorkspaceProjectContext projectContext = _languageServiceHost.ProjectContext;
+            if (projectContext == null)
+                return null;
+
+            return _codeModelFactory.GetCodeModel(projectContext, project);
+        }
+
+        public FileCodeModel GetFileCodeModel(ProjectItem fileItem)
+        {
+            Requires.NotNull(fileItem, nameof(fileItem));
+
+            IWorkspaceProjectContext projectContext = _languageServiceHost.ProjectContext;
+            if (projectContext == null)
+                return null;
+
+            return _codeModelFactory.GetFileCodeModel(projectContext, fileItem);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ILanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ILanguageServiceHost.cs
@@ -22,5 +22,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         {
             get;
         }
+
+        /// <summary>
+        ///     Gets the workspace project context that provides access to the language service.
+        /// </summary>
+        /// <value>
+        ///     An <see cref="IWorkspaceProjectContext"/> that providers access to the language service.
+        /// </value>
+        IWorkspaceProjectContext ProjectContext
+        {
+            get;
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -52,6 +52,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             get { return _projectContext; }
         }
 
+        public IWorkspaceProjectContext ProjectContext
+        {
+            get { return _projectContext; }
+        }
+
         [ImportMany]
         public OrderPrecedenceImportCollection<ILanguageServiceRuleHandler> Handlers
         {


### PR DESCRIPTION
Fixes #480 

Tests are blocked by the InternalsVisibleTo support that I added a few weeks ago and will add them in: https://github.com/dotnet/roslyn-project-system/issues/483