### PR TITLE
Switch to building the repo with VSSDK NuGet packages.

### DIFF
--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -106,7 +106,6 @@
 
   <PropertyGroup>
     <IsDev15RC Condition="Exists('$(MSBuildBinPath)\..\..\..\..\Microsoft.VisualStudio.ExtensionEngine.dll')">true</IsDev15RC>   
-    <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.25825-RC</VisualStudioBuildToolsNuGetPackagePath> 
   </PropertyGroup> 
   <Choose>
     <When Condition="'$(IsDev15RC)' == 'true'">

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -119,7 +119,8 @@
       </PropertyGroup> 
     </Otherwise>
   </Choose>
-  <Import Project="$(VisualStudioBuildToolsNuGetPackagePath)\build\Microsoft.VsSDK.BuildTools.props" Condition="'$(OS)' == 'Windows_NT'" /> 
+  <Import Project="$(VisualStudioBuildToolsNuGetPackagePath)\build\Microsoft.VsSDK.BuildTools.props" 
+          Condition="'$(OS)' == 'Windows_NT' And Exists('$(VisualStudioBuildToolsNuGetPackagePath)\build\Microsoft.VsSDK.BuildTools.props')" /> 
 
   <!-- Build reliability -->
   <PropertyGroup>

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -104,6 +104,24 @@
     </Otherwise>
   </Choose>
 
+  <PropertyGroup>
+    <IsDev15RC Condition="Exists('$(MSBuildBinPath)\..\..\..\..\Microsoft.VisualStudio.ExtensionEngine.dll')">true</IsDev15RC>   
+    <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.25825-RC</VisualStudioBuildToolsNuGetPackagePath> 
+  </PropertyGroup> 
+  <Choose>
+    <When Condition="'$(IsDev15RC)' == 'true'">
+      <PropertyGroup>
+        <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.25825-RC</VisualStudioBuildToolsNuGetPackagePath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.25728-Preview5</VisualStudioBuildToolsNuGetPackagePath>
+      </PropertyGroup> 
+    </Otherwise>
+  </Choose>
+  <Import Project="$(VisualStudioBuildToolsNuGetPackagePath)\build\Microsoft.VsSDK.BuildTools.props" Condition="'$(OS)' == 'Windows_NT'" /> 
+
   <!-- Build reliability -->
   <PropertyGroup>
     <OverwriteReadOnlyFiles Condition="'$(OverwriteReadOnlyFiles)' == ''">true</OverwriteReadOnlyFiles>

--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -381,8 +381,8 @@
 
        ==================================================================================== -->
 
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\VSSDK\Microsoft.VsSDK.targets"
-          Condition="'$(ImportVSSDKTargets)' == 'true' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\VSSDK\Microsoft.VsSDK.targets')" />
+  <Import Project="$(VisualStudioBuildToolsNuGetPackagePath)\build\Microsoft.VsSDK.BuildTools.targets" Condition="'$(ImportVSSDKTargets)' == 'true'" /> 
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(ImportVSSDKTargets)' == 'true'" />
   
   <!-- ====================================================================================
 

--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -381,8 +381,8 @@
 
        ==================================================================================== -->
 
-  <Import Project="$(VisualStudioBuildToolsNuGetPackagePath)\build\Microsoft.VsSDK.BuildTools.targets" Condition="'$(ImportVSSDKTargets)' == 'true'" /> 
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(ImportVSSDKTargets)' == 'true'" />
+  <Import Project="$(VisualStudioBuildToolsNuGetPackagePath)\build\Microsoft.VsSDK.BuildTools.targets" Condition="'$(ImportVSSDKTargets)' == 'true' And Exists('$(VisualStudioBuildToolsNuGetPackagePath)')" /> 
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(ImportVSSDKTargets)' == 'true' And Exists('$(VSToolsPath)')" />
   
   <!-- ====================================================================================
 

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -4,7 +4,6 @@
     <RoslynSemanticVersion Condition="'$(RoslynSemanticVersion)' == ''">2.0.0</RoslynSemanticVersion>
     <MicroBuildVersion>0.2.0</MicroBuildVersion>
     <BuildNumber Condition="'$(BuildNumber)' == ''">$(BUILD_BUILDNUMBER)</BuildNumber>
-    <BuildNumber Condition="'$(BuildNumber)' == ''">00000000.01</BuildNumber>
     <BuildNumberPart1>$(BuildNumber.Split('.')[0])</BuildNumberPart1>
     <BuildNumberPart2 Condition="($(BuildNumber.Split('.').Length) == 2)">$(BuildNumber.Split('.')[1].PadLeft(2,'0'))</BuildNumberPart2>
   </PropertyGroup>

--- a/src/Dependencies/Toolset.Previous/Toolset.Previous.csproj
+++ b/src/Dependencies/Toolset.Previous/Toolset.Previous.csproj
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
+  <PropertyGroup>
+    <ProjectGuid>{244BA98B-F80C-4BE4-BAE4-D48FFD7BCE95}</ProjectGuid>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectSystemLayer>Dependency</ProjectSystemLayer>
+  </PropertyGroup>
+  <ItemGroup>
+    <Content Include="project.json" />
+  </ItemGroup>
+  <Import Project="..\..\..\build\Targets\ProducesNoOutput.Imports.targets" />
+</Project>

--- a/src/Dependencies/Toolset.Previous/project.json
+++ b/src/Dependencies/Toolset.Previous/project.json
@@ -1,0 +1,12 @@
+{
+  "supports": { },
+  "dependencies": {
+    "Microsoft.VSSDK.BuildTools": {
+      "version": "15.0.25728-Preview5",
+      "exclude": "build"
+    },
+  },
+  "frameworks": {
+    ".NETPortable,Version=v4.5,Profile=Profile7": { }
+  }
+}

--- a/src/Dependencies/Toolset/project.json
+++ b/src/Dependencies/Toolset/project.json
@@ -9,6 +9,10 @@
     "Microsoft.Net.RoslynDiagnostics": {
       "version": "1.2.0-beta2",
       "exclude": "build"
+    },
+    "Microsoft.VSSDK.BuildTools": {
+      "version": "15.0.25825-RC",
+      "exclude": "build"
     }
   },
   "frameworks": {

--- a/src/ProjectSystem.sln
+++ b/src/ProjectSystem.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.25727.0
+VisualStudioVersion = 15.0.25817.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeployTestDependencies", "DeployTestDependencies\DeployTestDependencies.csproj", "{37BA82E6-9ABD-4ACA-AA26-2DFD39A359A5}"
 EndProject
@@ -85,6 +85,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Json.net", "Dependencies\Json.net\Json.net.csproj", "{CA374AF1-C983-4019-8FD0-01FA510C6E56}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSBuild", "Dependencies\MSBuild\MSBuild.csproj", "{83B4B0CC-33C2-46E3-A330-DFF43A0EC18D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Toolset.Previous", "Dependencies\Toolset.Previous\Toolset.Previous.csproj", "{244BA98B-F80C-4BE4-BAE4-D48FFD7BCE95}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -217,6 +219,10 @@ Global
 		{83B4B0CC-33C2-46E3-A330-DFF43A0EC18D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{83B4B0CC-33C2-46E3-A330-DFF43A0EC18D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{83B4B0CC-33C2-46E3-A330-DFF43A0EC18D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{244BA98B-F80C-4BE4-BAE4-D48FFD7BCE95}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{244BA98B-F80C-4BE4-BAE4-D48FFD7BCE95}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{244BA98B-F80C-4BE4-BAE4-D48FFD7BCE95}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{244BA98B-F80C-4BE4-BAE4-D48FFD7BCE95}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -233,5 +239,6 @@ Global
 		{03AB838C-1B9D-4ECA-856F-476616C35F0C} = {FD7E1AB8-9A44-4C31-A126-D6AF289C2C95}
 		{CA374AF1-C983-4019-8FD0-01FA510C6E56} = {FD7E1AB8-9A44-4C31-A126-D6AF289C2C95}
 		{83B4B0CC-33C2-46E3-A330-DFF43A0EC18D} = {FD7E1AB8-9A44-4C31-A126-D6AF289C2C95}
+		{244BA98B-F80C-4BE4-BAE4-D48FFD7BCE95} = {FD7E1AB8-9A44-4C31-A126-D6AF289C2C95}
 	EndGlobalSection
 EndGlobal

--- a/src/ProjectSystemDogfoodSetup/source.extension.vsixmanifest
+++ b/src/ProjectSystemDogfoodSetup/source.extension.vsixmanifest
@@ -11,6 +11,9 @@
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VWDExpress" />
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VSWinExpress" />
   </Installation>
+  <Prerequisites>  
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />  
+  </Prerequisites>  
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />
   </Dependencies>

--- a/src/ProjectSystemSetup/source.extension.vsixmanifest
+++ b/src/ProjectSystemSetup/source.extension.vsixmanifest
@@ -12,6 +12,9 @@
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VWDExpress" />
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VSWinExpress" />
   </Installation>
+  <Prerequisites>  
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />  
+  </Prerequisites>  
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />
   </Dependencies>

--- a/src/VisualStudioEditorsSetup/source.extension.vsixmanifest
+++ b/src/VisualStudioEditorsSetup/source.extension.vsixmanifest
@@ -12,6 +12,9 @@
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VWDExpress" />
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VSWinExpress" />
   </Installation>
+  <Prerequisites>  
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />  
+  </Prerequisites>  
   <Installer>
     <Actions>
       <Action Type="Ngen" Path="Microsoft.VisualStudio.Editors.dll" />


### PR DESCRIPTION
- Instead of using the VSSDK on the machine, use the NuGet packages.
- Building using RC packages fails on a Preview5 machine because it's still not cleanly separated out. Use a hack (that Roslyn put in today as well) to identify RC and switch packages based on that.
- Add Prerequisites section so that it builds with the RC package.
- Remove an errant BuildNumber property that broke local build versioning of 42.42.42.42

@dotnet/project-system @mavasani @333fred @RaulPerez1