### PR TITLE
Ensure that we force refresh the CPS active project configuration whe…

### DIFF
--- a/src/Dependencies/CPS/project.json
+++ b/src/Dependencies/CPS/project.json
@@ -2,7 +2,7 @@
   "supports": {},
   "dependencies": {
     "Microsoft.VisualStudio.ProjectSystem.SDK": {
-      "version": "15.0.561-pre-g30afd8d890",
+      "version": "15.0.574-pre-g1dd1014f4f",
       "suppressParent": "none"
     }
   },


### PR DESCRIPTION
…n TargetFrameworks is updated.

This change adds this functionality to the LanguageServiceHost itself. #614 tracks moving this and related functionality into a separate service.