### PR TITLE
Use TargetFramework Property in Nominate Restore when it is missing from Dimension Provider

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilderTests.cs
@@ -99,6 +99,63 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         }
 
         [Fact]
+        public void ProjectRestoreInfoBuilder_WithNoTargetFrameworkDimension_UsesPropertiesInstead()
+        {
+            var projectSubscriptionUpdates = GetVersionedUpdatesFromJson(@"{
+    ""ProjectConfiguration"": {
+        ""Name"": ""Debug|AnyCPU|netcoreapp1.0"",
+        ""Dimensions"": {
+            ""Configuration"": ""Debug"",            
+            ""Platform"": ""AnyCPU""
+        }
+    },
+    ""ProjectChanges"": {
+        ""ConfigurationGeneral"": {
+            ""Difference"": {
+                ""AnyChanges"": ""true""
+            },
+            ""After"": {
+                ""Properties"": {
+                   ""BaseIntermediateOutputPath"": ""obj\\"",
+                   ""TargetFrameworkMoniker"": "".NETCoreApp,Version=v1.0"",
+                   ""TargetFramework"": ""netcoreapp1.0""
+                }
+            }
+        },
+        ""PackageReference"": {
+            ""Difference"": {
+                ""AnyChanges"": ""false""
+            },
+            ""After"": {
+                ""Items"": { }
+            }
+        },
+        ""DotNetCliToolReference"": {
+            ""Difference"": {
+                ""AnyChanges"": ""false""
+            },
+            ""After"": {
+                ""Items"": { }
+            }
+        },
+        ""ProjectReference"": {
+            ""Difference"": {
+                ""AnyChanges"": ""false""
+            },
+            ""After"": {
+                ""Items"": { }
+            }
+        }
+    }
+}");
+            var restoreInfo = ProjectRestoreInfoBuilder.Build(projectSubscriptionUpdates);
+
+            Assert.NotNull(restoreInfo);
+            Assert.Equal(1, restoreInfo.TargetFrameworks.Count);
+            Assert.NotNull(restoreInfo.TargetFrameworks.Item("netcoreapp1.0"));
+        }
+
+        [Fact]
         public void ProjectRestoreInfoBuilder_WithTwoIdenticalUpdates_ReturnsSingleTFM()
         {
             var projectSubscriptionUpdates = GetVersionedUpdatesFromJson(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
@@ -133,6 +133,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             {
                 var changedProperties = projectChange.Difference.ChangedProperties;
                 return changedProperties.Contains(ConfigurationGeneral.TargetFrameworksProperty)
+                    || changedProperties.Contains(ConfigurationGeneral.TargetFrameworkProperty)
                     || changedProperties.Contains(ConfigurationGeneral.TargetFrameworkMonikerProperty);
             }
             return false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -30,6 +30,11 @@
             <DataSource Persistence="ProjectFile" PersistedName="TargetFrameworks" HasConfigurationCondition="False" />
         </StringProperty.DataSource>
     </StringProperty>
+    <StringProperty Name="TargetFramework" DisplayName="Target Framework">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFile" PersistedName="TargetFramework" HasConfigurationCondition="False" />
+        </StringProperty.DataSource>
+    </StringProperty>
     <StringProperty Name="TargetFrameworkProfile" DisplayName="Target Framework Profile">
         <StringProperty.DataSource>
             <DataSource Persistence="ProjectFile" PersistedName="TargetFrameworkProfile" HasConfigurationCondition="False" />


### PR DESCRIPTION
TargetFramework property is absent from Dimension Provider in non-cross targeting projects.
Add TargetFramework property to configuration general rules and use when target framework dimension is absent.

/cc @dotnet/project-system 
/cc @MattGertz for Ask Mode Approval
/cc  @alpaix @rrelyea @emgarten for Fyi