### PR TITLE
Temporary fix for #419

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorDesignerLoader.vb
@@ -120,6 +120,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     Catch ex As ArgumentException
                         ' Can happen if there is no supported TargetFrameworkMoniker
                         mtSvr = Nothing
+                    Catch ex As InvalidOperationException
+                        ' Can also happen if there is no supported TargetFrameworkMoniker, in a .NETCore project
+                        ' TODO: fix MultiTargetService to work for .NET Core apps. Tracked by https://github.com/dotnet/roslyn-project-system/issues/686
+                        mtSvr = Nothing
                     End Try
 
                     Dim ResourceFile As New ResourceFile(mtSvr, NewResourceEditorRoot, LoaderHost, BasePath)


### PR DESCRIPTION
Settings mtSvr to Nothing causes the Access Level combobox to be disabled, but a full fix will require changes that won't make the RC bar. ResX code-behind is successfully generated on save. We can also change the access level by manually setting the SingleFileGenerator for the file to be the PublicResXFileCodeGenerator. Follow up work to fix MultiTargetService is tracked by #686.