### PR TITLE
Stop validating p2p references

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\TargetFrameworkValueProviderTests.cs" />
     <Compile Include="ProjectSystem\Properties\OutputTypeEnumProviderTests.cs" />
     <Compile Include="ProjectSystem\Properties\SourceFilePropertiesProviderTests.cs" />
+    <Compile Include="ProjectSystem\References\AlwaysAllowValidProjectReferenceCheckerTests.cs" />
     <Compile Include="ProjectSystem\SpecialFileProviderTests.cs" />
     <Compile Include="ProjectSystem\PhysicalProjectTreeTests.cs" />
     <Compile Include="ProjectSystem\UnconfiguredProjectCommonServicesTests.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/References/AlwaysAllowValidProjectReferenceCheckerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/References/AlwaysAllowValidProjectReferenceCheckerTests.cs
@@ -1,0 +1,148 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.References
+{
+    [ProjectSystemTrait]
+    public class AlwaysAllowValidProjectReferenceCheckerTests
+    {
+
+        [Fact]
+        public void CanAddProjectReferenceAsync_NullAsReferencedProject_ThrowsArgumentNull()
+        {
+            var checker = CreateInstance();
+
+            Assert.Throws<ArgumentNullException>("referencedProject", () => {
+
+                checker.CanAddProjectReferenceAsync((object)null);
+            });
+
+        }
+
+        [Fact]
+        public void CanAddProjectReferencesAsync_NullAsReferencedProjects_ThrowsArgumentNull()
+        {
+            var checker = CreateInstance();
+
+            Assert.Throws<ArgumentNullException>("referencedProjects", () => {
+
+                checker.CanAddProjectReferencesAsync((IImmutableSet<object>)null);
+            });
+        }
+
+        [Fact]
+        public void CanAddProjectReferencesAsync_EmptyAsReferencedProjects_ThrowsArgument()
+        {
+            var checker = CreateInstance();
+
+            var referencedProjects = ImmutableHashSet<object>.Empty;
+
+            Assert.Throws<ArgumentException>("referencedProjects", () => {
+
+                checker.CanAddProjectReferencesAsync(ImmutableHashSet<object>.Empty);
+            });
+        }
+
+        [Fact]
+        public void CanBeReferencedAsync_NullAsReferencingProject_ThrowsArgumentNull()
+        {
+            var checker = CreateInstance();
+
+            Assert.Throws<ArgumentNullException>("referencingProject", () => {
+
+                checker.CanBeReferencedAsync((object)null);
+            });
+        }
+
+        [Fact]
+        public async Task CanAddProjectReferenceAsync_ReturnsSupported()
+        {
+            var project = new object();
+            var checker = CreateInstance();
+
+            var result = await checker.CanAddProjectReferenceAsync(project);
+
+            Assert.Equal(SupportedCheckResult.Supported, result);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(5)]
+        [InlineData(10)]
+        public async Task CanAddProjectReferencesAsync_ReturnsErrorMessageSetToNull(int count)
+        {
+            var checker = CreateInstance();
+            var referencedProjects = CreateSet(count);
+
+            var result = await checker.CanAddProjectReferencesAsync(referencedProjects);
+
+            Assert.Null(result.ErrorMessage);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(5)]
+        [InlineData(10)]
+        public async Task CanAddProjectReferencesAsync_ReturnsAsManyIndivualResultsAsProjects(int count)
+        {
+            var checker = CreateInstance();
+            var referencedProjects = CreateSet(count);
+
+            var result = await checker.CanAddProjectReferencesAsync(referencedProjects);
+
+            Assert.Equal(result.IndividualResults.Keys, referencedProjects);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(5)]
+        [InlineData(10)]
+        public async Task CanAddProjectReferencesAsync_ReturnsAllResultsSetToSupported(int count)
+        {
+            var checker = CreateInstance();
+            var referencedProjects = CreateSet(count);
+
+            var result = await checker.CanAddProjectReferencesAsync(referencedProjects);
+
+            Assert.All(result.IndividualResults.Values, r => Assert.Equal(SupportedCheckResult.Supported, r));
+        }
+
+        [Fact]
+        public async Task CanBeReferencedAsync_ReturnsSupported()
+        {
+            var project = new object();
+            var checker = CreateInstance();
+
+            var result = await checker.CanBeReferencedAsync(project);
+
+            Assert.Equal(SupportedCheckResult.Supported, result);
+        }
+
+        private IImmutableSet<object> CreateSet(int count)
+        {
+            var builder = ImmutableHashSet.CreateBuilder<object>();
+
+            for (int i = 0; i < count; i++)
+            {
+                builder.Add(new object());
+            }
+
+            return builder.ToImmutableHashSet();
+        }
+
+        private AlwaysAllowValidProjectReferenceChecker CreateInstance()
+        {
+            return new AlwaysAllowValidProjectReferenceChecker();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -75,6 +75,7 @@
     <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\ApplicationManifestValueProvider.cs" />
     <Compile Include="ProjectSystem\Properties\RuleExtensions.cs" />
     <Compile Include="ProjectSystem\Properties\RuleDataSourceTypes.cs" />
+    <Compile Include="ProjectSystem\References\AlwaysAllowValidProjectReferenceChecker.cs" />
     <Compile Include="ProjectSystem\Rules\AnalyzerReference.xaml.cs">
       <DependentUpon>AnalyzerReference.xaml</DependentUpon>
     </Compile>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/References/AlwaysAllowValidProjectReferenceChecker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/References/AlwaysAllowValidProjectReferenceChecker.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.References
+{
+    /// <summary>
+    ///     Provides an implementation of <see cref="IValidProjectReferenceChecker"/> that always allows a reference.
+    /// </summary>
+    /// <remarks>
+    ///     Unlike the old project system, we do zero validation when we get added as a project reference, or when 
+    ///     we reference another project. Instead, we push off all validation to MSBuild targets that do the validation
+    ///     during builds and design-time builds (ResolveProjectReferences). This gives a consistent behavior between 
+    ///     adding the project reference via the UI and adding the project via the editor - in the end they result in the 
+    ///     same behavior, inside and outside of Visual Studio.
+    /// </remarks>
+    [Export(typeof(IValidProjectReferenceChecker))]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
+    [Order(1)] // Before the default checker, which delegates onto normal P-2-P rules
+    internal class AlwaysAllowValidProjectReferenceChecker : IValidProjectReferenceChecker
+    {
+        private static readonly Task<SupportedCheckResult> Supported = Task.FromResult(SupportedCheckResult.Supported);
+
+        [ImportingConstructor]
+        public AlwaysAllowValidProjectReferenceChecker()
+        {
+        }
+
+        public Task<SupportedCheckResult> CanAddProjectReferenceAsync(object referencedProject)
+        {
+            Requires.NotNull(referencedProject, nameof(referencedProject));
+
+            return Supported;
+        }
+
+        public Task<CanAddProjectReferencesResult> CanAddProjectReferencesAsync(IImmutableSet<object> referencedProjects)
+        {
+            Requires.NotNullEmptyOrNullElements(referencedProjects, nameof(referencedProjects));
+
+            IImmutableDictionary<object, SupportedCheckResult> results = ImmutableDictionary.Create<object, SupportedCheckResult>();
+
+            foreach (object referencedProject in referencedProjects)
+            {
+                results = results.Add(referencedProject, SupportedCheckResult.Supported);
+            }
+
+            return Task.FromResult(new CanAddProjectReferencesResult(results, null));
+        }
+
+        public Task<SupportedCheckResult> CanBeReferencedAsync(object referencingProject)
+        {
+            Requires.NotNull(referencingProject, nameof(referencingProject));
+
+            return Supported;
+        }
+    }
+}


### PR DESCRIPTION
We're moving to a model where p2p references are validated by MSBuild in builds and design-time builds. Stop validating them in VS.

tag @dotnet/project-system @nguerrera 