### PR TITLE
Read AddItemTemplatesGuid from design-time targets

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Properties/CSharpProjectGuidProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Properties/CSharpProjectGuidProviderTests.cs
@@ -18,16 +18,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
-        public void AddItemTemplatesGuid_ReturnsNonEmptyGuid()
-        {
-            var provider = CreateInstance();
-
-            // Handshake between the project system and factory around the actual guid value so we do not test 
-            // for a specified guid, other than to confirm it's not empty
-            Assert.NotEqual(Guid.Empty, provider.AddItemTemplatesGuid);
-        }
-
-        [Fact]
         public void ProjectTypeGuid_ReturnsNonEmptyGuid()
         {
             var provider = CreateInstance();

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/CSharpProjectGuidProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/CSharpProjectGuidProvider.cs
@@ -7,12 +7,11 @@ using Microsoft.VisualStudio.Packaging;
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     /// <summary>
-    ///     Provides the C# implementation of <see cref="IItemTypeGuidProvider"/> and <see cref="IAddItemTemplatesGuidProvider"/>.
+    ///     Provides the C# implementation of <see cref="IItemTypeGuidProvider"/>.
     /// </summary>
     [Export(typeof(IItemTypeGuidProvider))]
-    [Export(typeof(IAddItemTemplatesGuidProvider))]
     [AppliesTo(ProjectCapabilities.CSharp)]
-    internal class CSharpProjectGuidProvider : IItemTypeGuidProvider, IAddItemTemplatesGuidProvider
+    internal class CSharpProjectGuidProvider : IItemTypeGuidProvider
     {
         private static readonly Guid s_csharpProjectType = new Guid(CSharpProjectSystemPackage.LegacyProjectTypeGuid);
 
@@ -23,11 +22,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         }
 
         public Guid ProjectTypeGuid
-        {
-            get { return s_csharpProjectType; }
-        }
-
-        public Guid AddItemTemplatesGuid
         {
             get { return s_csharpProjectType; }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/VisualBasicProjectGuidProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/VisualBasicProjectGuidProviderTests.cs
@@ -18,16 +18,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         }
 
         [Fact]
-        public void AddItemTemplatesGuid_ReturnsNonEmptyGuid()
-        {
-            var provider = CreateInstance();
-
-            // Handshake between the project system and factory around the actual guid value so we do not test 
-            // for a specified guid, other than to confirm it's not empty
-            Assert.NotEqual(Guid.Empty, provider.AddItemTemplatesGuid);
-        }
-
-        [Fact]
         public void ProjectTypeGuid_ReturnsNonEmptyGuid()
         {
             var provider = CreateInstance();

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/VisualBasicProjectGuidProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/VisualBasicProjectGuidProvider.cs
@@ -7,12 +7,11 @@ using Microsoft.VisualStudio.Packaging;
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     /// <summary>
-    ///     Provides the Visual Basic implementation of <see cref="IItemTypeGuidProvider"/> and <see cref="IAddItemTemplatesGuidProvider"/>.
+    ///     Provides the Visual Basic implementation of <see cref="IItemTypeGuidProvider"/>.
     /// </summary>
     [Export(typeof(IItemTypeGuidProvider))]
-    [Export(typeof(IAddItemTemplatesGuidProvider))]
     [AppliesTo(ProjectCapabilities.VB)]
-    internal class VisualBasicProjectGuidProvider : IItemTypeGuidProvider, IAddItemTemplatesGuidProvider
+    internal class VisualBasicProjectGuidProvider : IItemTypeGuidProvider
     {
         private static readonly Guid s_visualBasicProjectType = new Guid(VisualBasicProjectSystemPackage.LegacyProjectTypeGuid);
 
@@ -23,11 +22,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         }
 
         public Guid ProjectTypeGuid
-        {
-            get { return s_visualBasicProjectType; }
-        }
-
-        public Guid AddItemTemplatesGuid
         {
             get { return s_visualBasicProjectType; }
         }

--- a/src/Targets/Microsoft.CSharp.DesignTime.targets
+++ b/src/Targets/Microsoft.CSharp.DesignTime.targets
@@ -15,6 +15,7 @@
     <AppDesignerFolderContentsVisibleOnlyInShowAllFiles Condition="'$(AppDesignerFolderContentsVisibleOnlyInShowAllFiles)' == ''">false</AppDesignerFolderContentsVisibleOnlyInShowAllFiles>
     <LanguageServiceName Condition="'$(LanguageServiceName)' == ''">C#</LanguageServiceName>
     <TemplateLanguage Condition="'$(TemplateLanguage)' == ''">CSharp</TemplateLanguage>
+    <AddItemTemplatesGuid Condition="'$(AddItemTemplatesGuid)' == ''">{FAE04EC0-301F-11d3-BF4B-00C04F79EFBC}</AddItemTemplatesGuid>
   </PropertyGroup>
 
     <ItemGroup>

--- a/src/Targets/Microsoft.VisualBasic.DesignTime.targets
+++ b/src/Targets/Microsoft.VisualBasic.DesignTime.targets
@@ -15,6 +15,7 @@
     <AppDesignerFolderContentsVisibleOnlyInShowAllFiles Condition="'$(AppDesignerFolderContentsVisibleOnlyInShowAllFiles)' == ''">true</AppDesignerFolderContentsVisibleOnlyInShowAllFiles>
     <LanguageServiceName Condition="'$(LanguageServiceName)' == ''">Visual Basic</LanguageServiceName>
     <TemplateLanguage Condition="'$(TemplateLanguage)' == ''">VisualBasic</TemplateLanguage>
+    <AddItemTemplatesGuid Condition="'$(AddItemTemplatesGuid)' == ''">{F184B08F-C81C-45F6-A57F-5ABD9991F28F}</AddItemTemplatesGuid>
   </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
CPS reads AddItemTemplatesGuid from the design-time targets in ProjectNode if there's no implementation of IAddItemTemplatesGuidProvider. Move it there similar to other properties to reduce number of C#/VB components.

Verified that both Add Item dialog correctly showed the right templates.