### PR TITLE
Register Nominate Restore as a Critical Project System Task

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
@@ -120,9 +120,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 
             if (projectRestoreInfo != null)
             {
-                await _solutionRestoreService
-                    .NominateProjectAsync(_projectVsServices.Project.FullPath, projectRestoreInfo, CancellationToken.None)
-                    .ConfigureAwait(false);
+                try
+                {
+                    await _solutionRestoreService
+                        .NominateProjectAsync(_projectVsServices.Project.FullPath, projectRestoreInfo, CancellationToken.None)
+                        .ConfigureAwait(true);
+
+                    _projectVsServices.Project.Services.ProjectAsynchronousTasks
+                        .RegisterCriticalAsyncTask(JoinableFactory.RunAsync(() =>_solutionRestoreService.CurrentRestoreOperation));
+                }
+                catch (OperationCanceledException) { }
             }
         }
 


### PR DESCRIPTION
To block the build while a restore operation is happening.

Fixes #654: A deadlock can occur if the user builds while a restore operation is happening

Requires change from NuGet

/cc @alpaix @dotnet/project-system @rrelyea 
/cc @MattGertz 