### PR TITLE
Undo revert of dependencies bug fixes to complete PR

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -124,6 +124,7 @@
     <Compile Include="ProjectSystem\VS\Rename\SimpleRenamerTests.cs" />
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\DependenciesGraphProviderTests.cs" />
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\DependenciesSubTreeProviderBaseTests.cs" />
+    <Compile Include="ProjectSystem\VS\Tree\Dependencies\ProjectDependenciesSubTreeProviderTests.cs" />
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\NuGetDependenciesSubTreeProviderTests.cs" />
     <Compile Include="ProjectSystem\VS\UI\MultiChoiceMsgBoxViewModelTests.cs" />
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\DependencyNodeTests.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProviderTests.cs
@@ -393,6 +393,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             var mockProvider = new IProjectDependenciesSubTreeProviderMock();
             mockProvider.RootNode = rootNode;
+            mockProvider.AddTestDependencyNodes(new[] { topNode1, topNode2, topNode3 });
             mockProvider.AddSearchResults(new[] { topNode1, topNode2, topNode3 });
 
             var mockProjectContextProvider =

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProviderTests.cs
@@ -142,7 +142,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.True(inputNode.GetValue(DependenciesGraphSchema.ProviderProperty) is IProjectDependenciesSubTreeProviderMock);
         }
 
-        [Fact(Skip="https://github.com/dotnet/roslyn-project-system/issues/431")]
+        [Fact]
         public async Task DependenciesGraphProvider_GetChildrenAsync()
         {
             var projectPath = @"c:\myproject\project.csproj";
@@ -192,7 +192,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.False(childGraphNode.GetValue<bool>(DgmlNodeProperties.ContainsChildren));
             Assert.True(childGraphNode.GetValue(DependenciesGraphSchema.ProviderProperty) is IProjectDependenciesSubTreeProviderMock);
             Assert.Equal(1, childGraphNode.IncomingLinkCount);
-            Assert.Equal(1, provider.GetExpandedGraphContexts().Count());
             Assert.Equal(1, provider.GetRegisteredSubTreeProviders().Count());
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyNodeIdTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyNodeIdTests.cs
@@ -45,6 +45,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Theory]
+        [InlineData("MyProviderType", @"c:/somepath/xxx", "MyItemType", "c:/otherfolder/otherpath",
+                    @"file:///[MyProviderType;c:\somepath\xxx;MyItemType;c:\otherfolder\otherpath]")]
+        [InlineData("MyProviderType", @"c:/somepath/xxx", "MyItemType", null,
+                    @"file:///[MyProviderType;c:\somepath\xxx;MyItemType;]")]
+        [InlineData("MyProviderType", null, null, null,
+                    "file:///[MyProviderType;;;]")]
+        public void DependencyNodeId_ToNormalizedId(string providerType,
+                                                   string itemSpec,
+                                                   string itemType,
+                                                   string uniqueToken,
+                                                   string expectedResult)
+        {
+            var id = new DependencyNodeId(providerType, itemSpec, itemType, uniqueToken);
+
+            Assert.Equal(expectedResult, id.ToNormalizedId().ToString());
+        }
+
+        [Theory]
         [InlineData("file:///[MyProviderType;MyItemSpec;MyItemType;MyUniqueToken]",
                     "MyProviderType", "MyItemSpec", "MyItemType", "MyUniqueToken")]
         [InlineData("",

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyNodeTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyNodeTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                             string expectedCaption)
         {
             // Arrange
-            var priority = 3;
+            var priority = DependencyNode.FrameworkAssemblyNodePriority;
             var id = DependencyNodeId.FromString(
                         "file:///[MyProviderType;c:\\MyItemSpec.dll;MyItemType;MyUniqueToken]");
             var properties = new Dictionary<string, string>().ToImmutableDictionary();
@@ -165,7 +165,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                             string fusionName)
         {
             // Arrange
-            var priority = 3;
+            var priority = DependencyNode.FrameworkAssemblyNodePriority;
             var id = DependencyNodeId.FromString(
                         "file:///[MyProviderType;c:\\MyItemSpec.dll;MyItemType;MyUniqueToken]");
             var properties = new Dictionary<string, string>().ToImmutableDictionary();
@@ -198,7 +198,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     string expectedCaption)
         {
             // Arrange
-            var priority = 3;
+            var priority = DependencyNode.AnalyzerNodePriority;
             var id = DependencyNodeId.FromString(
                         $"file:///[AnalyzerDependency;{itemSpec};Analyzer;MyUniqueToken]");
             var properties = new Dictionary<string, string>().ToImmutableDictionary();
@@ -230,7 +230,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var expectedIcon = resolved
                 ? KnownMonikers.Component
                 : KnownMonikers.ReferenceWarning;
-            var priority = 3;
+            var priority = DependencyNode.ComNodePriority;
             var id = DependencyNodeId.FromString(
                         "file:///[MyProviderType;c:\\MyItemSpec.dll;MyItemType;MyUniqueToken]");
             var properties = new Dictionary<string, string>().ToImmutableDictionary();
@@ -262,7 +262,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var expectedIcon = resolved
                 ? KnownMonikers.BrowserSDK
                 : KnownMonikers.ReferenceWarning;
-            var priority = 3;
+            var priority = DependencyNode.SdkNodePriority;
             var id = DependencyNodeId.FromString(
                         "file:///[MyProviderType;c:\\MyItemSpec.dll;MyItemType;MyUniqueToken]");
             var properties = new Dictionary<string, string>().ToImmutableDictionary();
@@ -455,8 +455,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 .Add(ProjectTreeFlags.Common.ResolvedReference);
 
             var priority = resolved
-                            ? NuGetDependenciesSubTreeProvider.PackageAssemblyNodePriority
-                            : NuGetDependenciesSubTreeProvider.UnresolvedReferenceNodePriority;
+                            ? DependencyNode.PackageAssemblyNodePriority
+                            : DependencyNode.UnresolvedReferenceNodePriority;
 
             var caption = "MyCaption";
             var id = DependencyNodeId.FromString(
@@ -508,8 +508,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 .Add(ProjectTreeFlags.Common.ResolvedReference);
 
             var priority = resolved
-                            ? NuGetDependenciesSubTreeProvider.PackageAssemblyNodePriority
-                            : NuGetDependenciesSubTreeProvider.UnresolvedReferenceNodePriority;
+                            ? DependencyNode.PackageAssemblyNodePriority
+                            : DependencyNode.UnresolvedReferenceNodePriority;
 
             var caption = "MyCaption";
             var id = DependencyNodeId.FromString(
@@ -561,8 +561,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 .Add(ProjectTreeFlags.Common.ResolvedReference);
 
             var priority = resolved
-                            ? NuGetDependenciesSubTreeProvider.PackageNodePriority
-                            : NuGetDependenciesSubTreeProvider.UnresolvedReferenceNodePriority;
+                            ? DependencyNode.PackageNodePriority
+                            : DependencyNode.UnresolvedReferenceNodePriority;
 
             var caption = "MyCaption";
             var id = DependencyNodeId.FromString(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/NuGetDependenciesSubTreeProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/NuGetDependenciesSubTreeProviderTests.cs
@@ -324,7 +324,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             ""Id"": {
                 ""ProviderType"": ""NuGetDependency"",
-                ""ItemSpec"": ""tfm1/package1/1.0.2.0"",
+                ""ItemSpec"": ""tfm1/package1/1.0.0"",
                 ""ItemType"": ""PackageReference""
             }
         }
@@ -334,7 +334,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     ""RemovedNodes"": [
     ]
 }")]
-        public void NuGetDependenciesSubTreeProvider_ProcessDependenciesChanges_EmptyTreeAndBothReolvedAndUnresolvedAreProvided(
+        public void NuGetDependenciesSubTreeProvider_ProcessDependenciesChanges_EmptyTreeAndBothResolvedAndUnresolvedAreProvided(
                         string projectSubscriptionUpdateJson,
                         string existingTopLevelNodesJson,
                         string existingDependenciesChanges)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/NuGetDependenciesSubTreeProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/NuGetDependenciesSubTreeProviderTests.cs
@@ -17,15 +17,38 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     {
         [Theory]
         /* 
-            Tests 
-               - added items 
-               - removed items
-               - changed items and verifies that properties were updated in CurrentSnapshot
+            Tests following scenarios:
+               - added new resolved items 
+               - removed resolved items
+               - changed resolved items and verifies that properties were updated in CurrentSnapshot
+               - adding same package as unresolved and resolved - resolved should win
+               - add new unresolved package
+               - for existing unresolved package, add a resolved package - existing one should be gone from teh tree
+               - top level packages from all TFMs are added
          */
         [InlineData(
 @"{
     ""ProjectChanges"": {
-        ""itemtype1"": {
+        ""PackageReference"": {
+            ""After"": {
+                ""Items"": {
+                    ""unresolvedpackage1"": {
+                        ""Version"": ""1.0.0""
+                    },
+                    ""ToBeOverridenByResolvedPackage"": {
+                        ""Version"": ""1.0.0""
+                    }
+                },
+                ""RuleName"": ""PackageReference""
+            },
+            ""Difference"": {
+                ""AddedItems"": [ ""unresolvedpackage1"", ""ToBeOverridenByResolvedPackage"" ],
+                ""ChangedItems"": [ ],
+                ""RemovedItems"": [ ],
+                ""AnyChanges"": ""true""
+            },
+        },
+        ""ResolvedPackageReference"": {
             ""After"": {
                 ""Items"": {
                     ""tfm1"": {
@@ -33,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                         ""TargetFrameworkMoniker"": "".NetFramework,Version=v4.5"",
                         ""FrameworkName"": ""net45"",
                         ""FrameworkVersion"": ""4.5"",
-                        ""Dependencies"":""package1/1.0.2.0""
+                        ""Dependencies"":""package1/1.0.2.0;ToBeOverridenByResolvedPackage/1.0.0""
                     },
                     ""tfm1/package1/1.0.2.0"": {
                         ""Name"": ""package"",
@@ -58,25 +81,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                         ""Path"":""SomePath"",
                         ""Resolved"":""true"",
                         ""Dependencies"":""""
-                    }
-                }
-            },
-            ""Difference"": {
-                ""AddedItems"": [ ""tfm1"", ""tfm1/package1/1.0.2.0"" ],
-                ""ChangedItems"": [ ""tfm1/PackageToChange/2.0.0"", ""tfm1/PackageToChange2/2.0.0"" ],
-                ""RemovedItems"": [ ""tfm1/PackageToRemove/1.0.0"" ],
-                ""AnyChanges"": ""true""
-            },
-        },
-        ""itemtype2"": {
-            ""After"": {
-                ""Items"": {
+                    },
                     ""tfm2"": {
                         ""RuntimeIdentifier"": ""net45"",
                         ""TargetFrameworkMoniker"": "".NetFramework,Version=v4.5"",
                         ""FrameworkName"": ""net45"",
                         ""FrameworkVersion"": ""4.5"",
-                        ""Dependencies"":""package1/1.0.2.0""
+                        ""Dependencies"":""package1/1.0.2.0;ExistingUnresolvedPackage/2.0.0""
                     },
                     ""tfm1/package2/1.0.2.0"": {
                         ""Name"": ""package2"",
@@ -85,14 +96,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                         ""Path"":""SomePath2"",
                         ""Resolved"":""true"",
                         ""Dependencies"":""""
+                    },
+                    ""tfm1/ToBeOverridenByResolvedPackage/1.0.0"": {
+                        ""Name"": ""ToBeOverridenByResolvedPackage"",
+                        ""Version"": ""1.0.0"",
+                        ""Type"":""Package"",
+                        ""Path"":""SomePath2"",
+                        ""Resolved"":""true"",
+                        ""Dependencies"":""""
+                    },
+                    ""tfm2/ExistingUnresolvedPackage/2.0.0"": {
+                        ""Name"": ""ExistingUnresolvedPackage"",
+                        ""Version"": ""2.0.0"",
+                        ""Type"":""Package"",
+                        ""Path"":""SomePath3"",
+                        ""Resolved"":""true"",
+                        ""Dependencies"":""""
                     }
-                }
+                },
+                ""RuleName"": ""ResolvedPackageReference""
             },
             ""Difference"": {
-                ""AddedItems"": [ ""tfm2"", ""tfm1/package2/1.0.2.0"" ],
-                ""ChangedItems"": [ ],
-                ""RemovedItems"": [  ],
-                ""AnyChanges"": ""false""
+                ""AddedItems"": [ ""tfm1"", ""tfm1/package1/1.0.2.0"", ""tfm2"", ""tfm1/package2/1.0.2.0"", 
+                                  ""tfm1/ToBeOverridenByResolvedPackage/1.0.0"", ""tfm2/ExistingUnresolvedPackage/2.0.0"" ],
+                ""ChangedItems"": [ ""tfm1/PackageToChange/2.0.0"", ""tfm1/PackageToChange2/2.0.0"" ],
+                ""RemovedItems"": [ ""tfm1/PackageToRemove/1.0.0"" ],
+                ""AnyChanges"": ""true""
             },
         }
     }
@@ -113,6 +142,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 ""ItemSpec"": ""tfm1/PackageToChange/2.0.0"",
                 ""ItemType"": ""PackageReference""
             }
+        },
+        {
+            ""Id"": {
+                ""ProviderType"": ""NuGetDependency"",
+                ""ItemSpec"": ""ExistingUnresolvedPackage"",
+                ""ItemType"": ""PackageReference""
+            }
         }
     ]  
 }",
@@ -125,6 +161,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             ""Id"": {
                 ""ProviderType"": ""NuGetDependency"",
                 ""ItemSpec"": ""tfm1/package1/1.0.2.0"",
+                ""ItemType"": ""PackageReference""
+            }
+        },
+        {
+            ""Id"": {
+                ""ProviderType"": ""NuGetDependency"",
+                ""ItemSpec"": ""unresolvedpackage1"",
+                ""ItemType"": ""PackageReference""
+            }
+        },
+        {
+            ""Id"": {
+                ""ProviderType"": ""NuGetDependency"",
+                ""ItemSpec"": ""tfm1/ToBeOverridenByResolvedPackage/1.0.0"",
+                ""ItemType"": ""PackageReference""
+            }
+        },
+        {
+            ""Id"": {
+                ""ProviderType"": ""NuGetDependency"",
+                ""ItemSpec"": ""tfm2/ExistingUnresolvedPackage/2.0.0"",
                 ""ItemType"": ""PackageReference""
             }
         }
@@ -143,6 +200,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             ""Id"": {
                 ""ProviderType"": ""NuGetDependency"",
                 ""ItemSpec"": ""tfm1/PackageToRemove/1.0.0"",
+                ""ItemType"": ""PackageReference""
+            }
+        },
+        {
+            ""Id"": {
+                ""ProviderType"": ""NuGetDependency"",
+                ""ItemSpec"": ""ExistingUnresolvedPackage"",
                 ""ItemType"": ""PackageReference""
             }
         }
@@ -168,9 +232,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             // Check that for updated/changed nodes, properties were updated  
             var propertyToCheck = "Version";
             var itemsProperties = projectSubscriptionUpdate.ProjectChanges.Values
-                                                            .Where(y => y.Difference.AnyChanges)
-                                                            .Select(x => x.After.Items)
-                                                            .FirstOrDefault();
+                                    .Where(y => y.Difference.AnyChanges 
+                                                && y.Difference.ChangedItems.Any(x=> x.Equals(packageToTestVersionUpdate)))
+                                    .Select(x => x.After.Items)
+                                    .FirstOrDefault();
             var expectedPropertyValue = itemsProperties[packageToTestVersionUpdate][propertyToCheck];
 
             var properties = provider.GetDependencyProperties(packageToTestVersionUpdate);
@@ -184,7 +249,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var currentSnapshot = provider.GetCurrentSnapshotDependenciesWorld();
             foreach(var addedNode in expectedResult.AddedNodes)
             {
-                Assert.True(currentSnapshot.Any(x => x.Equals(addedNode.Id.ItemSpec, StringComparison.OrdinalIgnoreCase)));
+                if (addedNode.Id.ItemSpec.Contains("/"))
+                {
+                    // if it is a resolved package 
+                    Assert.True(currentSnapshot.Any(x => x.Equals(addedNode.Id.ItemSpec, StringComparison.OrdinalIgnoreCase)));
+                }
             }
         }
 
@@ -591,6 +660,87 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
+        public void NuGetDependenciesSubTreeProvider_DependenciesSnapshot_GetUniqueTopLevelDependencies()
+        {
+            var provider = new TestableNuGetDependenciesSubTreeProvider();
+
+            var snapshotJson = @"
+{
+    ""NodesCache"": [ ],
+    ""DependenciesWorld"": [
+        {
+            ""ItemSpec"": ""tfm1"",
+            ""Properties"": {
+                ""Name"": ""tfm1"",
+                ""Type"": ""Target"",
+                ""Dependencies"": ""Package3/2.0.0;Package2/1.0.0""
+            }
+        },
+        {
+            ""ItemSpec"": ""tfm1/Package3/2.0.0"",
+            ""Properties"": {
+                ""Name"": ""Package3"",
+                ""Version"": ""2.0.0"",
+                ""Type"": ""Package"",
+                ""Path"": ""SomePath"",
+                ""Resolved"": ""true"",
+                ""Dependencies"": """"
+            }
+        },
+        {
+            ""ItemSpec"": ""tfm1/Package2/1.0.0"",
+            ""Properties"": {
+                ""Name"": ""Package2"",
+                ""Version"": ""1.0.0"",
+                ""Type"": ""Package"",
+                ""Path"": ""SomePath"",
+                ""Resolved"": ""true"",
+                ""Dependencies"": """"
+            }
+        },
+        {
+            ""ItemSpec"": ""tfm2"",
+            ""Properties"": {
+                ""Name"": ""tfm2"",
+                ""Type"": ""Target"",
+                ""Dependencies"": ""Package1/1.0.0""
+            }
+        },
+        {
+            ""ItemSpec"": ""tfm2/Package1/1.0.0"",
+            ""Properties"": {
+                ""Name"": ""Package1"",
+                ""Version"": ""1.0.0"",
+                ""Type"": ""Package"",
+                ""Path"": ""SomePath"",
+                ""Resolved"": ""true"",
+                ""Dependencies"": """"
+            }
+        },
+        {
+            ""ItemSpec"": ""tfm2/Package2/1.0.0"",
+            ""Properties"": {
+                ""Name"": ""Package2"",
+                ""Version"": ""1.0.0"",
+                ""Type"": ""Package"",
+                ""Path"": ""SomePath"",
+                ""Resolved"": ""true"",
+                ""Dependencies"": """"
+            }
+        }
+    ]
+}";
+            provider.LoadSnapshotFromJson(snapshotJson);
+
+            var topLevelDependencies = provider.GetUniqueTopLevelDependencies();
+
+            Assert.Equal(3, topLevelDependencies.Count);
+            Assert.True(topLevelDependencies.Contains("tfm1/Package3/2.0.0"));
+            Assert.True(topLevelDependencies.Contains("tfm1/Package2/1.0.0"));
+            Assert.True(topLevelDependencies.Contains("tfm2/Package1/1.0.0"));
+        }
+
+        [Fact]
         public void NuGetDependenciesSubTreeProvider_DependenciesSnapshot_UpdateDependency()
         {
             var provider = new TestableNuGetDependenciesSubTreeProvider();
@@ -735,7 +885,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             var provider = new TestableNuGetDependenciesSubTreeProvider();
 
-            Assert.Equal(0, provider.GetUnresolvedReferenceRuleNames().Count());
+            Assert.Equal(1, provider.GetUnresolvedReferenceRuleNames().Count());
         }
 
         [Fact]
@@ -881,9 +1031,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 {
                     foreach(var dependency in data.DependenciesWorld)
                     {
-                        CurrentSnapshot.DependenciesWorld.Add(dependency.ItemSpec,
-                                                              new DependencyMetadata(dependency.ItemSpec, 
-                                                                                     dependency.Properties));
+                        CurrentSnapshot.AddDependency(dependency.ItemSpec, dependency.Properties);
                     }
                 }
             }
@@ -901,6 +1049,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             public void RemoveDependencyFromSnapshot(string itemSpec)
             {
                 CurrentSnapshot.RemoveDependency(itemSpec);
+            }
+
+            public HashSet<string> GetUniqueTopLevelDependencies()
+            {
+                return CurrentSnapshot.GetUniqueTopLevelDependencies();
             }
 
             public void AddChildToNodeInCache(string itemSpec, IDependencyNode childNode)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/ProjectDependenciesSubTreeProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/ProjectDependenciesSubTreeProviderTests.cs
@@ -1,0 +1,191 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.IO;
+using Microsoft.VisualStudio.Imaging;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
+{
+    [ProjectSystemTrait]
+    public class ProjectDependenciesSubTreeProviderTests
+    {
+        [Fact]
+        public void ProjectDependenciesSubTreeProvider_CreateRootNode()
+        {
+            var provider = new TestableProjectDependenciesSubTreeProvider(null, null);
+
+            var rootNode = provider.TestCreateRootNode();
+
+            Assert.True(rootNode is SubTreeRootDependencyNode);
+            Assert.True(rootNode.Flags.Contains(provider.ProjectSubTreeRootNodeFlags));
+            Assert.Equal("Projects", rootNode.Caption);
+            Assert.Equal(KnownMonikers.ApplicationGroup, rootNode.Icon);
+            Assert.Equal(ProjectDependenciesSubTreeProvider.ProviderTypeString, rootNode.Id.ProviderType);
+        }
+
+        [Fact]
+        public void ProjectDependenciesSubTreeProvider_GetDependencyNode()
+        {
+            // Arrange
+            var projectPath = @"c:\myproject\project.csproj";
+
+            // our provider under test nodes
+            var myRootNode = IDependencyNodeFactory.FromJson(@"
+{
+    ""Id"": {
+        ""ProviderType"": ""ProviderUnderTest"",
+        ""ItemSpec"": ""RootNodeUnderTest""
+    }
+}");
+
+            var myTopNode1 = IDependencyNodeFactory.FromJson(@"
+{
+    ""Id"": {
+        ""ProviderType"": ""ProviderUnderTest"",
+        ""ItemSpec"": ""MyTopNodeItemSpec1""
+    }
+}");
+
+            var myDependencyNode1 = IDependencyNodeFactory.FromJson(@"
+{
+    ""Id"": {
+        ""ProviderType"": ""ProviderUnderTest"",
+        ""ItemSpec"": ""MyDependencyNodeItemSpec1"",
+        ""UniqueToken"":""c:\\myproject\\project.csproj""
+    }
+}");
+
+            myTopNode1.Children.Add(myDependencyNode1);
+            myRootNode.Children.Add(myTopNode1);
+
+            // other provider nodes
+            var otherProviderRootNode = IDependencyNodeFactory.FromJson(@"
+{
+    ""Id"": {
+        ""ProviderType"": ""MyProvider"",
+        ""ItemSpec"": ""MyRootNode""
+    }
+}");
+
+            var topNode1 = IDependencyNodeFactory.FromJson(@"
+{
+    ""Id"": {
+        ""ProviderType"": ""MyProvider"",
+        ""ItemSpec"": ""MyTopNodeItemSpec""
+    }
+}");
+            var topNode2 = IDependencyNodeFactory.FromJson(@"
+{
+    ""Id"": {
+        ""ProviderType"": ""MyProvider"",
+        ""ItemSpec"": ""MyTopNodeItemSpec/1.0.0""
+    }
+}");
+
+            var topNode3 = IDependencyNodeFactory.FromJson(@"
+{
+    ""Id"": {
+        ""ProviderType"": ""MyProvider"",
+        ""ItemSpec"": ""MyTopNodeItemSpec3/1.0.0""
+    }
+}");
+
+            var childNode1 = IDependencyNodeFactory.FromJson(@"
+{
+    ""Id"": {
+        ""ProviderType"": ""MyProvider"",
+        ""ItemSpec"": ""MyChildNodeItemSpec1.0""
+    }
+}");
+
+            var childNode2 = IDependencyNodeFactory.FromJson(@"
+{
+    ""Id"": {
+        ""ProviderType"": ""MyProvider"",
+        ""ItemSpec"": ""MyChildNodeItemSpec/1.0.0""
+    }
+}");
+
+            var childNode3 = IDependencyNodeFactory.FromJson(@"
+{
+    ""Id"": {
+        ""ProviderType"": ""MyProvider"",
+        ""ItemSpec"": ""MyChildNodeItemSpec""
+    }
+}");
+            topNode1.Children.Add(childNode1);
+            topNode2.Children.Add(childNode3);
+            topNode2.Children.Add(childNode2);
+            otherProviderRootNode.AddChild(topNode1);
+            otherProviderRootNode.AddChild(topNode2);
+            otherProviderRootNode.AddChild(topNode3);
+
+            var mockProvider = new IProjectDependenciesSubTreeProviderMock();
+            mockProvider.RootNode = otherProviderRootNode;
+            mockProvider.AddTestDependencyNodes(new[] { topNode1, topNode2, topNode3 });
+            var mockProjectContextProvider = IDependenciesGraphProjectContextProviderFactory.Implement(
+                                                projectPath, subTreeProviders: new[] { mockProvider });
+
+            var provider = new TestableProjectDependenciesSubTreeProvider(unconfiguredProject:null,
+                                                                          projectContextProvider: mockProjectContextProvider);
+            provider.SetRootNode(myRootNode);
+
+            // Act 
+            var resultNode = provider.GetDependencyNode(myDependencyNode1.Id);                       
+
+            // Assert
+            Assert.Equal(resultNode.Id, myDependencyNode1.Id);
+            Assert.Equal(3, resultNode.Children.Count);
+        }
+
+        [Fact]
+        public void ProjectDependenciesSubTreeProvider_CreateDependencyNode()
+        {
+            // Arrange
+            var projectPath = @"c:\mySolution\myproject\project.csproj";
+            var testProjectPath = @"..\testProjectsubfolder\testproject.csproj";
+
+            var mockUnconfiguredProject = IUnconfiguredProjectFactory.Create(filePath: projectPath);
+
+            var provider = new TestableProjectDependenciesSubTreeProvider(unconfiguredProject: mockUnconfiguredProject,
+                                                                          projectContextProvider: null);
+
+            // Act 
+            var resultNode = provider.TestCreateDependencyNode(testProjectPath, "myItemType");
+
+            Assert.Equal(resultNode.Id.ItemSpec, testProjectPath);
+            Assert.Equal(resultNode.Id.UniqueToken, 
+                         Path.GetFullPath(Path.Combine(Path.GetDirectoryName(projectPath), testProjectPath)));
+        }
+
+        private class TestableProjectDependenciesSubTreeProvider : ProjectDependenciesSubTreeProvider
+        {
+            public TestableProjectDependenciesSubTreeProvider(
+                        UnconfiguredProject unconfiguredProject,
+                        IDependenciesGraphProjectContextProvider projectContextProvider)
+                : base(unconfiguredProject, projectContextProvider)
+            {
+            }
+
+            public IDependencyNode TestCreateRootNode()
+            {
+                return CreateRootNode();
+            }
+
+            public IDependencyNode TestCreateDependencyNode(string itemSpec,
+                                                            string itemType,
+                                                            int priority = 0,
+                                                            IImmutableDictionary<string, string> properties = null,
+                                                            bool resolved = true)
+            {
+                return CreateDependencyNode(itemSpec, itemType, priority, properties, resolved);
+            }
+
+            public void SetRootNode(IDependencyNode node)
+            {
+                RootNode = node;                
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -130,6 +130,7 @@
     <Compile Include="ProjectSystem\VS\RoslynServices.cs" />
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\AnalyzerDependenciesSubTreeProvider.cs" />
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\AnalyzerDependencyNode.cs" />
+    <Compile Include="ProjectSystem\VS\Tree\Dependencies\DependencyNodeResolvedStateComparer.cs" />
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\IDependencyNodeExtensions.cs" />
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\PackageAnalyzerAssemblyDependencyNode.cs" />
     <Compile Include="ProjectSystem\VS\UI\DialogServices.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -130,6 +130,7 @@
     <Compile Include="ProjectSystem\VS\RoslynServices.cs" />
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\AnalyzerDependenciesSubTreeProvider.cs" />
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\AnalyzerDependencyNode.cs" />
+    <Compile Include="ProjectSystem\VS\Tree\Dependencies\IDependencyNodeExtensions.cs" />
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\PackageAnalyzerAssemblyDependencyNode.cs" />
     <Compile Include="ProjectSystem\VS\UI\DialogServices.cs" />
     <Compile Include="ProjectSystem\VS\UI\IDialogServices.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AnalyzerDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AnalyzerDependencyNode.cs
@@ -32,6 +32,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 Caption = id.ItemSpec;
             }
 
+            Priority = AnalyzerNodePriority;
+
             ExpandedIcon = Icon;
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AssemblyDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AssemblyDependencyNode.cs
@@ -42,6 +42,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 Caption = Path.GetFileName(id.ItemSpec);
             }
 
+            Priority = FrameworkAssemblyNodePriority;
+
             ExpandedIcon = Icon;
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ComDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ComDependencyNode.cs
@@ -32,6 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 Caption = Path.GetFileName(id.ItemSpec);
             }
 
+            Priority = ComNodePriority;
             ExpandedIcon = Icon;
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProvider.cs
@@ -21,6 +21,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
     /// <summary>
     /// Provides actual dependencies nodes under Dependencies\[DependencyType]\[TopLevel]\[....] sub nodes. 
+    /// Note: when dependency has ProjectTreeFlags.Common.BrokenReference flag, GraphProvider API are not 
+    /// called for that node.
     /// </summary>
     [GraphProvider(Name = "Microsoft.VisualStudio.ProjectSystem.VS.Tree.DependenciesNodeGraphProvider",
                    ProjectCapability = "DependenciesTree")]
@@ -352,7 +354,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 return;
             }
 
-            var searchTerm = searchParameters.SearchQuery.SearchString;
+            var searchTerm = searchParameters.SearchQuery.SearchString?.ToLowerInvariant();
             if (searchTerm == null)
             {
                 return;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Threading;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Threading;
@@ -527,7 +528,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                 var itemContext = ProjectPropertiesContext.GetContext(UnconfiguredProject,
                                                                                       addedItem.Id.ItemType,
                                                                                       itemSpec);
-
                                 if (addedItem.Resolved)
                                 {
                                     rule = GetRuleForResolvableReference(
@@ -558,12 +558,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                             ApplyProjectTreePropertiesCustomization(customTreePropertyContext, customTreePropertyValues);
 
                             treeNode = NewTree(caption: addedItem.Caption,
-                                               visible: true,
-                                               filePath: addedItem.Id.ToString(),
-                                               browseObjectProperties: rule,
-                                               flags: addedItem.Flags,
-                                               icon: addedItem.Icon.ToProjectSystemType(),
-                                               expandedIcon: addedItem.ExpandedIcon.ToProjectSystemType());
+                                                visible: true,
+                                                filePath: addedItem.Id.ToString(),
+                                                browseObjectProperties: rule,
+                                                flags: addedItem.Flags,
+                                                icon: addedItem.Icon.ToProjectSystemType(),
+                                                expandedIcon: addedItem.ExpandedIcon.ToProjectSystemType());
 
                             providerRootTreeNode = providerRootTreeNode.Add(treeNode).Parent;
                         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesSubTreeProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesSubTreeProviderBase.cs
@@ -244,13 +244,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                                                   IProjectCatalogSnapshot,
                                                                   IProjectSharedFoldersSnapshot>> e)
         {
-            var dependenciesChange = ProcessDependenciesChanges(e.Value.Item1, e.Value.Item2);
-
-            // process separatelly shared projects changes
-            ProcessSharedProjectImportNodes(e.Value.Item3, dependenciesChange);
+            DependenciesChange dependenciesChange;
 
             lock (_rootNodeSync)
             {
+                dependenciesChange = ProcessDependenciesChanges(e.Value.Item1, e.Value.Item2);
+
+                // process separatelly shared projects changes
+                ProcessSharedProjectImportNodes(e.Value.Item3, dependenciesChange);
+
                 // Apply dependencies changes to actual RootNode children collection
                 // remove first nodes from actual RootNode
                 dependenciesChange.RemovedNodes.ForEach(RootNode.RemoveChild);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesSubTreeProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesSubTreeProviderBase.cs
@@ -42,12 +42,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// <summary>
         /// The value to dispose to terminate the link providing evaluation snapshots.
         /// </summary>
-        private IDisposable _projectSubscriptionLink;
+        private List<IDisposable> _evaluationSubscriptionLinks;
 
         /// <summary>
-        /// The value to dispose to terminate the SyncLinkTo subscription.
+        /// The value to dispose to terminate the SyncLinkTo subscriptions.
         /// </summary>
-        private IDisposable _projectSyncLink;
+        private List<IDisposable> _projectSyncLinks;
+
+        private object _rootNodeSync = new object();
 
         /// <summary>
         /// Gets the project asynchronous tasks service.
@@ -148,6 +150,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
         protected override void Initialize()
         {
+            _evaluationSubscriptionLinks = new List<IDisposable>();
+            _projectSyncLinks = new List<IDisposable>();
+
             using (UnconfiguredProjectAsynchronousTasksService.LoadedProject())
             {
                 // this.IsApplicable may take a project lock, so we can't do it inline with this method
@@ -164,14 +169,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                         {
                             Verify.NotDisposed(this);
 
-                            var intermediateBlock = new BufferBlock<
+                            var intermediateBlockDesignTime = new BufferBlock<
                                                             IProjectVersionedValue<
                                                                 IProjectSubscriptionUpdate>>();
 
-                            _projectSubscriptionLink = ProjectSubscriptionService.JointRuleSource.SourceBlock.LinkTo(
-                                intermediateBlock,
+                            _evaluationSubscriptionLinks.Add(ProjectSubscriptionService.JointRuleSource.SourceBlock.LinkTo(
+                                intermediateBlockDesignTime,
                                 ruleNames: UnresolvedReferenceRuleNames.Union(ResolvedReferenceRuleNames),
-                                suppressVersionOnlyUpdates: false);
+                                suppressVersionOnlyUpdates: true));
 
                             var actionBlock = new ActionBlock<
                                                     IProjectVersionedValue<
@@ -189,17 +194,31 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                                        NameFormat = "ReferencesSubtree Input: {1}"
                                                    });
 
-                            _projectSyncLink = ProjectDataSources.SyncLinkTo(
-                                intermediateBlock.SyncLinkOptions(),
+                            _projectSyncLinks.Add(ProjectDataSources.SyncLinkTo(
+                                intermediateBlockDesignTime.SyncLinkOptions(),
                                 ProjectSubscriptionService.ProjectCatalogSource.SourceBlock.SyncLinkOptions(),
                                 ProjectSubscriptionService.SharedFoldersSource.SourceBlock.SyncLinkOptions(),
-                                actionBlock);
+                                actionBlock));
+
+                            var intermediateBlockEvaluation = new BufferBlock<
+                                IProjectVersionedValue<
+                                    IProjectSubscriptionUpdate>>();
+                            _evaluationSubscriptionLinks.Add(ProjectSubscriptionService.ProjectRuleSource.SourceBlock.LinkTo(
+                                intermediateBlockEvaluation,
+                                ruleNames: UnresolvedReferenceRuleNames,
+                                suppressVersionOnlyUpdates: true));
+
+                            _projectSyncLinks.Add(ProjectDataSources.SyncLinkTo(
+                                intermediateBlockEvaluation.SyncLinkOptions(),
+                                ProjectSubscriptionService.ProjectCatalogSource.SourceBlock.SyncLinkOptions(),
+                                ProjectSubscriptionService.SharedFoldersSource.SourceBlock.SyncLinkOptions(),
+                                actionBlock));
+
                         }
                     },
                     registerFaultHandler: true);
             }
         }
-
 
         /// <summary>
         /// Disposes this instance.
@@ -208,8 +227,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             if (disposing)
             {
-                _projectSubscriptionLink?.Dispose();
-                _projectSyncLink?.Dispose();
+                _evaluationSubscriptionLinks.ForEach(x => x?.Dispose());
+                _evaluationSubscriptionLinks.Clear();
+
+                _projectSyncLinks.ForEach(x => x?.Dispose());
+                _projectSyncLinks.Clear();
             }
         }
 
@@ -227,13 +249,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             // process separatelly shared projects changes
             ProcessSharedProjectImportNodes(e.Value.Item3, dependenciesChange);
 
-            // Apply dependencies changes to actual RootNode children collection
-            // remove first nodes from actual RootNode
-            dependenciesChange.RemovedNodes.ForEach(RootNode.RemoveChild);
+            lock (_rootNodeSync)
+            {
+                // Apply dependencies changes to actual RootNode children collection
+                // remove first nodes from actual RootNode
+                dependenciesChange.RemovedNodes.ForEach(RootNode.RemoveChild);
 
-            ProcessDuplicatedNodes(dependenciesChange);
+                ProcessDuplicatedNodes(dependenciesChange);
 
-            dependenciesChange.AddedNodes.ForEach(RootNode.AddChild);
+                dependenciesChange.UpdatedNodes.ForEach((topLevelNode) =>
+                {
+                    var oldNode = RootNode.Children.FirstOrDefault(x => x.Id.Equals(topLevelNode.Id));
+                    if (oldNode != null)
+                    {
+                        RootNode.RemoveChild(oldNode);
+                        RootNode.AddChild(topLevelNode);
+                    }
+                });
+
+                dependenciesChange.AddedNodes.ForEach(RootNode.AddChild);
+            }
 
             OnDependenciesChanged(dependenciesChange.GetDiff(), e);
         }
@@ -255,11 +290,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                                     IProjectCatalogSnapshot catalogs)
         {
             var changes = projectSubscriptionUpdate.ProjectChanges;
-            var resolvedReferenceChanges = ResolvedReferenceRuleNames.Select(ruleName => changes[ruleName])
-                                                                     .ToImmutableHashSet();
-            IProjectRuleSnapshot[] resolvedReferences = resolvedReferenceChanges.Select(c => c.After)
-                                                                                .ToArray();
-
+            var resolvedReferenceChanges =
+                ResolvedReferenceRuleNames.Where(x => changes.Keys.Contains(x))
+                                          .Select(ruleName => changes[ruleName]).ToImmutableHashSet();
+                
             var unresolvedReferenceSnapshots = changes.Values
                 .Where(cd => !ResolvedReferenceRuleNames.Any(ruleName =>
                                 string.Equals(ruleName,
@@ -267,6 +301,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                               StringComparison.OrdinalIgnoreCase)))
                 .ToDictionary(d => d.After.RuleName, d => d, StringComparer.OrdinalIgnoreCase);
 
+            var rootTreeNodes = new HashSet<IDependencyNode>(RootNode.Children);
             var dependenciesChange = new DependenciesChange();
             foreach (var unresolvedChange in unresolvedReferenceSnapshots.Values)
             {
@@ -286,7 +321,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
                 foreach (string removedItemSpec in unresolvedChange.Difference.RemovedItems)
                 {
-                    var node = RootNode.Children.FindNode(removedItemSpec, itemType);
+                    var node = rootTreeNodes.FindNode(removedItemSpec, itemType);
                     if (node != null)
                     {
                         dependenciesChange.RemovedNodes.Add(node);
@@ -295,7 +330,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
                 foreach (string addedItemSpec in unresolvedChange.Difference.AddedItems)
                 {
-                    var node = RootNode.Children.FindNode(addedItemSpec, itemType);
+                    var node = rootTreeNodes.FindNode(addedItemSpec, itemType);
                     if (node == null)
                     {
                         var properties = GetProjectItemProperties(unresolvedChange.After, addedItemSpec);
@@ -332,7 +367,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                                                             updatedUnresolvedSnapshots,
                                                                             catalogs,
                                                                             out unresolvedReferenceSnapshot);
-                    var node = RootNode.Children.FindNode(removedItemSpec, unresolvedItemType);
+                    var node = rootTreeNodes.FindNode(removedItemSpec, unresolvedItemType);
                     if (node != null)
                     {
                         dependenciesChange.RemovedNodes.Add(node);
@@ -375,17 +410,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                         continue;
                     }
 
+                    // avoid adding unresolved dependency along with resolved one 
                     var existingUnresolvedNode = dependenciesChange.AddedNodes.FindNode(originalItemSpec, itemType);
                     if (existingUnresolvedNode != null)
                     {
-                        // delete existing unresolved item node
                         dependenciesChange.AddedNodes.Remove(existingUnresolvedNode);
                     }
 
-                    var node = CreateDependencyNode(originalItemSpec,
+                    // if unresolved dependency was added earlier, remove it, since it will be substituted by resolved one
+                    existingUnresolvedNode = rootTreeNodes.FindNode(originalItemSpec, itemType);
+                    if (existingUnresolvedNode != null)
+                    {
+                        dependenciesChange.RemovedNodes.Add(existingUnresolvedNode);
+                    }
+
+                    var newNode = CreateDependencyNode(originalItemSpec,
                                                     itemType: itemType,
                                                     properties: properties);
-                    dependenciesChange.AddedNodes.Add(node);
+                    dependenciesChange.AddedNodes.Add(newNode);
                 }
             }
 
@@ -496,18 +538,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             return null;
         }
 
-        protected void OnDependenciesChanged(IDependenciesChangeDiff changes, 
+        protected void OnDependenciesChanged(IDependenciesChangeDiff changes,
                                              IProjectVersionedValue<
                                                 Tuple<IProjectSubscriptionUpdate,
                                                         IProjectCatalogSnapshot,
                                                         IProjectSharedFoldersSnapshot>> e)
         {
-            DependenciesChanged(this, 
+            DependenciesChanged(this,
                                 new DependenciesChangedEventArgs(
-                                        this, 
-                                        changes, 
-                                        e.Value.Item2, 
-                                        e.DataSourceVersions));
+                                        this,
+                                        changes,
+                                        e?.Value?.Item2,
+                                        e?.DataSourceVersions));
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesSubTreeProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesSubTreeProviderBase.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// <summary>
         /// The value to dispose to terminate the link providing evaluation snapshots.
         /// </summary>
-        private List<IDisposable> _evaluationSubscriptionLinks;
+        private List<IDisposable> _subscriptionLinks;
 
         /// <summary>
         /// The value to dispose to terminate the SyncLinkTo subscriptions.
@@ -150,7 +150,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
         protected override void Initialize()
         {
-            _evaluationSubscriptionLinks = new List<IDisposable>();
+            _subscriptionLinks = new List<IDisposable>();
             _projectSyncLinks = new List<IDisposable>();
 
             using (UnconfiguredProjectAsynchronousTasksService.LoadedProject())
@@ -173,7 +173,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                                             IProjectVersionedValue<
                                                                 IProjectSubscriptionUpdate>>();
 
-                            _evaluationSubscriptionLinks.Add(ProjectSubscriptionService.JointRuleSource.SourceBlock.LinkTo(
+                            _subscriptionLinks.Add(ProjectSubscriptionService.JointRuleSource.SourceBlock.LinkTo(
                                 intermediateBlockDesignTime,
                                 ruleNames: UnresolvedReferenceRuleNames.Union(ResolvedReferenceRuleNames),
                                 suppressVersionOnlyUpdates: true));
@@ -203,7 +203,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                             var intermediateBlockEvaluation = new BufferBlock<
                                 IProjectVersionedValue<
                                     IProjectSubscriptionUpdate>>();
-                            _evaluationSubscriptionLinks.Add(ProjectSubscriptionService.ProjectRuleSource.SourceBlock.LinkTo(
+                            _subscriptionLinks.Add(ProjectSubscriptionService.ProjectRuleSource.SourceBlock.LinkTo(
                                 intermediateBlockEvaluation,
                                 ruleNames: UnresolvedReferenceRuleNames,
                                 suppressVersionOnlyUpdates: true));
@@ -227,8 +227,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             if (disposing)
             {
-                _evaluationSubscriptionLinks.ForEach(x => x?.Dispose());
-                _evaluationSubscriptionLinks.Clear();
+                _subscriptionLinks.ForEach(x => x?.Dispose());
+                _subscriptionLinks.Clear();
 
                 _projectSyncLinks.ForEach(x => x?.Dispose());
                 _projectSyncLinks.Clear();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
@@ -10,6 +10,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
     internal class DependencyNode : IDependencyNode
     {
+        // These priorities are for graph nodes only and are used to group graph nodes 
+        // appropriatelly in order groups predefined order instead of alphabetically.
+        // Order is not changed for top dependency nodes only for grpah hierarchies.
         public const int DiagnosticsNodePriority = 100; // for any custom nodes like errors or warnings
         public const int UnresolvedReferenceNodePriority = 110;
         public const int ProjectNodePriority = 120;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
@@ -10,6 +10,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
     internal class DependencyNode : IDependencyNode
     {
+        public const int DiagnosticsNodePriority = 100; // for any custom nodes like errors or warnings
+        public const int UnresolvedReferenceNodePriority = 110;
+        public const int ProjectNodePriority = 120;
+        public const int PackageNodePriority = 130;
+        public const int FrameworkAssemblyNodePriority = 140;
+        public const int PackageAssemblyNodePriority = 150;
+        public const int AnalyzerNodePriority = 160;
+        public const int ComNodePriority = 170;
+        public const int SdkNodePriority = 180;
+        
         /// <summary>
         /// The set of flags common to all Reference nodes.
         /// </summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
@@ -18,6 +18,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
         /// <summary>
         /// The set of flags to assign to unresolvable Reference nodes.
+        /// Note: when dependency has ProjectTreeFlags.Common.BrokenReference flag, GraphProvider API are not 
+        /// called for that node.
         /// </summary>
         private static readonly ProjectTreeFlags UnresolvedReferenceFlags
                 = BaseReferenceFlags.Add(ProjectTreeFlags.Common.BrokenReference);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNodeId.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNodeId.cs
@@ -62,6 +62,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// </summary>
         public string UniqueToken { get; private set; }
 
+        public DependencyNodeId ToNormalizedId()
+        {
+            return new DependencyNodeId(ProviderType,
+                                        ItemSpec?.Replace('\\', '/'),
+                                        ItemType,
+                                        UniqueToken);
+        }
+
         public override string ToString()
         {
             var builder = new StringBuilder();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNodeId.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNodeId.cs
@@ -62,12 +62,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// </summary>
         public string UniqueToken { get; private set; }
 
+        /// <summary>
+        /// Creates a copy if the ID that has all paths in normal form with '\' slashes instead of '/'.
+        /// Note: this is needed to switch back to normal IDs for graph nodes, since graph provider nodes
+        /// switch paths in their IDs to uri style with '/'.
+        /// </summary>
+        /// <returns></returns>
         public DependencyNodeId ToNormalizedId()
         {
             return new DependencyNodeId(ProviderType,
-                                        ItemSpec?.Replace('\\', '/'),
+                                        ItemSpec?.Replace('/', '\\'),
                                         ItemType,
-                                        UniqueToken);
+                                        UniqueToken?.Replace('/', '\\'));
         }
 
         public override string ToString()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNodeResolvedStateComparer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNodeResolvedStateComparer.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
+{
+    /// <summary>
+    /// Compares IDependencyNode using default comparison (IDs) + Resolved state
+    /// </summary>            
+    internal class DependencyNodeResolvedStateComparer : IEqualityComparer<IDependencyNode>
+    {
+        public bool Equals(IDependencyNode x, IDependencyNode y)
+        {
+            if (x == null || y == null)
+            {
+                return false;
+            }
+
+            return x.Equals(y) && x.Resolved == y.Resolved;
+        }
+
+        public int GetHashCode(IDependencyNode obj)
+        {
+            return obj.GetHashCode() ^ obj.Resolved.GetHashCode();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependencyNodeExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependencyNodeExtensions.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
+{
+    /// <summary>
+    /// Extensions for IDependencyNode implementations
+    /// </summary>
+    public static class IDependencyNodeExtensions
+    {
+        /// <summary>
+        /// Finds a node with given id (recusrive when needed)
+        /// </summary>
+        public static IDependencyNode FindNode(this IDependencyNode self, DependencyNodeId id, bool recursive = false)
+        {
+            IDependencyNode resultNode = null;
+            foreach(var child in self.Children)
+            {
+                if (child.Id.Equals(id))
+                {
+                    resultNode = child;
+                }
+                else if (recursive)
+                {
+                    resultNode = FindNode(child, id, recursive);
+                }
+
+                if (resultNode != null)
+                {
+                    break;
+                }
+            }
+
+            return resultNode;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/NuGetDependenciesSubTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/NuGetDependenciesSubTreeProvider.cs
@@ -40,8 +40,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             // For now we don't need unresolved package rules, since we can get all 
             // info from resolved items
-            //UnresolvedReferenceRuleNames = Empty.OrdinalIgnoreCaseStringSet
-            //    .Add(PackageReference.SchemaName);
+            UnresolvedReferenceRuleNames = Empty.OrdinalIgnoreCaseStringSet
+                .Add(PackageReference.SchemaName);
             ResolvedReferenceRuleNames = Empty.OrdinalIgnoreCaseStringSet
                 .Add(ResolvedPackageReference.SchemaName);
         }
@@ -85,7 +85,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         private object _snapshotLock = new object();
+
+        /// <summary>
+        /// Contains a snapshot of package dependencies obtained from nuget assets file. Data here is the
+        /// actual resolved packages that should replace package nodes from unresolved TopLevelDependencies.
+        /// </summary>
         protected DependenciesSnapshot CurrentSnapshot { get; } = new DependenciesSnapshot();
+
+        /// <summary>
+        /// Contains direct top level package dependencies obtained from project evaluation.
+        /// </summary>
+        protected Dictionary<string, DependencyMetadata> TopLevelDependencies { get; }
+            = new Dictionary<string, DependencyMetadata>(StringComparer.OrdinalIgnoreCase);
 
         protected override IDependencyNode CreateRootNode()
         {
@@ -216,91 +227,254 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         protected override DependenciesChange ProcessDependenciesChanges(
-                                                    IProjectSubscriptionUpdate projectSubscriptionUpdate,
-                                                    IProjectCatalogSnapshot catalogs)
+                                                     IProjectSubscriptionUpdate projectSubscriptionUpdate,
+                                                     IProjectCatalogSnapshot catalogs)
         {
-            var changes = projectSubscriptionUpdate.ProjectChanges;
-            var dependenciesChange = new DependenciesChange();
+            var dependenciesChange = new DependenciesChange();            
+            // take a snapshot for current top level tree nodes
+            var rootNodes = new HashSet<IDependencyNode>(RootNode.Children);
 
             lock (_snapshotLock)
             {
-                var newDependencies = new HashSet<DependencyMetadata>();
-                foreach (var change in changes.Values)
+                var unresolvedChanges = ProcessUnresolvedChanges(projectSubscriptionUpdate);
+                var resolvedChanges = ProcessResolvedChanges(projectSubscriptionUpdate, rootNodes);
+
+                // merge changes
+                // remove
+                foreach (var metadata in unresolvedChanges.RemovedNodes)
                 {
-                    if (!change.Difference.AnyChanges)
+                    var itemNode = rootNodes.FirstOrDefault(
+                                    x => x.Id.ItemSpec.Equals(metadata.ItemSpec, StringComparison.OrdinalIgnoreCase));
+                    if (itemNode != null)
+                    {
+                        dependenciesChange.RemovedNodes.Add(itemNode);
+                    }
+                }
+
+                foreach (var metadata in resolvedChanges.RemovedNodes)
+                {
+                    var itemNode = rootNodes.FirstOrDefault(
+                                    x => x.Id.ItemSpec.Equals(metadata.ItemSpec, StringComparison.OrdinalIgnoreCase));
+                    if (itemNode != null)
+                    {
+                        dependenciesChange.RemovedNodes.Add(itemNode);
+                    }
+                }
+
+                // update
+                foreach (var resolvedMetadata in resolvedChanges.UpdatedNodes)
+                {
+                    var itemNode = rootNodes.FirstOrDefault(
+                                    x => x.Id.ItemSpec.Equals(resolvedMetadata.ItemSpec, StringComparison.OrdinalIgnoreCase));
+                    if (itemNode != null)
+                    {
+                        itemNode = CreateDependencyNode(resolvedMetadata, topLevel: true);
+                        dependenciesChange.UpdatedNodes.Add(itemNode);
+                    }
+
+                    var unresolvedMatch = unresolvedChanges.UpdatedNodes.FirstOrDefault(x => x.ItemSpec.Equals(resolvedMetadata.Name));
+                    if (unresolvedMatch != null)
+                    {
+                        unresolvedChanges.UpdatedNodes.Remove(unresolvedMatch);
+                    }
+                }
+
+                foreach (var unresolvedMetadata in unresolvedChanges.UpdatedNodes)
+                {
+                    var itemNode = rootNodes.FirstOrDefault(
+                                    x => x.Id.ItemSpec.Equals(unresolvedMetadata.ItemSpec, StringComparison.OrdinalIgnoreCase));
+                    if (itemNode != null)
+                    {
+                        dependenciesChange.UpdatedNodes.Add(itemNode);
+                    }
+                }
+
+                // add
+                foreach (var resolvedMetadata in resolvedChanges.AddedNodes)
+                {
+                    // see if there is already node created for unresolved package - if yes, delete it
+                    // Note: unresolved packages ItemSpec contain only package name, when resolved package ItemSpec
+                    // contains TFM/PackageName/version, so we need to check for name if we want to find unresolved
+                    // packages.
+                    var itemNode = rootNodes.FirstOrDefault(
+                                    x => x.Id.ItemSpec.Equals(resolvedMetadata.Name, StringComparison.OrdinalIgnoreCase));
+                    if (itemNode != null)
+                    {
+                        dependenciesChange.RemovedNodes.Add(itemNode);
+                    }
+
+                    // see if there no node with the same resolved metadata - if no, create it
+                    itemNode = rootNodes.FirstOrDefault(
+                                    x => x.Id.ItemSpec.Equals(resolvedMetadata.ItemSpec, StringComparison.OrdinalIgnoreCase));
+                    if (itemNode == null)
+                    {
+                        itemNode = CreateDependencyNode(resolvedMetadata, topLevel: true);
+                        dependenciesChange.AddedNodes.Add(itemNode);
+                    }
+
+                    // avoid adding matching unresolved packages
+                    var unresolvedMatch = unresolvedChanges.AddedNodes.FirstOrDefault(x => x.ItemSpec.Equals(resolvedMetadata.Name));
+                    if (unresolvedMatch != null)
+                    {
+                        unresolvedChanges.AddedNodes.Remove(unresolvedMatch);
+                    }
+                }
+
+                foreach (var unresolvedMetadata in unresolvedChanges.AddedNodes)
+                {
+                    var itemNode = rootNodes.FirstOrDefault(
+                                    x => x.Id.ItemSpec.Equals(unresolvedMetadata.ItemSpec, StringComparison.OrdinalIgnoreCase));
+                    if (itemNode == null)
+                    {
+                        itemNode = CreateDependencyNode(unresolvedMetadata, topLevel: true);
+                        dependenciesChange.AddedNodes.Add(itemNode);
+                    }
+                }                
+            }
+
+            return dependenciesChange;
+        }
+
+        private NugetDependenciesChange ProcessUnresolvedChanges(IProjectSubscriptionUpdate projectSubscriptionUpdate)
+        {
+            var unresolvedChanges = projectSubscriptionUpdate.ProjectChanges.Values
+                .Where(cd => !ResolvedReferenceRuleNames.Any(ruleName =>
+                                string.Equals(ruleName,
+                                              cd.After.RuleName,
+                                              StringComparison.OrdinalIgnoreCase)))
+                .ToDictionary(d => d.After.RuleName, d => d, StringComparer.OrdinalIgnoreCase);
+
+            var dependenciesChange = new NugetDependenciesChange();
+            foreach (var change in unresolvedChanges.Values)
+            {
+                if (!change.Difference.AnyChanges)
+                {
+                    continue;
+                }
+
+                foreach (string removedItemSpec in change.Difference.RemovedItems)
+                {
+                    DependencyMetadata metadata = null;
+                    if (TopLevelDependencies.TryGetValue(removedItemSpec, out metadata))
+                    {
+                        TopLevelDependencies.Remove(removedItemSpec);
+                        dependenciesChange.RemovedNodes.Add(metadata);
+                    }
+                }
+
+                foreach (string changedItemSpec in change.Difference.ChangedItems)
+                {
+                    var properties = GetProjectItemProperties(change.After, changedItemSpec);
+                    if (properties == null)
                     {
                         continue;
                     }
 
-                    foreach (string removedItemSpec in change.Difference.RemovedItems)
+                    DependencyMetadata metadata = null;
+                    if (TopLevelDependencies.TryGetValue(changedItemSpec, out metadata))
                     {
-                        CurrentSnapshot.RemoveDependency(removedItemSpec);
+                        metadata = CreateUnresolvedMetadata(changedItemSpec, properties);
+                        TopLevelDependencies[changedItemSpec] = metadata;
 
-                        var itemNode = RootNode.Children.FirstOrDefault(
-                                        x => x.Id.ItemSpec.Equals(removedItemSpec, StringComparison.OrdinalIgnoreCase));
-                        if (itemNode != null)
-                        {
-                            dependenciesChange.RemovedNodes.Add(itemNode);
-                        }
-                    }
-                    
-                    foreach (string changedItemSpec in change.Difference.ChangedItems)
-                    {
-                        var properties = GetProjectItemProperties(change.After, changedItemSpec);
-                        if (properties == null)
-                        {
-                            continue;
-                        }
-
-                        CurrentSnapshot.UpdateDependency(changedItemSpec, properties);
-
-                        var itemNode = RootNode.Children.FirstOrDefault(
-                                        x => x.Id.ItemSpec.Equals(changedItemSpec, StringComparison.OrdinalIgnoreCase));
-                        if (itemNode != null)
-                        {
-                            dependenciesChange.UpdatedNodes.Add(itemNode);
-                        }
-                    }
-
-                    foreach (string addedItemSpec in change.Difference.AddedItems)
-                    {
-                        var properties = GetProjectItemProperties(change.After, addedItemSpec);
-                        if (properties == null)
-                        {
-                            continue;
-                        }
-
-                        var newDependency = CurrentSnapshot.AddDependency(addedItemSpec, properties);
-
-                        newDependencies.Add(newDependency);
+                        dependenciesChange.UpdatedNodes.Add(metadata);
                     }
                 }
 
-                // since we have limited implementation for multi targeted projects,
-                // we assume that there is only one target - take first target and add 
-                // top level nodes for it
-
-                var currentTarget = CurrentSnapshot.Targets.Keys.FirstOrDefault();
-                if (currentTarget == null)
+                foreach (string addedItemSpec in change.Difference.AddedItems)
                 {
-                    return dependenciesChange;
-                }
-
-                var currentTargetDependency = CurrentSnapshot.DependenciesWorld[currentTarget];
-                var currentTargetTopLevelDependencies = currentTargetDependency.DependenciesItemSpecs;
-                var addedTopLevelDependencies = newDependencies.Where(
-                                                    x => currentTargetTopLevelDependencies.Contains(x.ItemSpec));
-                foreach (var addedDependency in addedTopLevelDependencies)
-                {
-                    var itemNode = RootNode.Children.FirstOrDefault(
-                                    x => x.Id.ItemSpec.Equals(addedDependency.ItemSpec, 
-                                                              StringComparison.OrdinalIgnoreCase));
-                    if (itemNode == null)
+                    var properties = GetProjectItemProperties(change.After, addedItemSpec);
+                    if (properties == null)
                     {
-                        itemNode = CreateDependencyNode(addedDependency, topLevel: true);
-                        dependenciesChange.AddedNodes.Add(itemNode);
+                        continue;
+                    }
+
+                    DependencyMetadata metadata = null;
+                    if (!TopLevelDependencies.TryGetValue(addedItemSpec, out metadata))
+                    {
+                        metadata = CreateUnresolvedMetadata(addedItemSpec, properties);
+                        TopLevelDependencies.Add(addedItemSpec, metadata);
+
+                        dependenciesChange.AddedNodes.Add(metadata);
                     }
                 }
+            }
+
+            return dependenciesChange;
+        }
+
+        private NugetDependenciesChange ProcessResolvedChanges(IProjectSubscriptionUpdate projectSubscriptionUpdate,
+                                                               HashSet<IDependencyNode> rootTreeNodes)
+        {
+            var changes = projectSubscriptionUpdate.ProjectChanges;
+            var resolvedChanges = ResolvedReferenceRuleNames.Where(x => changes.Keys.Contains(x))
+                                                            .Select(ruleName => changes[ruleName])
+                                                            .ToImmutableHashSet();
+            var dependenciesChange = new NugetDependenciesChange();
+            var newDependencies = new HashSet<DependencyMetadata>();
+            foreach (var change in resolvedChanges)
+            {
+                if (!change.Difference.AnyChanges)
+                {
+                    continue;
+                }
+
+                foreach (string removedItemSpec in change.Difference.RemovedItems)
+                {
+                    var metadata = CurrentSnapshot.RemoveDependency(removedItemSpec);
+                    var itemNode = rootTreeNodes.FirstOrDefault(
+                                    x => x.Id.ItemSpec.Equals(removedItemSpec, StringComparison.OrdinalIgnoreCase));
+                    if (itemNode != null)
+                    {
+                        dependenciesChange.RemovedNodes.Add(metadata);
+                    }
+                }
+
+                foreach (string changedItemSpec in change.Difference.ChangedItems)
+                {
+                    var properties = GetProjectItemProperties(change.After, changedItemSpec);
+                    if (properties == null)
+                    {
+                        continue;
+                    }
+
+                    var metadata = CurrentSnapshot.UpdateDependency(changedItemSpec, properties);
+                    var itemNode = rootTreeNodes.FirstOrDefault(
+                                    x => x.Id.ItemSpec.Equals(changedItemSpec, StringComparison.OrdinalIgnoreCase));
+                    if (itemNode != null)
+                    {
+                        dependenciesChange.UpdatedNodes.Add(metadata);
+                    }
+                }
+
+                foreach (string addedItemSpec in change.Difference.AddedItems)
+                {
+                    var properties = GetProjectItemProperties(change.After, addedItemSpec);
+                    if (properties == null)
+                    {
+                        continue;
+                    }
+
+                    var newDependency = CurrentSnapshot.AddDependency(addedItemSpec, properties);
+                    newDependencies.Add(newDependency);
+                }
+            }
+
+            // Note: currently deisgn time build is limited and is not aware of conditional on TFM 
+            // PackageReference items: Unresolved PackageReference items for conditional TFMs are not sent.
+            // Thus we will display conditional PackageReferences if they were resolved and are in assets.json.
+            // This limitation should go away, when we have final design for cross target dependencies and 
+            // DesignTime build.
+            var currentTargetTopLevelDependencies = CurrentSnapshot.GetUniqueTopLevelDependencies();
+            if (currentTargetTopLevelDependencies.Count == 0)
+            {
+                return dependenciesChange;
+            }
+
+            var addedTopLevelDependencies = newDependencies.Where(
+                                                x => currentTargetTopLevelDependencies.Contains(x.ItemSpec));
+            foreach (var addedDependency in addedTopLevelDependencies)
+            {
+                dependenciesChange.AddedNodes.Add(addedDependency);
             }
 
             return dependenciesChange;
@@ -369,6 +543,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             return matchingNodes;
         }
 
+        private static DependencyMetadata CreateUnresolvedMetadata(string itemSpec,
+                                                            IImmutableDictionary<string, string> properties)
+        {
+            // add this properties here since unresolved PackageReferences don't have it
+            properties = properties.SetItem(MetadataKeys.Resolved, "false");
+            properties = properties.SetItem(MetadataKeys.Type, DependencyType.Package.ToString());
+
+            return new DependencyMetadata(itemSpec, properties);
+        }
+
         protected class TargetMetadata
         {
             public TargetMetadata(IImmutableDictionary<string, string> properties)
@@ -432,7 +616,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             {
                 Requires.NotNull(properties, nameof(properties));
 
-                Name = properties.ContainsKey(MetadataKeys.Name) ? properties[MetadataKeys.Name] : string.Empty;
+                Name = properties.ContainsKey(MetadataKeys.Name) && !string.IsNullOrEmpty(properties[MetadataKeys.Name]) 
+                            ? properties[MetadataKeys.Name] 
+                            : ItemSpec;
                 Version = properties.ContainsKey(MetadataKeys.Version) 
                                     ? properties[MetadataKeys.Version] : string.Empty;
                 var dependencyTypeString = properties.ContainsKey(MetadataKeys.Type) 
@@ -549,6 +735,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
                 RemoveNodeFromCache(itemSpec);
 
+                if (!itemSpec.Contains("/") && Targets.ContainsKey(itemSpec))
+                {
+                    Targets.Remove(itemSpec);
+                }
+
                 return removedMetadata;
             }
 
@@ -607,6 +798,45 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     RemoveNodeFromCacheRecursive(childNode);
                 }
             }
+
+            /// <summary>
+            /// Until we have a proper design for displaying cross-target dependencies, we show all
+            /// in one list. 
+            /// </summary>
+            /// <returns></returns>
+            public HashSet<string> GetUniqueTopLevelDependencies()
+            {
+                HashSet<string> topLevelDependenciesNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                HashSet<string> topLevelDependenciesItemSpecs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach(var target in Targets)
+                {
+                    DependencyMetadata targetMetadata = null;
+                    if (!DependenciesWorld.TryGetValue(target.Key, out targetMetadata))
+                    {
+                        continue;
+                    }
+
+                    foreach (var dependencyItemSpec in targetMetadata.DependenciesItemSpecs)
+                    {
+                        DependencyMetadata dependencyMetadata = null;
+                        if (!DependenciesWorld.TryGetValue(dependencyItemSpec, out dependencyMetadata))
+                        {
+                            continue;
+                        }
+
+                        if (topLevelDependenciesNames.Contains(dependencyMetadata.Name))
+                        {
+                            // we already have this dependency form other target
+                            continue;
+                        }
+
+                        topLevelDependenciesNames.Add(dependencyMetadata.Name);
+                        topLevelDependenciesItemSpecs.Add(dependencyItemSpec);
+                    }
+                }
+
+                return topLevelDependenciesItemSpecs;
+            }
         }
 
         protected enum DependencyType
@@ -636,6 +866,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             public const string TargetFrameworkMoniker = "TargetFrameworkMoniker";
             public const string FrameworkName = "FrameworkName";
             public const string FrameworkVersion = "FrameworkVersion";
+        }
+
+        protected class NugetDependenciesChange
+        {
+            public NugetDependenciesChange()
+            {
+                AddedNodes = new List<DependencyMetadata>();
+                UpdatedNodes = new List<DependencyMetadata>();
+                RemovedNodes = new List<DependencyMetadata>();
+            }
+
+            public List<DependencyMetadata> AddedNodes { get; protected set; }
+            public List<DependencyMetadata> UpdatedNodes { get; protected set; }
+            public List<DependencyMetadata> RemovedNodes { get; protected set; }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageAnalyzerAssemblyDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageAnalyzerAssemblyDependencyNode.cs
@@ -19,9 +19,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Caption = caption;
             Icon = resolved ? KnownMonikers.CodeInformation : KnownMonikers.ReferenceWarning;
             ExpandedIcon = Icon;
+            // we explicitly want analyzers have same priority as assemblies
             Priority = resolved
-                            ? NuGetDependenciesSubTreeProvider.PackageAssemblyNodePriority
-                            : NuGetDependenciesSubTreeProvider.UnresolvedReferenceNodePriority;
+                            ? PackageAssemblyNodePriority
+                            : UnresolvedReferenceNodePriority;
 
             Flags = (resolved ? ResolvedDependencyFlags : UnresolvedDependencyFlags)
                         .Add(ProjectTreeFlags.Common.ResolvedReference)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageAssemblyDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageAssemblyDependencyNode.cs
@@ -20,8 +20,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Icon = resolved ? KnownMonikers.Reference : KnownMonikers.ReferenceWarning;
             ExpandedIcon = Icon;
             Priority = resolved
-                            ? NuGetDependenciesSubTreeProvider.PackageAssemblyNodePriority
-                            : NuGetDependenciesSubTreeProvider.UnresolvedReferenceNodePriority;
+                            ? PackageAssemblyNodePriority
+                            : UnresolvedReferenceNodePriority;
 
             Flags = (resolved ? ResolvedDependencyFlags : UnresolvedDependencyFlags)
                         .Add(ProjectTreeFlags.Common.ResolvedReference)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageDependencyNode.cs
@@ -20,8 +20,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Icon = resolved ? KnownMonikers.PackageReference : KnownMonikers.ReferenceWarning;
             ExpandedIcon = Icon;
             Priority = resolved 
-                            ? NuGetDependenciesSubTreeProvider.PackageNodePriority 
-                            : NuGetDependenciesSubTreeProvider.UnresolvedReferenceNodePriority;
+                            ? PackageNodePriority 
+                            : UnresolvedReferenceNodePriority;
 
             Flags = (resolved ? ResolvedDependencyFlags : UnresolvedDependencyFlags)
                         .Add(ProjectTreeFlags.Common.ResolvedReference)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageFrameworkAssembliesDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageFrameworkAssembliesDependencyNode.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Caption = VSResources.FrameworkAssembliesNodeName;
             Icon = KnownMonikers.Library;
             ExpandedIcon = Icon;
-            Priority = NuGetDependenciesSubTreeProvider.FrameworkAssemblyNodePriority;
+            Priority = FrameworkAssemblyNodePriority;
 
             // Note: PreFilledFolderNode flag suggests graph provider to assume that this node already 
             // has children added to it, so it can create graph nodes right away and not query them.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageUnknownDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageUnknownDependencyNode.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                      ProjectTreeFlags flags,
                                      IImmutableDictionary<string, string> properties = null,
                                      bool resolved = true)
-            : base(id, flags, NuGetDependenciesSubTreeProvider.UnresolvedReferenceNodePriority, 
+            : base(id, flags, UnresolvedReferenceNodePriority, 
                    properties, resolved)
         {
             Requires.NotNullOrEmpty(caption, nameof(caption));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ProjectDependenciesSubTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ProjectDependenciesSubTreeProvider.cs
@@ -119,6 +119,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                              resolved: resolved);
         }
 
+        /// <summary>
+        /// Returns refreshed dependnecy node. There is a non trivial logic which is important:
+        /// in order to find node at anypoint of time, we always fill live node instance children collection,
+        /// which then could be found by recusrive search from RootNode. However we return always a new 
+        /// instance for requested node, to allow graph provider to compare old node instances to new ones
+        /// when some thing changes in the dependent project and track changes. So in 
+        /// DependenciesGrpahProvider.TrackChangesOnGraphContextAsync we always remember old children
+        /// collection for existing node, since for top level nodes (sent by CPS IProjectTree(s) we do update
+        /// them here, which would make no difference between old and new nodes. For lower hierarchies below top 
+        /// nodes, new instances solve this problem.
+        /// </summary>
+        /// <param name="nodeId"></param>
+        /// <returns></returns>
         public override IDependencyNode GetDependencyNode(DependencyNodeId nodeId)
         {
             if (nodeId == null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ProjectDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ProjectDependencyNode.cs
@@ -29,6 +29,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             }
 
             ExpandedIcon = Icon;
+
+            Flags = (resolved ? ResolvedDependencyFlags : GenericUnresolvedDependencyFlags)
+                        .Union(flags);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SdkDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SdkDependencyNode.cs
@@ -30,6 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 Icon = KnownMonikers.ReferenceWarning;
             }
 
+            Priority = SdkNodePriority;
             ExpandedIcon = Icon;
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
@@ -15,10 +15,6 @@
                   DisplayName="Reference Output Assembly"
 				  Description="A value indicating whether the compiler should include a reference to the target project's primary output assembly." />
 
-    <BoolProperty Name="Private"
-                  DisplayName="Copy Local"
-				  Description="Indicates whether the primary output of the reference target should be copied into this project's output directory, when that metadata is set on an unresolved reference." />
-
     <BoolProperty Name="CopyLocalSatelliteAssemblies"
                   DisplayName="Copy Local Satellite Assemblies"
 				  Description="Indicates whether the satellite assemblies of the reference target should be copied into this project's output directory." />


### PR DESCRIPTION
#We had to revert my changes over the weekend to review and complete a PR properly. Undoing a "revert" commit 79f0fadc10c44f7e2157ab711e8c9c8f972c4971..  This was original PR https://github.com/dotnet/roslyn-project-system/pull/671 

Fixes #663, Fixes #412, Fixes #431 and Fixes #635