### PR TITLE
Don't initialize the file watcher in the MEF constructor.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeProviderFactory.cs
@@ -3,6 +3,7 @@
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Moq;
+using System.Threading.Tasks.Dataflow;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
@@ -11,6 +12,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public static IProjectTreeProvider Create(string addNewItemDirectoryReturn = null)
         {
             var mock = new Mock<IProjectTreeProvider>();
+
+            var mockTree = Mock.Of<IReceivableSourceBlock<IProjectVersionedValue<IProjectTreeSnapshot>>>();
+            mock.SetupGet(t => t.Tree)
+                .Returns(mockTree);
 
             mock.Setup(t => t.GetPath(It.IsAny<IProjectTree>()))
                 .Returns<IProjectTree>(tree => tree.FilePath);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ProjectLockFileWatcherTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ProjectLockFileWatcherTests.cs
@@ -39,6 +39,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\foo.proj""
                                                      IProjectLockServiceFactory.Create());
 
             var tree = ProjectTreeParser.Parse(inputTree);
+            watcher.Load();
             watcher.ProjectTree_ChangedAsync(IProjectVersionedValueFactory<IProjectTreeSnapshot>.Create(IProjectTreeSnapshotFactory.Create(tree)));
 
             // If fileToWatch is null then we expect to not register any filewatcher.
@@ -96,6 +97,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\foo.proj""
                                                      IUnconfiguredProjectCommonServicesFactory.Create(unconfiguredProject,
                                                                                                       projectProperties: ProjectPropertiesFactory.Create(unconfiguredProject, new[] { propertyData })),
                                                      IProjectLockServiceFactory.Create());
+            watcher.Load();
 
             var firstTree = ProjectTreeParser.Parse(inputTree);
             watcher.ProjectTree_ChangedAsync(IProjectVersionedValueFactory<IProjectTreeSnapshot>.Create(IProjectTreeSnapshotFactory.Create(firstTree)));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectLockFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectLockFileWatcher.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         private readonly IUnconfiguredProjectCommonServices _projectServices;
         private readonly IProjectLockService _projectLockService;
         private readonly IProjectTreeProvider _fileSystemTreeProvider;
-        private readonly IVsFileChangeEx _fileChangeService;
+        private IVsFileChangeEx _fileChangeService;
         private IDisposable _treeWatcher;
         private uint _filechangeCookie;
         private string _fileBeingWatched;
@@ -37,13 +37,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             _fileSystemTreeProvider = fileSystemTreeProvider;
             _projectServices = projectServices;
             _projectLockService = projectLockService;
-            _fileChangeService = _serviceProvider.GetService<IVsFileChangeEx, SVsFileChangeEx>();
         }
 
         /// <summary>
         /// Called on project load.
         /// </summary>
-        [ConfiguredProjectAutoLoad]
+        [ConfiguredProjectAutoLoad(RequiresUIThread = true)]
         [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
         internal void Load()
         {
@@ -55,6 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// </summary>
         protected override void Initialize()
         {
+            _fileChangeService = _serviceProvider.GetService<IVsFileChangeEx, SVsFileChangeEx>();
             _treeWatcher = _fileSystemTreeProvider.Tree.LinkTo(new ActionBlock<IProjectVersionedValue<IProjectTreeSnapshot>>(new Action<IProjectVersionedValue<IProjectTreeSnapshot>>(this.ProjectTree_ChangedAsync)));
         }
 


### PR DESCRIPTION
Making a COM call in the MEF constructor can potentially cause deadlocks. At the very least it can perf problems by blocking background initialization.

@dotnet/project-system @lifengl