### PR TITLE
https://github.com/dotnet/roslyn-project-system/issues/423

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
@@ -29,6 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
         {
             _mockFS.WriteAllText(@"c:\test\Project\someapp.exe", "");
             _mockFS.CreateDirectory(@"c:\test\Project");
+            _mockFS.CreateDirectory(@"c:\test\Project\bin\");
             _mockFS.WriteAllText(@"c:\program files\dotnet\dotnet.exe", "");
 
             LaunchProfile activeProfile = new LaunchProfile() { Name = "MyApplication",  CommandLineArgs = "--someArgs", ExecutablePath=@"c:\test\Project\someapp.exe" };
@@ -48,7 +49,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
             if (properties == null)
             {
                 properties = new Dictionary<string, string>() {
-                    { "TargetPath", @"c:\test\project\bin\project.dll" },
+                    {"RunCommand", @"dotnet"},
+                    {"RunArguments", "exec " + "\"" + @"c:\test\project\bin\project.dll"+ "\""},
+                    {"RunWorkingDirectory",  @"bin\"},
                     { "TargetFrameworkIdentifier", @".NetCoreApp" }
                 }; 
             }
@@ -157,7 +160,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
             Assert.Equal(DebugLaunchOperation.CreateProcess, targets[0].LaunchOperation);
             Assert.Equal((DebugLaunchOptions.StopDebuggingOnEnd), targets[0].LaunchOptions);
             Assert.Equal(DebuggerEngines.ManagedCoreEngine, targets[0].LaunchDebugEngineGuid);
-            Assert.Equal("\"c:\\test\\project\\bin\\project.dll\" --someArgs", targets[0].Arguments);
+            Assert.Equal("exec \"c:\\test\\project\\bin\\project.dll\" --someArgs", targets[0].Arguments);
         }
 
         [Fact]
@@ -176,7 +179,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
             Assert.Equal((DebugLaunchOptions.NoDebug | DebugLaunchOptions.StopDebuggingOnEnd | DebugLaunchOptions.MergeEnvironment), targets[0].LaunchOptions);
             Assert.Equal(DebuggerEngines.ManagedCoreEngine, targets[0].LaunchDebugEngineGuid);
             Assert.True(targets[0].Environment.ContainsKey("var1"));
-            Assert.Equal("/c \"\"c:\\program files\\dotnet\\dotnet.exe\" \"c:\\test\\project\\bin\\project.dll\" --someArgs & pause\"", targets[0].Arguments);
+            Assert.Equal("/c \"\"c:\\program files\\dotnet\\dotnet.exe\" exec \"c:\\test\\project\\bin\\project.dll\" --someArgs & pause\"", targets[0].Arguments);
         }
 
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -301,6 +301,15 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to run your project. The &quot;RunCommand&quot; property is not defined..
+        /// </summary>
+        internal static string NoRunCommandSpecifiedInProject {
+            get {
+                return ResourceManager.GetString("NoRunCommandSpecifiedInProject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The debug profile &apos;{0}&apos; has requested a web browser be launched, but a URL was not specified..
         /// </summary>
         internal static string NoUrlSpecified {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -255,4 +255,7 @@ In order to debug this project, add an executable project to this solution which
   <data name="XprojMigrationFailedProjectJsonFileNotFound" xml:space="preserve">
     <value>Failed to migrate XProj project {0}. Could not find project.json at {1}.</value>
   </data>
+  <data name="NoRunCommandSpecifiedInProject" xml:space="preserve">
+    <value>Unable to run your project. The "RunCommand" property is not defined.</value>
+  </data>
 </root>


### PR DESCRIPTION
Fix the way we launch the application to get the run information from the SDK properties. Addresses issue https://github.com/dotnet/roslyn-project-system/issues/423

@srivatsn @abpiskunov 

Also Fixes https://github.com/dotnet/roslyn-project-system/issues/589