### PR TITLE
Avoid leaking a Renamer when renaming non-source files

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FileRenameTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FileRenameTracker.cs
@@ -78,6 +78,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                  .CurrentSolution
                  .Projects.Where(p => StringComparers.Paths.Equals(p.FilePath, _projectVsServices.Project.FullPath))
                  .FirstOrDefault();
+
+            if (myProject == null)
+            {
+                return;
+            }
             
             var renamer = new Renamer(_visualStudioWorkspace, _projectVsServices.ThreadingService, _userNotificationServices,  _optionsSettings, _roslynServices,  myProject, oldFilePath, newFilePath);
             _visualStudioWorkspace.WorkspaceChanged += renamer.OnWorkspaceChangedAsync;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FileRenameTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FileRenameTracker.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 if (!hint.ChangeAlreadyOccurred)
                 {
                     var kvp = hint.RenamedFiles.First();
-                    ScheduleRenameAsync(kvp.Key, kvp.Value);
+                    ScheduleRename(kvp.Key, kvp.Value);
                 }
             }
 
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             return Task.CompletedTask;
         }
 
-        private void ScheduleRenameAsync(string oldFilePath, string newFilePath)
+        private void ScheduleRename(string oldFilePath, string newFilePath)
         {
             string codeExtension = Path.GetExtension(newFilePath);
             if (!oldFilePath.EndsWith(codeExtension, StringComparison.OrdinalIgnoreCase))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FileRenameTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FileRenameTracker.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 if (!hint.ChangeAlreadyOccurred)
                 {
                     var kvp = hint.RenamedFiles.First();
-                    return ScheduleRenameAsync(kvp.Key, kvp.Value);
+                    ScheduleRenameAsync(kvp.Key, kvp.Value);
                 }
             }
 
@@ -66,15 +66,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             return Task.CompletedTask;
         }
 
-        private async Task ScheduleRenameAsync(string oldFilePath, string newFilePath)
+        private void ScheduleRenameAsync(string oldFilePath, string newFilePath)
         {
             string codeExtension = Path.GetExtension(newFilePath);
             if (codeExtension == null || !oldFilePath.EndsWith(codeExtension, StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }
-
-            await _projectVsServices.ThreadingService.SwitchToUIThread();
 
             var myProject = _visualStudioWorkspace
                  .CurrentSolution

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FileRenameTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FileRenameTracker.cs
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         private void ScheduleRenameAsync(string oldFilePath, string newFilePath)
         {
             string codeExtension = Path.GetExtension(newFilePath);
-            if (codeExtension == null || !oldFilePath.EndsWith(codeExtension, StringComparison.OrdinalIgnoreCase))
+            if (!oldFilePath.EndsWith(codeExtension, StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FileRenameTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FileRenameTracker.cs
@@ -47,11 +47,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         public async Task HintedAsync(IImmutableDictionary<Guid, IImmutableSet<IProjectChangeHint>> hints)
         {
-            var files = hints.GetValueOrDefault(ProjectChangeFileSystemEntityRenameHint.RenamedFile) ?? ImmutableHashSet.Create<IProjectChangeHint>();
+            var files = hints[ProjectChangeFileSystemEntityRenameHint.RenamedFile];
             if (files.Count == 1)
             {
-                var hint = files.First() as IProjectChangeFileRenameHint;
-                if (hint != null && !hint.ChangeAlreadyOccurred)
+                var hint = (IProjectChangeFileRenameHint)files.First();
+                if (!hint.ChangeAlreadyOccurred)
                 {
                     var kvp = hint.RenamedFiles.First();
                     await ScheduleRenameAsync(kvp.Key, kvp.Value).ConfigureAwait(false);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FileRenameTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FileRenameTracker.cs
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             _roslynServices = roslynServices;
         }
 
-        public async Task HintedAsync(IImmutableDictionary<Guid, IImmutableSet<IProjectChangeHint>> hints)
+        public Task HintedAsync(IImmutableDictionary<Guid, IImmutableSet<IProjectChangeHint>> hints)
         {
             var files = hints[ProjectChangeFileSystemEntityRenameHint.RenamedFile];
             if (files.Count == 1)
@@ -54,9 +54,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 if (!hint.ChangeAlreadyOccurred)
                 {
                     var kvp = hint.RenamedFiles.First();
-                    await ScheduleRenameAsync(kvp.Key, kvp.Value).ConfigureAwait(false);
+                    return ScheduleRenameAsync(kvp.Key, kvp.Value);
                 }
             }
+
+            return Task.CompletedTask;
         }
 
         public Task HintingAsync(IProjectChangeHint hint)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Renamer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Renamer.cs
@@ -75,8 +75,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             }
         }
 
-        public async Task RenameAsync(Project project) =>
-            await (GetStrategy()?.RenameAsync(project, _oldFilePath, _newFilePath) ?? Task.CompletedTask).ConfigureAwait(false);
+        public Task RenameAsync(Project project)
+        {
+            return GetStrategy()?.RenameAsync(project, _oldFilePath, _newFilePath) ?? Task.CompletedTask;
+        }
 
         private IRenameStrategy GetStrategy()
         {


### PR DESCRIPTION
Fixed a leak and a few other changes, dig into each commit for more context if you want to see why I made the change.

Avoid leaking a Renamer when renaming non-source files 
Path.GetExtension doesn't return null for paths 
Avoid unnecessary transition to the UI thread
Remove unneeded async state machine
Remove defensive coding against possible CPS bugs  …