### PR TITLE
Set LastDesignTimeBuildSucceeded = false by default, so we don't show…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
@@ -274,6 +274,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
                         await _commonServices.ThreadingService.SwitchToUIThread();
                         workspaceProjectContext = _contextFactory.Value.CreateProjectContext(languageName, displayName, projectData.FullPath, projectGuid, configuredProjectHostObject, targetPath);
 
+                        // By default, set "LastDesignTimeBuildSucceeded = false" to turn off diagnostics until first design time build succeeds for this project.
+                        workspaceProjectContext.LastDesignTimeBuildSucceeded = false;
+
                         AddConfiguredProjectState(configuredProject, workspaceProjectContext, configuredProjectHostObject);                        
                     }
 


### PR DESCRIPTION
… any diagnostics until the first design time build succeeds.

We need a successful design time build so that references, options, etc. is correctly set. As our design time builds are on a background thread, these might take some time to complete, and we need to turn off diagnostics while the project is in broken state.