### PR TITLE
Read TemplateLanguage from design-time targets 

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectThreadingServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectThreadingServiceFactory.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
@@ -8,6 +10,16 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public static IProjectThreadingService Create()
         {
             return new IProjectThreadingServiceMock();
+        }
+
+        public static IProjectThreadingService ImplementVerifyOnUIThread(Action action)
+        {
+            var mock = new Mock<IProjectThreadingService>();
+
+            mock.Setup(s => s.VerifyOnUIThread())
+                .Callback(action);
+
+            return mock.Object;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectPropertiesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectPropertiesFactory.cs
@@ -12,7 +12,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class ProjectPropertiesFactory
     {
-        public static ProjectProperties CreateEmpty() => Mock.Of<ProjectProperties>();
+        public static ProjectProperties CreateEmpty()
+        {
+            return Create(IUnconfiguredProjectFactory.Create());
+        }
 
         public static ProjectProperties Create(UnconfiguredProject unconfiguredProject, params PropertyPageData[] data)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Mocks\IActiveConfiguredProjectSubscriptionServiceFactory.cs" />
     <Compile Include="Mocks\IDebugLaunchProviderFactory.cs" />
     <Compile Include="Mocks\IDebugLaunchProviderMetadataViewFactory.cs" />
+    <Compile Include="Mocks\IDteServicesFactory.cs" />
     <Compile Include="Mocks\IOutputGroupsFactory.cs" />
     <Compile Include="Mocks\IProjectCapabilitiesScopeFactory.cs" />
     <Compile Include="CollectionsExtensions.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -49,6 +49,7 @@
     <Compile Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Properties\AssemblyAttributes.cs">
       <Link>Properties\AssemblyAttributes.cs</Link>
     </Compile>
+    <Compile Include="Mocks\DteFactory.cs" />
     <Compile Include="Mocks\IActiveConfiguredProjectSubscriptionServiceFactory.cs" />
     <Compile Include="Mocks\IDebugLaunchProviderFactory.cs" />
     <Compile Include="Mocks\IDebugLaunchProviderMetadataViewFactory.cs" />
@@ -69,6 +70,7 @@
     <Compile Include="Mocks\IProjectValueDataSourceFactory.cs" />
     <Compile Include="Mocks\DataFlowExtensionMethodWrapperMock.cs" />
     <Compile Include="Mocks\IRoslynServicesFactory.cs" />
+    <Compile Include="Mocks\IServiceProviderFactory.cs" />
     <Compile Include="Mocks\IServiceProviderMoq.cs" />
     <Compile Include="Mocks\IVsSolutionFactory.cs" />
     <Compile Include="Mocks\IVsFileChangeExFactory.cs" />
@@ -112,6 +114,7 @@
     <Compile Include="ProjectSystem\VS\UI\MultiChoiceMsgBoxViewModelTests.cs" />
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\DependencyNodeTests.cs" />
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\DependencyNodeIdTests.cs" />
+    <Compile Include="ProjectSystem\VS\DteServicesTests.cs" />
     <Compile Include="ProjectSystem\VS\UnconfiguredProjectVsServicesTests.cs" />
     <Compile Include="ProjectSystem\VS\Properties\ProjectDesignerServiceTests.cs" />
     <Compile Include="Shell\HierarchyIdTests.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/DteFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/DteFactory.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using EnvDTE;
+using Moq;
+
+namespace EnvDTE80
+{
+    internal static class DteFactory
+    {
+        public static DTE Create()
+        {
+            var mock = new Mock<DTE2>();
+
+            return mock.As<DTE>().Object;
+        }
+
+        public static DTE2 ImplementSolution(Func<Solution> action)
+        {
+            var mock = new Mock<DTE2>();
+            mock.As<DTE>();
+
+            mock.SetupGet(m => m.Solution)
+                .Returns(action);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDteServicesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDteServicesFactory.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using EnvDTE80;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    internal static class IDteServicesFactory
+    {
+        public static IDteServices Create()
+        {
+            return Mock.Of<IDteServices>();
+        }
+
+        public static IDteServices ImplementSolution(Func<Solution2> solution)
+        {
+            var mock = new Mock<IDteServices>();
+            mock.SetupGet(s => s.Solution)
+                .Returns(solution);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IServiceProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IServiceProviderFactory.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Moq;
+
+namespace Microsoft.VisualStudio
+{
+    internal static class IServiceProviderFactory
+    {
+        public static IServiceProvider Create(Type type, object instance)
+        {
+            return ImplementGetService(t => {
+
+                if (t == type)
+                    return instance;
+
+                return null;
+            });
+        }
+
+        public static IServiceProvider ImplementGetService(Func<Type, object> func)
+        {
+            var mock = new Mock<IServiceProvider>();
+            mock.Setup(sp => sp.GetService(It.IsAny<Type>()))
+                .Returns(func);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IUnconfiguredProjectVsServicesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IUnconfiguredProjectVsServicesFactory.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             return Mock.Of<IUnconfiguredProjectVsServices>();
         }
 
-        public static IUnconfiguredProjectVsServices Implement(Func<IVsHierarchy> hierarchyCreator = null, Func<IVsProject4> projectCreator = null, Func<ProjectProperties> projectProperties = null)
+        public static IUnconfiguredProjectVsServices Implement(Func<IVsHierarchy> hierarchyCreator = null, Func<IVsProject4> projectCreator = null, Func<IProjectThreadingService> threadingServiceCreator = null, Func<ProjectProperties> projectProperties = null)
         {
             var mock = new Mock<IUnconfiguredProjectVsServices>();
             if (hierarchyCreator != null)
@@ -22,8 +22,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                     .Returns(hierarchyCreator);
             }
 
+            var threadingService = threadingServiceCreator == null ? IProjectThreadingServiceFactory.Create() : threadingServiceCreator();
+
             mock.SetupGet(h => h.ThreadingService)
-                .Returns(IProjectThreadingServiceFactory.Create());
+                .Returns(threadingService);
 
             if (projectCreator != null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ProjectFactory.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using EnvDTE;
+using EnvDTE80;
 using Moq;
 
-namespace Microsoft.VisualStudio.Mocks
+namespace EnvDTE
 {
     internal static class ProjectFactory
     {
@@ -13,11 +13,11 @@ namespace Microsoft.VisualStudio.Mocks
             return Mock.Of<Project>();
         }
 
-        public static Project CreateWithSolution(Solution solution)
+        public static Project CreateWithSolution(Solution2 solution)
         {
             var mock = new Mock<Project>();
 
-            mock.SetupGet(p => p.DTE.Solution).Returns(solution);
+            mock.SetupGet(p => p.DTE.Solution).Returns((Solution)solution);
 
             return mock.Object;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/SolutionFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/SolutionFactory.cs
@@ -2,19 +2,23 @@
 
 using System;
 using EnvDTE;
-using EnvDTE80;
 using Moq;
 
-namespace Microsoft.VisualStudio.Mocks
+namespace EnvDTE80
 {
     internal static class SolutionFactory
     {
-        public static Solution CreateWithGetProjectItemTemplate(Func<string, string, string> projectItemsTemplatePathFunc)
+        public static Solution Create()
         {
-            var mock = new Mock<Solution>();
+            var mock = new Mock<Solution2>();
+            return mock.As<Solution>().Object;
+        }
 
-            mock.As<Solution2>()
-                .Setup(s => s.GetProjectItemTemplate(It.IsAny<string>(), It.IsAny<string>()))
+        public static Solution2 CreateWithGetProjectItemTemplate(Func<string, string, string> projectItemsTemplatePathFunc)
+        {
+            var mock = new Mock<Solution2>();
+            mock.As<Solution>();
+            mock.Setup(s => s.GetProjectItemTemplate(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(projectItemsTemplatePathFunc);
 
             return mock.Object;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/CreateFileFromTemplateServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/CreateFileFromTemplateServiceTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Threading.Tasks;
 using EnvDTE;
+using EnvDTE80;
 using Microsoft.VisualStudio.Mocks;
 using Microsoft.VisualStudio.Shell.Interop;
 using Xunit;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DteServicesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DteServicesTests.cs
@@ -1,0 +1,135 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using EnvDTE;
+using EnvDTE80;
+using Microsoft.VisualStudio.Mocks;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    [ProjectSystemTrait]
+    public class DteServicesTests
+    {
+        [Fact]
+        public void Constructor_NullAsServiceProvider_ThrowsArgumentNull()
+        {
+            var projectVsServices = IUnconfiguredProjectVsServicesFactory.Create();
+
+            Assert.Throws<ArgumentNullException>("serviceProvider", () => {
+                new DteServices((IServiceProvider)null, projectVsServices);
+            });
+        }
+
+        [Fact]
+        public void Constructor_NullAsProjectVsServices_ThrowsArgumentNull()
+        {
+            var serviceProvider = SVsServiceProviderFactory.Create();
+
+            Assert.Throws<ArgumentNullException>("projectVsServices", () => {
+                new DteServices(serviceProvider, (IUnconfiguredProjectVsServices)null);
+            });
+        }
+
+        [Fact]
+        public void DTE_WhenNotOnUIThread_Throws()
+        {
+            var threadingService = IProjectThreadingServiceFactory.ImplementVerifyOnUIThread(() => { throw new InvalidOperationException(); });
+            var projectVsServices = IUnconfiguredProjectVsServicesFactory.Implement(threadingServiceCreator: () => threadingService);
+
+            var dteServices = CreateInstance(projectVsServices);
+
+            Assert.Throws<InvalidOperationException>(() => {
+
+                var ignored = dteServices.Dte;
+            });
+        }
+
+        [Fact]
+        public void Solution_WhenNotOnUIThread_Throws()
+        {
+            var threadingService = IProjectThreadingServiceFactory.ImplementVerifyOnUIThread(() => { throw new InvalidOperationException(); });
+            var projectVsServices = IUnconfiguredProjectVsServicesFactory.Implement(threadingServiceCreator: () => threadingService);
+
+            var dteServices = CreateInstance(projectVsServices);
+
+            Assert.Throws<InvalidOperationException>(() => {
+
+                var ignored = dteServices.Solution;
+            });
+        }
+
+        [Fact]
+        public void Project_WhenNotOnUIThread_Throws()
+        {
+            var threadingService = IProjectThreadingServiceFactory.ImplementVerifyOnUIThread(() => { throw new InvalidOperationException(); });
+            var projectVsServices = IUnconfiguredProjectVsServicesFactory.Implement(threadingServiceCreator: () => threadingService);
+
+            var dteServices = CreateInstance(projectVsServices);
+
+            Assert.Throws<InvalidOperationException>(() => {
+
+                var ignored = dteServices.Project;
+            });
+        }
+
+        [Fact]
+        public void DTE_ReturnsServiceProviderGetService()
+        {
+            var dte = DteFactory.Create();
+            var serviceProvider = IServiceProviderFactory.Create(typeof(SDTE), dte);
+
+            var dteServices = CreateInstance(serviceProvider);
+
+            var result = dteServices.Dte;
+
+            Assert.Same(dte, result);
+        }
+
+        [Fact]
+        public void Solution_ReturnsServiceProviderGetService()
+        {
+            var solution = SolutionFactory.Create();
+            var dte = DteFactory.ImplementSolution(() => solution);
+            var serviceProvider = IServiceProviderFactory.Create(typeof(SDTE), dte);
+
+            var dteServices = CreateInstance(serviceProvider);
+
+            var result = dteServices.Solution;
+
+            Assert.Same(solution, result);
+        }
+
+        [Fact]
+        public void Project_ReturnsVsHierarchyGetProperty()
+        {
+            var project = ProjectFactory.Create();
+            var hierarchy = IVsHierarchyFactory.Create();
+            hierarchy.ImplementGetProperty(VsHierarchyPropID.ExtObject, project);
+            var threadingService = IProjectThreadingServiceFactory.ImplementVerifyOnUIThread(() => { });
+            var projectVsServices = IUnconfiguredProjectVsServicesFactory.Implement(hierarchyCreator: () => hierarchy, threadingServiceCreator: () => threadingService);
+
+            var dteServices = CreateInstance(projectVsServices);
+
+            var result = dteServices.Project;
+
+            Assert.Same(project, result);
+        }
+
+        private DteServices CreateInstance(IUnconfiguredProjectVsServices projectVsServices)
+        {
+            return new DteServices(SVsServiceProviderFactory.Create(), projectVsServices);
+        }
+
+        private DteServices CreateInstance(IServiceProvider serviceProvider)
+        {
+            var threadingService = IProjectThreadingServiceFactory.ImplementVerifyOnUIThread(() => { });
+            var projectVsServices = IUnconfiguredProjectVsServicesFactory.Implement(threadingServiceCreator: () => threadingService);
+
+            return new DteServices(serviceProvider, projectVsServices);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -36,6 +36,8 @@
     <Compile Include="Input\VisualStudioStandard97CommandId.cs" />
     <Compile Include="ProjectSystem\VS\Debug\ConsoleDebugTargetsProvider.cs" />
     <Compile Include="ProjectSystem\VS\Debug\ErrorProfileDebugTargetsProvider.cs" />
+    <Compile Include="ProjectSystem\VS\DteServices.cs" />
+    <Compile Include="ProjectSystem\VS\IDteServices.cs" />
     <Compile Include="ProjectSystem\VS\LanguageServices\VsContainedLanguageComponentsFactoryBase.cs" />
     <Compile Include="ProjectSystem\VS\LanguageServices\IVsContainedLanguageComponentsFactory.cs" />
     <Compile Include="Packaging\ManagedProjectSystemPackage.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DteServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DteServices.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using EnvDTE;
+using EnvDTE80;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    [Export(typeof(IDteServices))]
+    internal class DteServices : IDteServices
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly IUnconfiguredProjectVsServices _projectVsServices;
+
+        [ImportingConstructor]
+        public DteServices([Import(typeof(SVsServiceProvider))]IServiceProvider serviceProvider, IUnconfiguredProjectVsServices projectVsServices)
+        {
+            Requires.NotNull(serviceProvider, nameof(serviceProvider));
+            Requires.NotNull(projectVsServices, nameof(projectVsServices));
+
+            _serviceProvider = serviceProvider;
+            _projectVsServices = projectVsServices;            
+        }
+
+        public DTE2 Dte
+        {
+            get
+            {
+                _projectVsServices.ThreadingService.VerifyOnUIThread();
+
+                return _serviceProvider.GetService<DTE2, SDTE>();
+            }
+        }
+
+        public Solution2 Solution
+        {
+            get { return (Solution2)Dte.Solution; }
+        }
+
+        public Project Project
+        {
+            get
+            {
+                _projectVsServices.ThreadingService.VerifyOnUIThread();
+
+                return _projectVsServices.VsHierarchy.GetProperty<Project>(VsHierarchyPropID.ExtObject);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IDteServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IDteServices.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Runtime.InteropServices;
+using EnvDTE;
+using EnvDTE80;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <summary>
+    ///     Provides access to common Visual Studio automation objects.
+    /// </summary>
+    internal interface IDteServices
+    {
+        /// <summary>
+        ///     Gets the top-level object in the Visual Studio automation object model.
+        /// </summary>
+        /// <exception cref="COMException">
+        ///     This property was not access from the UI thread.
+        /// </exception>
+        DTE2 Dte
+        {
+            get;
+        }
+
+        /// <summary>
+        ///     Gets the current solution.
+        /// </summary>
+        /// <exception cref="COMException">
+        ///     This property was not access from the UI thread.
+        /// </exception>
+        Solution2 Solution
+        {
+            get;
+        }
+
+        /// <summary>
+        ///     Gets the current project.
+        /// </summary>
+        /// <exception cref="COMException">
+        ///     This property was not access from the UI thread.
+        /// </exception>
+        Project Project
+        {
+
+            get;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/VsHierarchyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/VsHierarchyExtensions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
         /// <summary>
         ///     Gets the value of the specified property if the hierarchy supports it.
         /// </summary>
-        public static T GetProperty<T>(this IVsHierarchy hierarchy, VsHierarchyPropID property, T defaultValue)
+        public static T GetProperty<T>(this IVsHierarchy hierarchy, VsHierarchyPropID property, T defaultValue = default(T))
         {
             return GetProperty(hierarchy, HierarchyId.Root, property, defaultValue);
         }
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
         /// <summary>
         ///     Gets the value of the specified property if the hierarchy supports it.
         /// </summary>
-        public static T GetProperty<T>(this IVsHierarchy hierarchy, HierarchyId item, VsHierarchyPropID property, T defaultValue)
+        public static T GetProperty<T>(this IVsHierarchy hierarchy, HierarchyId item, VsHierarchyPropID property, T defaultValue = default(T))
         {
             Requires.NotNull(hierarchy, nameof(hierarchy));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -118,6 +118,7 @@
     <StringProperty Name="SharedProjectAppliesTo" Visible="False" Description="Capability match expression that at a minimum tests for the language of the Shared Project; used to filter Add Shared Project Reference choices."/>
     <BoolProperty Name="AlwaysUseNumericalSuffixInItemNames" Visible="False" Description="Indicates if names of newly added items should always be suffixed with a number." />
 
-  <!-- Represents the "LanguageName" that is passed to Roslyn -->
-  <StringProperty Name="LanguageServiceName" ReadOnly="True" Visible="False" />
+  
+  <StringProperty Name="LanguageServiceName" ReadOnly="True" Visible="False" /> <!-- Represents the "LanguageName" that is passed to Roslyn -->
+  <StringProperty Name="TemplateLanguage" ReadOnly="True" Visible="False" /> <!-- Represent the language that is persisted in items and project templates -->
 </Rule>

--- a/src/Targets/Microsoft.CSharp.DesignTime.targets
+++ b/src/Targets/Microsoft.CSharp.DesignTime.targets
@@ -14,6 +14,7 @@
     <AppDesignerFolder Condition="'$(AppDesignerFolder)' == ''">Properties</AppDesignerFolder>
     <AppDesignerFolderContentsVisibleOnlyInShowAllFiles Condition="'$(AppDesignerFolderContentsVisibleOnlyInShowAllFiles)' == ''">false</AppDesignerFolderContentsVisibleOnlyInShowAllFiles>
     <LanguageServiceName Condition="'$(LanguageServiceName)' == ''">C#</LanguageServiceName>
+    <TemplateLanguage Condition="'$(TemplateLanguage)' == ''">CSharp</TemplateLanguage>
   </PropertyGroup>
 
     <ItemGroup>

--- a/src/Targets/Microsoft.VisualBasic.DesignTime.targets
+++ b/src/Targets/Microsoft.VisualBasic.DesignTime.targets
@@ -14,6 +14,7 @@
     <AppDesignerFolder Condition="'$(AppDesignerFolder)' == ''">My Project</AppDesignerFolder>
     <AppDesignerFolderContentsVisibleOnlyInShowAllFiles Condition="'$(AppDesignerFolderContentsVisibleOnlyInShowAllFiles)' == ''">true</AppDesignerFolderContentsVisibleOnlyInShowAllFiles>
     <LanguageServiceName Condition="'$(LanguageServiceName)' == ''">Visual Basic</LanguageServiceName>
+    <TemplateLanguage Condition="'$(TemplateLanguage)' == ''">VisualBasic</TemplateLanguage>
   </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Instead of hardcoding C#/VB for the template language based on the CodeModel object - we now read this from design-time targets.

tag @srivatsn @dotnet/project-system 