### PR TITLE
Fix command line item handler to use whitespace to concatenate arguments

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             // We don't pass differences to Roslyn for options, we just pass them all
             IEnumerable<string> commandlineArguments = projectChange.After.Items.Keys;
 
-            _context.SetOptions(string.Join(",", commandlineArguments));
+            _context.SetOptions(string.Join(" ", commandlineArguments));
         }
 
         private void ProcessItems(IProjectChangeDescription projectChange)


### PR DESCRIPTION
This should fix the issue where we are not correctly setting the options.

[SplitCommandLineIntoArguments](http://source.roslyn.io/#Microsoft.CodeAnalysis/CommandLine/CommonCommandLineParser.cs,691) splits arguments based on whitespace characters.