### PR TITLE
Precompute and cache the bool value indicating if the project support…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/ProjectDesignerServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/ProjectDesignerServiceTests.cs
@@ -28,11 +28,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             var hierarchy = IVsHierarchyFactory.ImplementGetProperty(hr: VSConstants.E_FAIL);
             var projectVsServices = IUnconfiguredProjectVsServicesFactory.Implement(() => hierarchy);
 
-            var designerService = CreateInstance(projectVsServices);
-
             Assert.Throws<COMException>(() => {
 
-                var result = designerService.SupportsProjectDesigner;
+                var designerService = CreateInstance(projectVsServices);
             });
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/ProjectDesignerServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/ProjectDesignerServiceTests.cs
@@ -28,9 +28,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             var hierarchy = IVsHierarchyFactory.ImplementGetProperty(hr: VSConstants.E_FAIL);
             var projectVsServices = IUnconfiguredProjectVsServicesFactory.Implement(() => hierarchy);
 
+            var designerService = CreateInstance(projectVsServices);
+
             Assert.Throws<COMException>(() => {
 
-                var designerService = CreateInstance(projectVsServices);
+                var result = designerService.SupportsProjectDesigner;
             });
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/ProjectDesignerService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/ProjectDesignerService.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             Requires.NotNull(projectVsServices, nameof(projectVsServices));
 
             _projectVsServices = projectVsServices;
-            _lazySupportsProjectDesigner = new Lazy<bool>(() => _projectVsServices.VsHierarchy.GetProperty(VsHierarchyPropID.SupportsProjectDesigner, defaultValue: false));
+            _lazySupportsProjectDesigner = new Lazy<bool>(() => _projectVsServices.VsHierarchy.GetProperty(VsHierarchyPropID.SupportsProjectDesigner, defaultValue: false), mode: System.Threading.LazyThreadSafetyMode.PublicationOnly);
         }
 
         public bool SupportsProjectDesigner => _lazySupportsProjectDesigner.Value;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/ProjectDesignerService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/ProjectDesignerService.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
     internal class ProjectDesignerService : IProjectDesignerService
     {
         private readonly IUnconfiguredProjectVsServices _projectVsServices;
-        private readonly bool _supportsProjectDesigner;
+        private readonly Lazy<bool> _lazySupportsProjectDesigner;
 
         [ImportingConstructor]
         public ProjectDesignerService(IUnconfiguredProjectVsServices projectVsServices)
@@ -24,10 +24,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             Requires.NotNull(projectVsServices, nameof(projectVsServices));
 
             _projectVsServices = projectVsServices;
-            _supportsProjectDesigner = _projectVsServices.VsHierarchy.GetProperty(VsHierarchyPropID.SupportsProjectDesigner, defaultValue: false);
+            _lazySupportsProjectDesigner = new Lazy<bool>(() => _projectVsServices.VsHierarchy.GetProperty(VsHierarchyPropID.SupportsProjectDesigner, defaultValue: false));
         }
 
-        public bool SupportsProjectDesigner => _supportsProjectDesigner;
+        public bool SupportsProjectDesigner => _lazySupportsProjectDesigner.Value;
 
         public Task ShowProjectDesignerAsync()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/ProjectDesignerService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/ProjectDesignerService.cs
@@ -16,6 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
     internal class ProjectDesignerService : IProjectDesignerService
     {
         private readonly IUnconfiguredProjectVsServices _projectVsServices;
+        private readonly bool _supportsProjectDesigner;
 
         [ImportingConstructor]
         public ProjectDesignerService(IUnconfiguredProjectVsServices projectVsServices)
@@ -23,12 +24,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             Requires.NotNull(projectVsServices, nameof(projectVsServices));
 
             _projectVsServices = projectVsServices;
+            _supportsProjectDesigner = _projectVsServices.VsHierarchy.GetProperty(VsHierarchyPropID.SupportsProjectDesigner, defaultValue: false);
         }
 
-        public bool SupportsProjectDesigner
-        {
-            get { return _projectVsServices.VsHierarchy.GetProperty(VsHierarchyPropID.SupportsProjectDesigner, defaultValue: false); }
-        }
+        public bool SupportsProjectDesigner => _supportsProjectDesigner;
 
         public Task ShowProjectDesignerAsync()
         {


### PR DESCRIPTION
…s appdesigner or not.

This avoids invoking into the hierarchy while calculating property values for app designer folders and should address the CPS regression in #618.
Fixes #618.