### PR TITLE
Opt .Net Core Projects out of DPL

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
@@ -31,6 +31,7 @@ namespace Microsoft.VisualStudio.Packaging
     [GeneratorExtensionRegistration(SingleFileGenerators.TextTemplatingFileGeneratorExtension,
         SingleFileGenerators.TextTemplatingFileGenerator, ProjectTypeGuidFormatted)]
     [ClassRegistration(DebugPropertyClassId, DebugPropertyClassInfo)]
+    [DplOptOutRegistration(CSharpProjectSystemPackage.ProjectTypeGuid, true)]
     internal class CSharpProjectSystemPackage : AsyncPackage
     {
         public const string ProjectTypeGuid = "9A19103F-16F7-4668-BE54-9A1E7A4F7556";

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -34,6 +34,7 @@
     <Compile Include="Input\CommandGroup.cs" />
     <Compile Include="Input\UIHierarchyWindowCommandId.cs" />
     <Compile Include="Input\VisualStudioStandard97CommandId.cs" />
+    <Compile Include="Packaging\DplOptOutRegistrationAttribute.cs" />
     <Compile Include="ProjectSystem\VS\NuGet\ProjectProperties.cs" />
     <Compile Include="ProjectSystem\VS\NuGet\ProjectProperty.cs" />
     <Compile Include="ProjectSystem\VS\NuGet\VsItemList.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/DplOptOutRegistrationAttribute.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/DplOptOutRegistrationAttribute.cs
@@ -8,28 +8,20 @@ namespace Microsoft.VisualStudio.Packaging
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
     internal sealed class DplOptOutRegistrationAttribute : RegistrationAttribute
     {
+        private Guid _projectTypeGuid;
+        private bool _optOutDeferredProjectLoad;
+
         public DplOptOutRegistrationAttribute(string projectTypeGuid, bool optOutDeferredProjectLoad)
         {
-            this.ProjectTypeGuid = new Guid(projectTypeGuid);
-            this.OptOutDeferredProjectLoad = optOutDeferredProjectLoad;
+            _projectTypeGuid = new Guid(projectTypeGuid);
+            _optOutDeferredProjectLoad = optOutDeferredProjectLoad;
         }
-
-
-        /// <summary>
-        /// Gets a unique value specific to this project file extension.
-        /// </summary>
-        public Guid ProjectTypeGuid { get; private set; }
-
-        /// <summary>
-        /// Value to say if the project type wants to Opt out of Deferred Project Load.
-        /// </summary>
-        public bool OptOutDeferredProjectLoad { get; private set; }
 
         public override void Register(RegistrationContext context)
         {
             using (Key key = context.CreateKey(GetRegKeyName()))
             {
-                if (OptOutDeferredProjectLoad)
+                if (_optOutDeferredProjectLoad)
                 {
                     key.SetValue("AllowDeferredProjectLoad", "0");
                 }
@@ -43,7 +35,7 @@ namespace Microsoft.VisualStudio.Packaging
 
         private string GetRegKeyName()
         {
-            return string.Format(CultureInfo.InvariantCulture, "Projects\\{0}", this.ProjectTypeGuid.ToString("B"));
+            return string.Format(CultureInfo.InvariantCulture, "Projects\\{0}", _projectTypeGuid.ToString("B"));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/DplOptOutRegistrationAttribute.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/DplOptOutRegistrationAttribute.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.VisualStudio.Shell;
+using System;
+using System.Globalization;
+
+namespace Microsoft.VisualStudio.Packaging
+{
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+    internal sealed class DplOptOutRegistrationAttribute : RegistrationAttribute
+    {
+        public DplOptOutRegistrationAttribute(string projectTypeGuid, bool optOutDeferredProjectLoad)
+        {
+            this.ProjectTypeGuid = new Guid(projectTypeGuid);
+            this.OptOutDeferredProjectLoad = optOutDeferredProjectLoad;
+        }
+
+
+        /// <summary>
+        /// Gets a unique value specific to this project file extension.
+        /// </summary>
+        public Guid ProjectTypeGuid { get; private set; }
+
+        /// <summary>
+        /// Value to say if the project type wants to Opt out of Deferred Project Load.
+        /// </summary>
+        public bool OptOutDeferredProjectLoad { get; private set; }
+
+        public override void Register(RegistrationContext context)
+        {
+            using (Key key = context.CreateKey(GetRegKeyName()))
+            {
+                if (OptOutDeferredProjectLoad)
+                {
+                    key.SetValue("AllowDeferredProjectLoad", "0");
+                }
+            }
+        }
+
+        public override void Unregister(RegistrationContext context)
+        {
+            context.RemoveKey(GetRegKeyName());
+        }
+
+        private string GetRegKeyName()
+        {
+            return string.Format(CultureInfo.InvariantCulture, "Projects\\{0}", this.ProjectTypeGuid.ToString("B"));
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Packaging/VisualBasicProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Packaging/VisualBasicProjectSystemPackage.cs
@@ -28,6 +28,7 @@ namespace Microsoft.VisualStudio.Packaging
     [GeneratorExtensionRegistration(SingleFileGenerators.TextTemplatingFileGeneratorExtension,
         SingleFileGenerators.TextTemplatingFileGenerator, ProjectTypeGuidFormatted)]
     [ClassRegistration(DebugPropertyClassId, DebugPropertyClassInfo)]
+    [DplOptOutRegistration(VisualBasicProjectSystemPackage.ProjectTypeGuid, true)]
     internal class VisualBasicProjectSystemPackage : AsyncPackage
     {
         public const string ProjectTypeGuid = "778DAE3C-4631-46EA-AA77-85C1314464D9";


### PR DESCRIPTION
Deferred Project Load is yet to support globbing so we are opting .Net Core Projects out of DPL.

@srivatsn @dotnet/project-system for review