### PR TITLE
Fix razor intellisense that broke after combined intellisense support

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/LanguageServices/CSharpVsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/LanguageServices/CSharpVsContainedLanguageComponentsFactory.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
@@ -13,9 +14,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         private static Guid CSharpLanguageServiceGuid = new Guid("694dd9b6-b865-4c5b-ad85-86356e9c88dc");
         [ImportingConstructor]
         public CSharpVsContainedLanguageComponentsFactory(SVsServiceProvider serviceProvider,
-                                                        IUnconfiguredProjectVsServices projectServices)
-            : base(serviceProvider, projectServices, CSharpLanguageServiceGuid)
-                                                        
+                                                        IUnconfiguredProjectVsServices projectServices,
+                                                        IProjectHostProvider projectHostProvider)
+            : base(serviceProvider, projectServices, projectHostProvider, CSharpLanguageServiceGuid)
         {
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/AbstractHostObject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/AbstractHostObject.cs
@@ -7,12 +7,22 @@ using IOLEServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 {
+
     /// <summary>
     /// Base type for language service host object for cross targeting projects.
     /// </summary>
-    internal abstract class AbstractHostObject : IVsHierarchy, IVsContainedLanguageProjectNameProvider
+    internal abstract class AbstractHostObject : IVsHierarchy, IVsContainedLanguageProjectNameProvider, IVsProject
     {
-        protected abstract IVsHierarchy InnerHierarchy { get; }
+        protected AbstractHostObject(object innerHostObject)
+        {
+            Requires.NotNull(innerHostObject, nameof(innerHostObject));
+
+            InnerHierarchy = (IVsHierarchy)innerHostObject;
+            InnerVsProject = (IVsProject)innerHostObject;
+        }
+
+        protected IVsHierarchy InnerHierarchy { get; }
+        protected IVsProject InnerVsProject { get; }
         public abstract string ActiveIntellisenseProjectDisplayName { get; }
 
         #region IVsHierarchy members
@@ -109,12 +119,45 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 
         #endregion
 
-        #region IVsContainedLanguageProjectNameProvider name
+        #region IVsContainedLanguageProjectNameProvider members
 
         public int GetProjectName(uint itemid, out String pbstrProjectName)
         {
             pbstrProjectName = ActiveIntellisenseProjectDisplayName;
             return VSConstants.S_OK;
+        }
+
+        #endregion
+
+        #region IVsProject members
+        public int AddItem(uint itemidLoc, VSADDITEMOPERATION dwAddItemOperation, string pszItemName, uint cFilesToOpen, string[] rgpszFilesToOpen, IntPtr hwndDlgOwner, VSADDRESULT[] pResult)
+        {
+            return InnerVsProject.AddItem(itemidLoc, dwAddItemOperation, pszItemName, cFilesToOpen, rgpszFilesToOpen, hwndDlgOwner, pResult);
+        }
+
+        public int GenerateUniqueItemName(uint itemidLoc, string pszExt, string pszSuggestedRoot, out string pbstrItemName)
+        {
+            return InnerVsProject.GenerateUniqueItemName(itemidLoc, pszExt, pszSuggestedRoot, out pbstrItemName);
+        }
+
+        public int GetItemContext(uint itemid, out IOLEServiceProvider ppSP)
+        {
+            return InnerVsProject.GetItemContext(itemid, out ppSP);
+        }
+
+        public int GetMkDocument(uint itemid, out string pbstrMkDocument)
+        {
+            return InnerVsProject.GetMkDocument(itemid, out pbstrMkDocument);
+        }
+
+        public int IsDocumentInProject(string pszMkDocument, out int pfFound, VSDOCUMENTPRIORITY[] pdwPriority, out uint pitemid)
+        {
+            return InnerVsProject.IsDocumentInProject(pszMkDocument, out pfFound, pdwPriority, out pitemid);
+        }
+
+        public int OpenItem(uint itemid, ref Guid rguidLogicalView, IntPtr punkDocDataExisting, out IVsWindowFrame ppWindowFrame)
+        {
+            return InnerVsProject.OpenItem(itemid, ref rguidLogicalView, punkDocDataExisting, out ppWindowFrame);
         }
 
         #endregion

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/AbstractHostObject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/AbstractHostObject.cs
@@ -13,12 +13,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
     /// </summary>
     internal abstract class AbstractHostObject : IVsHierarchy, IVsContainedLanguageProjectNameProvider, IVsProject
     {
-        protected AbstractHostObject(object innerHostObject)
+        protected AbstractHostObject(IVsHierarchy innerHierarchy, IVsProject innerVsProject)
         {
-            Requires.NotNull(innerHostObject, nameof(innerHostObject));
+            Requires.NotNull(innerHierarchy, nameof(innerHierarchy));
+            Requires.NotNull(innerVsProject, nameof(innerVsProject));
 
-            InnerHierarchy = (IVsHierarchy)innerHostObject;
-            InnerVsProject = (IVsProject)innerHostObject;
+            InnerHierarchy = innerHierarchy;
+            InnerVsProject = innerVsProject;
         }
 
         protected IVsHierarchy InnerHierarchy { get; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ConfiguredProjectHostObject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ConfiguredProjectHostObject.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         private readonly string _projectDisplayName;
 
         public ConfiguredProjectHostObject(UnconfiguredProjectHostObject unconfiguredProjectHostObject, string projectDisplayName)
-            : base (unconfiguredProjectHostObject)
+            : base (innerHierarchy: unconfiguredProjectHostObject, innerVsProject: unconfiguredProjectHostObject)
         {
             Requires.NotNull(unconfiguredProjectHostObject, nameof(unconfiguredProjectHostObject));
             Requires.NotNullOrEmpty(projectDisplayName, nameof(projectDisplayName));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ConfiguredProjectHostObject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ConfiguredProjectHostObject.cs
@@ -15,6 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         private readonly string _projectDisplayName;
 
         public ConfiguredProjectHostObject(UnconfiguredProjectHostObject unconfiguredProjectHostObject, string projectDisplayName)
+            : base (unconfiguredProjectHostObject)
         {
             Requires.NotNull(unconfiguredProjectHostObject, nameof(unconfiguredProjectHostObject));
             Requires.NotNullOrEmpty(projectDisplayName, nameof(projectDisplayName));
@@ -24,7 +25,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         }
 
         public String ProjectDisplayName => _projectDisplayName;
-        protected override IVsHierarchy InnerHierarchy => _unconfiguredProjectHostObject;
         public override String ActiveIntellisenseProjectDisplayName => _unconfiguredProjectHostObject.ActiveIntellisenseProjectDisplayName;
 
         #region IVsHierarchy overrides

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ProjectHostProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ProjectHostProvider.cs
@@ -10,14 +10,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
     internal sealed partial class ProjectHostProvider : IProjectHostProvider
     {
         [ImportingConstructor]
-        public ProjectHostProvider()
+        public ProjectHostProvider(UnconfiguredProject unconfiguredProject)
         {
+            Requires.NotNull(unconfiguredProject, nameof(unconfiguredProject));
+
+            UnconfiguredProjectHostObject = new UnconfiguredProjectHostObject(unconfiguredProject);
         }
 
-        public IUnconfiguredProjectHostObject GetUnconfiguredProjectHostObject(UnconfiguredProject unconfiguredProject)
-        {
-            return new UnconfiguredProjectHostObject(unconfiguredProject);
-        }
+        public IUnconfiguredProjectHostObject UnconfiguredProjectHostObject { get; }
 
         public IConfiguredProjectHostObject GetConfiguredProjectHostObject(IUnconfiguredProjectHostObject unconfiguredProjectHostObject, String projectDisplayName)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/UnconfiguredProjectHostObject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/UnconfiguredProjectHostObject.cs
@@ -12,20 +12,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
     /// </summary>
     internal sealed class UnconfiguredProjectHostObject : AbstractHostObject, IUnconfiguredProjectHostObject
     {
-        private readonly IVsHierarchy _innerHierarchy;
         private readonly Dictionary<uint, IVsHierarchyEvents> _hierEventSinks;
         private readonly HashSet<uint> _pendingItemIds;
 
         public UnconfiguredProjectHostObject(UnconfiguredProject unconfiguredProject)
+            : base (unconfiguredProject.Services.HostObject)
         {
             Requires.NotNull(unconfiguredProject, nameof(unconfiguredProject));
 
-            _innerHierarchy = (IVsHierarchy)unconfiguredProject.Services.HostObject;
             _hierEventSinks = new Dictionary<uint, IVsHierarchyEvents>();
             _pendingItemIds = new HashSet<uint>();
         }
 
-        protected override IVsHierarchy InnerHierarchy => _innerHierarchy;
         public IConfiguredProjectHostObject ActiveIntellisenseProjectHostObject { get; set; }
         public override String ActiveIntellisenseProjectDisplayName => ActiveIntellisenseProjectHostObject?.ProjectDisplayName;
         public bool DisposingConfiguredProjectHostObjects { get; set; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/UnconfiguredProjectHostObject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/UnconfiguredProjectHostObject.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         private readonly HashSet<uint> _pendingItemIds;
 
         public UnconfiguredProjectHostObject(UnconfiguredProject unconfiguredProject)
-            : base (unconfiguredProject.Services.HostObject)
+            : base (innerHierarchy: (IVsHierarchy)unconfiguredProject.Services.HostObject, innerVsProject: (IVsProject)unconfiguredProject.Services.HostObject)
         {
             Requires.NotNull(unconfiguredProject, nameof(unconfiguredProject));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactoryBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactoryBase.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
@@ -12,23 +13,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
     {
         public VsContainedLanguageComponentsFactoryBase(SVsServiceProvider serviceProvider,
                                                         IUnconfiguredProjectVsServices projectServices,
+                                                        IProjectHostProvider projectHostProvider,
                                                         Guid languageServiceGuid)
         {
             ServiceProvider = serviceProvider;
             ProjectServices = projectServices;
             LanguageServiceGuid = languageServiceGuid;
+            ProjectHostProvider = projectHostProvider;
         }
 
         private Guid LanguageServiceGuid { get; }
         private SVsServiceProvider ServiceProvider { get; }
         private IUnconfiguredProjectVsServices ProjectServices { get; }
+        private IProjectHostProvider ProjectHostProvider { get; }
 
         /// <summary>
-        ///     Gets an object that represents a host-specific IVsContainedLanguageFactory implementation.
-        ///     Note: currently we have only one target framework and IVsHierarchy and itemId is returned as 
-        ///     they are from the unconfigured project. Later when combined intellisense is implemented, depending
-        ///     on implementation we might need to have a logic that returns IVsHierarchy and itemId specific to 
-        ///     currently active target framework (thats how it was in Dev14's dnx/dotnet project system)
+        ///     Gets an object that represents a host-specific IVsContainedLanguageFactory implementation and
+        ///     IVsHierarchy and itemId specific to currently active target framework.
         /// </summary>
         /// <param name="filePath">Path to a file</param>
         /// <param name="hierarchy">Project hierarchy containing given file for current language service</param>
@@ -59,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
                     return;
                 }
              
-                myHierarchy = ProjectServices.VsHierarchy;
+                myHierarchy = (ConfiguredProjectHostObject)ProjectHostProvider.UnconfiguredProjectHostObject.ActiveIntellisenseProjectHostObject;
 
                 var oleServiceProvider = ServiceProvider.GetService(typeof(IOLEServiceProvider)) as IOLEServiceProvider;
                 if (oleServiceProvider == null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactoryBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactoryBase.cs
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
                     return;
                 }
              
-                myHierarchy = (ConfiguredProjectHostObject)ProjectHostProvider.UnconfiguredProjectHostObject.ActiveIntellisenseProjectHostObject;
+                myHierarchy = (IVsHierarchy)ProjectHostProvider.UnconfiguredProjectHostObject.ActiveIntellisenseProjectHostObject;
 
                 var oleServiceProvider = ServiceProvider.GetService(typeof(IOLEServiceProvider)) as IOLEServiceProvider;
                 if (oleServiceProvider == null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IProjectHostProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IProjectHostProvider.cs
@@ -15,9 +15,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         IConfiguredProjectHostObject GetConfiguredProjectHostObject(IUnconfiguredProjectHostObject unconfiguredProjectHostObject, string projectDisplayName);
 
         /// <summary>
-        /// Creates an <see cref="IUnconfiguredProjectHostObject"/> for the given unconfigured project.
+        /// Gets an <see cref="IUnconfiguredProjectHostObject"/> for the current unconfigured project.
         /// </summary>
-        /// <param name="project">Unconfigured project.</param>
-        IUnconfiguredProjectHostObject GetUnconfiguredProjectHostObject(UnconfiguredProject project);
+        IUnconfiguredProjectHostObject UnconfiguredProjectHostObject { get; }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             _projectHostProvider = projectHostProvider;
             _activeConfiguredProjectsProvider = activeConfiguredProjectsProvider;
 
-            _unconfiguredProjectHostObject = _projectHostProvider.GetUnconfiguredProjectHostObject(_commonServices.Project);
+            _unconfiguredProjectHostObject = _projectHostProvider.UnconfiguredProjectHostObject;
         }
 
         public async Task<AggregateWorkspaceProjectContext> CreateProjectContextAsync()

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/LanguageServices/VisualBasicVsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/LanguageServices/VisualBasicVsContainedLanguageComponentsFactory.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
@@ -14,9 +15,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 
         [ImportingConstructor]
         public VisualBasicVsContainedLanguageComponentsFactory(SVsServiceProvider serviceProvider,
-                                                        IUnconfiguredProjectVsServices projectServices)
-            : base(serviceProvider, projectServices, VisualBasicLanguageServiceGuid)
-                                                        
+                                                        IUnconfiguredProjectVsServices projectServices,
+                                                        IProjectHostProvider projectHostProvider)
+            : base(serviceProvider, projectServices, projectHostProvider, VisualBasicLanguageServiceGuid)
         {
         }
     }


### PR DESCRIPTION
1. Return active intellisense project host object from VsContainedLanguageComponentsFactoryBase.GetContainedLanguageFactoryForFile.
2. AbstractHostObject implements IVsProject and delegates to the inner hierarchy for all implementations - Roslyn `ContainedDocument` assumes that the host object implements this interface.

Fixes #677