### PR TITLE
Fix launching debugger when Launch type is set to Executable

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -49,7 +49,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// </summary>
         public bool SupportsProfile(ILaunchProfile profile)
         {
-            return string.IsNullOrWhiteSpace(profile.CommandName) || profile.CommandName.Equals(LaunchSettingsProvider.RunProjectCommandName, StringComparison.OrdinalIgnoreCase);
+            return string.IsNullOrWhiteSpace(profile.CommandName) ||
+                profile.CommandName.Equals(LaunchSettingsProvider.RunProjectCommandName, StringComparison.OrdinalIgnoreCase) ||
+                profile.CommandName.Equals(LaunchSettingsProvider.RunExecutableCommandName, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -69,6 +69,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         // Command that means run this project
         public  const string RunProjectCommandName = "Project";
 
+        //  Command that means run an executable
+        public const string RunExecutableCommandName = "Executable";
+
         // These are used internally to loop in debuggers to handle F5 when there are errors in 
         // the launch settings file or when there are no profiles specified (like class libraries)
         public  const string ErrorProfileCommandName = "ErrorProfile";


### PR DESCRIPTION
Fixes #655

@BillHiebert @jinujoseph 

The debug properties page is setting the `commandName` in `launchSettings.json` to `Executable`, while the `ConsoleDebugTargetsProvider` wasn't coded to expect that.
