### PR TITLE
Split building v2 and v3 VSIXes into separate commands

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -15,6 +15,8 @@ if /I "%1" == "/?" call :Usage && exit /b 1
 if /I "%1" == "/debug" set BuildConfiguration=Debug&&shift&& goto :ParseArguments
 if /I "%1" == "/release" set BuildConfiguration=Release&&shift&& goto :ParseArguments
 if /I "%1" == "/rebuild" set MSBuildTarget=Rebuild&&shift&& goto :ParseArguments
+if /I "%1" == "/restore" set MSBuildTarget=RestorePackages&&shift&& goto :ParseArguments
+if /I "%1" == "/modernvsixonly" set MSBuildTarget=BuildModernVsixPackages&&shift&& goto :ParseArguments
 if /I "%1" == "/no-node-reuse" set NodeReuse=false&&shift&& goto :ParseArguments
 if /I "%1" == "/no-multi-proc" set MSBuildAdditionalArguments=&&shift&& goto :ParseArguments
 call :Usage && exit /b 1
@@ -57,8 +59,10 @@ echo.
 echo   /debug             Perform debug build (default)
 echo   /release           Perform release build
 echo   /rebuild           Perform a clean, then build
+echo   /restore           Only restore nuget packages
 echo   /no-node-reuse     Run msbuild with /nodeReuse=false, which affects performance
 echo   /no-multi-proc     No multi-proc build, useful for diagnosing build logs
+echo   /modernvsixonly    Only build modern vsman vsixes.
 goto :eof
 
 :BuildFailed

--- a/build/build.proj
+++ b/build/build.proj
@@ -54,14 +54,6 @@
   <Target Name="BuildModernVsixPackages">
 
     <MSBuild Projects="@(VsManProjectFile)"
-             Targets="Build"
-             Condition="'$(RunningInMicroBuild)' == 'true'"
-             />
-  </Target>
-
-  <Target Name="RebuildModernVsixPackages">
-
-    <MSBuild Projects="@(VsManProjectFile)"
              Targets="Rebuild"
              Condition="'$(RunningInMicroBuild)' == 'true'"
              />
@@ -88,7 +80,7 @@
 
   </Target>
 
-  <Target Name="Build" DependsOnTargets="RestorePackages;BuildSolution;BuildModernVsixPackages;Test" />
-  <Target Name="Rebuild" DependsOnTargets="RestorePackages;RebuildSolution;RebuildModernVsixPackages;Test" />
+  <Target Name="Build" DependsOnTargets="RestorePackages;BuildSolution;Test" />
+  <Target Name="Rebuild" DependsOnTargets="RestorePackages;RebuildSolution;Test" />
 
 </Project>


### PR DESCRIPTION
Latest SWIX plugin doesn't support building them with the same msbuild command.