### PR TITLE
Telemetry fault logging fixes

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
@@ -7,6 +7,7 @@ Imports System.Reflection
 Imports System.Runtime.InteropServices
 Imports System.Text.RegularExpressions
 Imports System.Windows.Forms
+Imports Microsoft.VisualStudio.Shell
 Imports Microsoft.VisualStudio.Telemetry
 Imports VB = Microsoft.VisualBasic
 
@@ -239,7 +240,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
             throwingComponentName = Regex.Replace(throwingComponentName, "([A-Z])", "-$1").TrimPrefix("-").ToLower() + "-fault"
 
             TelemetryService.DefaultSession.PostFault(
-                eventName:="vs/ml/cps/appdesigner/" & throwingComponentName.ToLower,
+                eventName:="vs/ml/proppages/appdesigner/" & throwingComponentName.ToLower,
                 description:=exceptionEventDescription,
                 exceptionObject:=ex)
 

--- a/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
@@ -3,12 +3,12 @@
 Imports System.ComponentModel.Design
 Imports System.Drawing
 Imports System.IO
-Imports System.Runtime.InteropServices
-Imports System.Windows.Forms
-Imports VB = Microsoft.VisualBasic
 Imports System.Reflection
-Imports System.Threading
+Imports System.Runtime.InteropServices
+Imports System.Text.RegularExpressions
+Imports System.Windows.Forms
 Imports Microsoft.VisualStudio.Telemetry
+Imports VB = Microsoft.VisualBasic
 
 Namespace Microsoft.VisualStudio.Editors.AppDesCommon
 
@@ -235,8 +235,11 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
             Debug.Assert(Not String.IsNullOrEmpty(throwingComponentName))
             Debug.Assert(Not String.IsNullOrEmpty(exceptionEventDescription))
 
+            ' Follow naming convention for entity name: A string to identify the entity in the feature. E.g. open-project, build-project, fix-error.
+            throwingComponentName = Regex.Replace(throwingComponentName, "([A-Z])", "-$1").TrimPrefix("-").ToLower() + "-fault"
+
             TelemetryService.DefaultSession.PostFault(
-                eventName:="vs/projectsystem/appdesigner/" & throwingComponentName.ToLower,
+                eventName:="vs/ml/cps/appdesigner/" & throwingComponentName.ToLower,
                 description:=exceptionEventDescription,
                 exceptionObject:=ex)
 

--- a/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
@@ -7,6 +7,7 @@ Imports System.IO
 Imports System.Runtime.InteropServices
 Imports System.Runtime.Versioning
 Imports System.Text
+Imports System.Text.RegularExpressions
 Imports System.Windows.Forms
 Imports Microsoft.VisualStudio.Editors.Interop
 Imports Microsoft.VisualStudio.Imaging.Interop
@@ -335,8 +336,11 @@ Namespace Microsoft.VisualStudio.Editors.Common
             Debug.Assert(Not String.IsNullOrEmpty(throwingComponentName))
             Debug.Assert(Not String.IsNullOrEmpty(exceptionEventDescription))
 
+            ' Follow naming convention for entity name: A string to identify the entity in the feature. E.g. open-project, build-project, fix-error.
+            throwingComponentName = Regex.Replace(throwingComponentName, "([A-Z])", "-$1").TrimPrefix("-").ToLower() + "-fault"
+
             TelemetryService.DefaultSession.PostFault(
-                eventName:="vs/projectsystem/editors/" & throwingComponentName.ToLower,
+                eventName:="vs/ml/cps/editors/" & throwingComponentName.ToLower,
                 description:=exceptionEventDescription,
                 exceptionObject:=ex)
 

--- a/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
@@ -340,7 +340,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
             throwingComponentName = Regex.Replace(throwingComponentName, "([A-Z])", "-$1").TrimPrefix("-").ToLower() + "-fault"
 
             TelemetryService.DefaultSession.PostFault(
-                eventName:="vs/ml/cps/editors/" & throwingComponentName.ToLower,
+                eventName:="vs/ml/proppages/editors/" & throwingComponentName.ToLower,
                 description:=exceptionEventDescription,
                 exceptionObject:=ex)
 

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
@@ -675,7 +675,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                 Dim LostFocusProjectItem As EnvDTE.ProjectItem = Nothing
                 Try
                     LostFocusProjectItem = LostFocus.ProjectItem
-                Catch ex As Exception When Common.ReportWithoutCrash(ex, NameOf(m_WindowEvents_WindowActivated), NameOf(BaseDesignerLoader))
+                Catch ex As Exception
                 End Try
 
                 If LostFocusProjectItem Is ThisProjectItem Then

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
@@ -1453,10 +1453,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="ExceptionToRethrow">The exception to rethrow, if any.  May be the same exeption as ExceptionFromGetValue or different.</param>
         ''' <remarks></remarks>
         Friend Sub SetTaskFromGetValueException(ExceptionFromGetValue As Exception, ByRef ExceptionToRethrow As Exception)
-            If Not Common.Utils.ReportWithoutCrash(ExceptionFromGetValue, NameOf(SetTaskFromGetValueException), NameOf(Resource)) Then
-                Throw ExceptionToRethrow
-            End If
-
             'We hit an exception.  Add a task list item for resource instantiation (if it doesn't already exist)
 
             If TypeOf ExceptionFromGetValue Is TargetInvocationException Then
@@ -2052,7 +2048,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
                     'No exceptions were thrown, so no task list entries should be associated with this.
                     ClearTask(ResourceFile.ResourceTaskType.CantInstantiateResource)
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(CheckValueForErrors), NameOf(Resource)) 'We want task list entries for out of memory loading a resource
+                Catch ex As Exception
 
                     'Create task list entry
                     SetTaskFromGetValueException(ex, ex)

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
@@ -1132,7 +1132,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Else
                 Try
                     ThumbnailSourceImage = Resource.ResourceTypeEditor.GetImageForThumbnail(Resource, Me.BackColor)
-                Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, NameOf(GetThumbnailIndex), NameOf(ResourceListView))
+                Catch ex As Exception
                     'For some reason, we could not get a value for this resource.  So, we use an error glyph for the
                     '  source of the thumbnail image instead.  Note that an alternative would be to have a single
                     '  thumbnail in the thumbnail cache representing an error be used for all error cases.  However,
@@ -1170,7 +1170,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
                 'NOTE: This is a slow operation, we should prevent to do so if it is possible...
                 Thumbnail = CreateThumbnail(ThumbnailSourceImage, ThumbnailSize, DrawBorder, _borderWidth, _selectionBorderWidth, _thumbnailImageList.TransparentColor)
-            Catch ex As Exception When Common.Utils.ReportWithoutCrash(ex, "Failed creating thumbnail", NameOf(ResourceListView))
+            Catch ex As Exception
                 Thumbnail = Nothing
             End Try
             Using Thumbnail


### PR DESCRIPTION
1. Follow the naming conventions for post fault entity name
2. Remove crash reporting at places where we are generating 10,000+ AI events, we are actually handling the exception and passing it back up to the callers, so these are not too useful.

Fixes VSO [278184](https://devdiv.visualstudio.com/DevDiv/_workitems/index?_a=edit&id=278184&triage=true)