### PR TITLE
ActiveConfiguredProjectsIgnoringTargetFrameworkProvider: Provides set…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Extensions/ProjectConfigurationExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Extensions/ProjectConfigurationExtensions.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.ProjectSystem.Build;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class ProjectConfigurationExtensions
+    {
+        /// <summary>
+        /// Returns true if this is a cross-targeting project configuration with a "TargetFramework" dimension.
+        /// This is true for a project with an explicit "TargetFrameworks" property, but no "TargetFrameworkMoniker" or "TargetFramework" property.
+        /// </summary>
+        /// <param name="projectConfiguration"></param>
+        /// <returns></returns>
+        internal static bool IsCrossTargeting(this ProjectConfiguration projectConfiguration)
+        {
+            return projectConfiguration.Dimensions.ContainsKey(TargetFrameworkProjectConfigurationDimensionProvider.TargetFrameworkPropertyName);
+        }
+
+        /// <summary>
+        /// Returns true if the given project configurations are equal ignoring the "TargetFramework" dimension.
+        /// </summary>
+        internal static bool EqualIgnoringTargetFramework(this ProjectConfiguration projectConfiguration1, ProjectConfiguration projectConfiguration2)
+        {
+            Requires.NotNull(projectConfiguration1, nameof(projectConfiguration1));
+            Requires.NotNull(projectConfiguration2, nameof(projectConfiguration2));
+
+            if (projectConfiguration1.Dimensions.Count != projectConfiguration2.Dimensions.Count)
+            {
+                return false;
+            }
+
+            if (!projectConfiguration1.IsCrossTargeting() || !projectConfiguration2.IsCrossTargeting())
+            {
+                return projectConfiguration1.Equals(projectConfiguration2);
+            }
+
+            foreach (var dimensionKvp in projectConfiguration1.Dimensions)
+            {
+                var dimensionName = dimensionKvp.Key;
+                var dimensionValue = dimensionKvp.Value;
+
+                // Ignore the TargetFramework.
+                if (string.Equals(dimensionName, TargetFrameworkProjectConfigurationDimensionProvider.TargetFrameworkPropertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                string activeValue;
+                if (!projectConfiguration2.Dimensions.TryGetValue(dimensionName, out activeValue) ||
+                    !string.Equals(dimensionValue, activeValue, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Extensions/ProjectConfigurationExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Extensions/ProjectConfigurationExtensions.cs
@@ -47,9 +47,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
                     continue;
                 }
 
+                // Dimension values must be compared in a case-sensitive manner.
                 string activeValue;
                 if (!projectConfiguration2.Dimensions.TryGetValue(dimensionName, out activeValue) ||
-                    !string.Equals(dimensionValue, activeValue, StringComparison.OrdinalIgnoreCase))
+                    !string.Equals(dimensionValue, activeValue, StringComparison.Ordinal))
                 {
                     return false;
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -32,6 +32,7 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions\ProjectConfigurationExtensions.cs" />
     <Compile Include="ProjectSystem\Build\BuildProperty.cs" />
     <Compile Include="CommonConstants.cs" />
     <Compile Include="ProjectSystem\Build\CommandLineDesignTimeBuildPropertiesProvider.cs" />
@@ -52,6 +53,7 @@
     <Compile Include="ProjectSystem\Debug\LaunchSettingsData.cs" />
     <Compile Include="ProjectSystem\Debug\LaunchSettingsProvider.cs" />
     <Compile Include="ProjectSystem\DefaultCapabilitiesProvider.cs" />
+    <Compile Include="ProjectSystem\ActiveConfiguredProjectsProvider.cs" />
     <Compile Include="ProjectSystem\LanguageServices\CommandLineParserService.cs" />
     <Compile Include="ProjectSystem\LanguageServices\Handlers\CommandLineItemHandler.cs" />
     <Compile Include="ProjectSystem\LanguageServices\Handlers\MetadataReferenceItemHandler.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Build;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    /// <summary>
+    ///     Provides set of configured projects whose ProjectConfiguration has all dimensions (except the TargetFramework) matching the active VS configuration.
+    ///
+    ///     For example, for a cross-targeting project with TargetFrameworks = "net45;net46" we have:
+    ///     -> All known configurations:
+    ///         Debug | AnyCPU | net45
+    ///         Debug | AnyCPU | net46
+    ///         Release | AnyCPU | net45
+    ///         Release | AnyCPU | net46
+    ///         
+    ///     -> Say, active VS configuration = "Debug | AnyCPU"
+    ///       
+    ///     -> Active configurations returned by this provider:
+    ///         Debug | AnyCPU | net45
+    ///         Debug | AnyCPU | net46
+    /// </summary>
+    [Export(typeof(ActiveConfiguredProjectsProvider))]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
+    internal class ActiveConfiguredProjectsProvider
+    {
+        private readonly IUnconfiguredProjectServices _services;
+        private readonly IUnconfiguredProjectCommonServices _commonServices;
+        private readonly IProjectAsynchronousTasksService _tasksService;
+
+        [ImportingConstructor]
+        public ActiveConfiguredProjectsProvider(IUnconfiguredProjectServices services, IUnconfiguredProjectCommonServices commonServices)
+        {
+            Requires.NotNull(services, nameof(services));
+            Requires.NotNull(commonServices, nameof(commonServices));
+            
+            _services = services;
+            _commonServices = commonServices;
+        }
+
+        /// <summary>
+        /// Gets all the active configured projects by TargetFramework dimension for the current unconfigured project.
+        /// If the current project is not a cross-targeting project, then it returns a singleton key-value pair with an ignorable key and single active configured project as value.
+        /// </summary>
+        /// <returns>Map from TargetFramework dimension to active configured project.</returns>
+        public async Task<ImmutableDictionary<string, ConfiguredProject>> GetActiveConfiguredProjectsMapAsync()
+        {
+            var builder = ImmutableDictionary.CreateBuilder<string, ConfiguredProject>();
+            var knownConfigurations = await _services.ProjectConfigurationsService.GetKnownProjectConfigurationsAsync().ConfigureAwait(true);
+            var isCrossTarging = knownConfigurations.All(c => c.IsCrossTargeting());
+            if (isCrossTarging)
+            {
+                // Get all the project configurations with all dimensions (ignoring the TargetFramework) matching the active configuration.
+                var activeConfiguration = _services.ActiveConfiguredProjectProvider.ActiveProjectConfiguration;
+                foreach (var configuration in knownConfigurations)
+                {
+                    if (configuration.EqualIgnoringTargetFramework(activeConfiguration))
+                    {
+                        var configuredProject = await _commonServices.Project.LoadConfiguredProjectAsync(configuration).ConfigureAwait(true);
+                        var targetFramework = configuration.Dimensions[TargetFrameworkProjectConfigurationDimensionProvider.TargetFrameworkPropertyName];
+                        builder.Add(targetFramework, configuredProject);
+                    }
+                }
+            }
+            else
+            {
+                builder.Add(String.Empty, _services.ActiveConfiguredProjectProvider.ActiveConfiguredProject);
+            }
+
+            return builder.ToImmutableDictionary();
+        }
+
+        /// <summary>
+        /// Gets all the active configured projects for the current unconfigured project.
+        /// </summary>
+        /// <returns>Set of active configured projects.</returns>
+        public async Task<ImmutableArray<ConfiguredProject>> GetActiveConfiguredProjectsAsync()
+        {
+            var projectMap = await GetActiveConfiguredProjectsMapAsync().ConfigureAwait(false);
+            return projectMap.Values.ToImmutableArray();
+        }
+
+        /// <summary>
+        /// Gets all the active project configurations for the current unconfigured project.
+        /// </summary>
+        /// <returns>Set of active project configurations.</returns>
+        public async Task<ImmutableArray<ProjectConfiguration>> GetActiveProjectConfigurationsAsync()
+        {
+            var projectMap = await GetActiveConfiguredProjectsMapAsync().ConfigureAwait(false);
+            return projectMap.Values.Select(p => p.ProjectConfiguration).ToImmutableArray();
+        }
+    }
+}


### PR DESCRIPTION
… of active configured projects whose ProjectConfiguration has all dimensions (ignoring the TargetFramework) matching the active VS configuration