### PR TITLE
Override common xaml rules in Project System

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -161,9 +161,30 @@
     <Compile Include="ProjectSystem\Rules\COMReference.cs">
       <DependentUpon>COMReference.xaml</DependentUpon>
     </Compile>
+    <Compile Include="ProjectSystem\Rules\ConfigurationGeneralFile.cs">
+      <DependentUpon>ConfigurationGeneralFile.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="ProjectSystem\Rules\Content.cs">
+      <DependentUpon>Content.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="ProjectSystem\Rules\DebuggerGeneral.cs">
+      <DependentUpon>DebuggerGeneral.xaml</DependentUpon>
+    </Compile>
     <Compile Include="ProjectSystem\Rules\DotNetCliToolReference.cs">
       <DependentUpon>DotNetCliToolReference.xaml</DependentUpon>
     </Compile>
+    <Compile Include="ProjectSystem\Rules\EmbeddedResource.cs">
+      <DependentUpon>EmbeddedResource.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="ProjectSystem\Rules\Folder.cs">
+      <DependentUpon>Folder.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="ProjectSystem\Rules\SourceControl.cs">
+      <DependentUpon>SourceControl.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="ProjectSystem\Rules\SpecialFolder.cs">
+      <DependentUpon>SpecialFolder.xaml</DependentUpon>
+    </Compile>    
     <Compile Include="ProjectSystem\Rules\SubProject.cs">
       <DependentUpon>SubProject.xaml</DependentUpon>
     </Compile>
@@ -232,11 +253,39 @@
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
       <SubType>Designer</SubType>
     </XamlPropertyRule>
+    <XamlPropertyRule Include="ProjectSystem\Rules\Content.xaml">
+      <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
+      <SubType>Designer</SubType>
+    </XamlPropertyRule>
+    <XamlPropertyRule Include="ProjectSystem\Rules\EmbeddedResource.xaml">
+      <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
+      <SubType>Designer</SubType>
+    </XamlPropertyRule>
+    <XamlPropertyRule Include="ProjectSystem\Rules\Folder.xaml">
+      <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
+      <SubType>Designer</SubType>
+    </XamlPropertyRule>
+    <XamlPropertyRule Include="ProjectSystem\Rules\SourceControl.xaml">
+      <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
+      <SubType>Designer</SubType>
+    </XamlPropertyRule>
+    <XamlPropertyRule Include="ProjectSystem\Rules\SpecialFolder.xaml">
+      <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
+      <SubType>Designer</SubType>
+    </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\SubProject.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
       <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\ConfigurationGeneral.xaml">
+      <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
+      <SubType>Designer</SubType>
+    </XamlPropertyRule>
+    <XamlPropertyRule Include="ProjectSystem\Rules\ConfigurationGeneralFile.xaml">
+      <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
+      <SubType>Designer</SubType>
+    </XamlPropertyRule>
+    <XamlPropertyRule Include="ProjectSystem\Rules\DebuggerGeneral.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
       <SubType>Designer</SubType>
     </XamlPropertyRule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneralFile.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneralFile.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    [ExcludeFromCodeCoverage]
+    partial class ConfigurationGeneralFile
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneralFile.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneralFile.xaml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Copyright, Microsoft Corporation, All rights reserved.-->
+<Rule
+  Name="ConfigurationGeneralFile"
+  DisplayName="General"
+  PageTemplate="generic"
+  Description="Project item general properties"
+  xmlns="http://schemas.microsoft.com/build/2009/properties">
+
+  <Rule.DataSource>
+    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="{}{AnyType}" />
+  </Rule.DataSource>
+
+  <Rule.Categories>
+    <Category Name="Advanced" DisplayName="Advanced" />
+    <Category Name="Misc" DisplayName="Misc" />
+  </Rule.Categories>
+
+  <DynamicEnumProperty
+    Name="{}{ItemType}"
+    DisplayName="Build Action"
+    Category="Advanced"
+    Description="How the file relates to the build and deployment processes."
+    EnumProvider="ItemTypes" />
+
+  <EnumProperty
+      Name="CopyToOutputDirectory"
+      DisplayName="Copy to Output Directory"
+      Category="Advanced"
+      Description="Specifies the source file will be copied to the output directory.">
+    <EnumValue Name="Never" DisplayName="Do not copy" />
+    <EnumValue Name="Always" DisplayName="Copy always" />
+    <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
+  </EnumProperty>
+
+  <StringProperty
+      Name="Identity"
+      Visible="false"
+      ReadOnly="true"
+      Category="Misc"
+      Description="The item specified in the Include attribute.">
+    <StringProperty.DataSource>
+      <DataSource Persistence="Intrinsic" ItemType="{}{AnyType}" PersistedName="Identity" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty
+      Name="FullPath"
+      DisplayName="Full Path"
+      ReadOnly="true"
+      Category="Misc"
+      Description="Location of the file.">
+    <StringProperty.DataSource>
+      <DataSource Persistence="Intrinsic" ItemType="{}{AnyType}" PersistedName="FullPath" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty
+      Name="FileNameAndExtension"
+      DisplayName="File Name"
+      ReadOnly="true"
+      Category="Misc"
+      Description="Name of the file or folder.">
+    <StringProperty.DataSource>
+      <DataSource Persistence="Intrinsic" ItemType="{}{AnyType}" PersistedName="FileNameAndExtension" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="URL" ReadOnly="true" Visible="false">
+    <StringProperty.DataSource>
+      <DataSource Persistence="Intrinsic" ItemType="{}{AnyType}" PersistedName="FullPath" />
+    </StringProperty.DataSource>
+  </StringProperty>
+  <StringProperty Name="DependentUpon" Visible="False" Description="The leaf name of the file that this item appears as a child to in the project tree." />
+  <BoolProperty Name="Visible" Visible="false" />
+  <StringProperty Name="Link" Visible="false" />
+  <StringProperty Name="Extension" Visible="False" ReadOnly="true">
+    <StringProperty.DataSource>
+      <DataSource Persistence="Intrinsic" ItemType="{}{AnyType}" PersistedName="Extension" />
+    </StringProperty.DataSource>
+  </StringProperty>
+  <StringProperty Name="GeneratorTarget" Visible="false" />
+  <EnumProperty Name="SubType" Visible="false">
+    <EnumValue Name="Designer" />
+    <EnumValue Name="Component" />
+    <EnumValue Name="Control" />
+    <EnumValue Name="Form" />
+    <EnumValue Name="Code" />
+  </EnumProperty>
+
+  <StringProperty Name="LastGenOutput" Visible="false" Description="The filename of the last file generated as a result of the SFG." />
+  <BoolProperty Name="DesignTime" Visible="false" Description="A value indicating whether this file has a designer." />
+  <BoolProperty Name="AutoGen" Visible="false" Description="A value indicating whether this is a generated file." />
+</Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneralFile.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneralFile.xaml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--Copyright, Microsoft Corporation, All rights reserved.-->
+<!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
 <Rule
   Name="ConfigurationGeneralFile"
   DisplayName="General"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Content.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Content.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    [ExcludeFromCodeCoverage]
+    partial class Content
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Content.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Content.xaml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--Copyright, Microsoft Corporation, All rights reserved.-->
+<!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
 <Rule
   Name="Content"
   DisplayName="File Properties"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Content.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Content.xaml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Copyright, Microsoft Corporation, All rights reserved.-->
+<Rule
+  Name="Content"
+  DisplayName="File Properties"
+  PageTemplate="generic"
+  Description="File Properties"
+  xmlns="http://schemas.microsoft.com/build/2009/properties">
+
+  <Rule.DataSource>
+    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="Content" />
+  </Rule.DataSource>
+
+  <Rule.Categories>
+    <Category Name="Advanced" DisplayName="Advanced" />
+    <Category Name="Misc" DisplayName="Misc" />
+  </Rule.Categories>
+
+  <DynamicEnumProperty
+      Name="{}{ItemType}"
+      DisplayName="Build Action"
+      Category="Advanced"
+      Description="How the file relates to the build and deployment processes."
+      EnumProvider="ItemTypes" />
+
+  <EnumProperty
+      Name="CopyToOutputDirectory"
+      DisplayName="Copy to Output Directory"
+      Category="Advanced"
+      Description="Specifies the source file will be copied to the output directory.">
+    <EnumValue Name="Never" DisplayName="Do not copy" />
+    <EnumValue Name="Always" DisplayName="Copy always" />
+    <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
+  </EnumProperty>
+
+  <StringProperty
+    Name="Identity"
+    Visible="false"
+    ReadOnly="true"
+    Category="Misc"
+    Description="The item specified in the Include attribute.">
+    <StringProperty.DataSource>
+      <DataSource Persistence="Intrinsic" ItemType="Content" PersistedName="Identity" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty
+      Name="FullPath"
+      DisplayName="Full Path"
+      ReadOnly="true"
+      Category="Misc"
+      Description="Location of the file.">
+    <StringProperty.DataSource>
+      <DataSource Persistence="Intrinsic" ItemType="Content" PersistedName="FullPath" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty
+    Name="FileNameAndExtension"
+    DisplayName="File Name"
+    ReadOnly="true"
+    Category="Misc"
+    Description="Name of the file or folder.">
+    <StringProperty.DataSource>
+      <DataSource Persistence="Intrinsic" ItemType="Content" PersistedName="FileNameAndExtension" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <BoolProperty Name="Visible" Visible="false" />
+  <StringProperty Name="DependentUpon" Visible="false">
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects" Value="true" />
+    </StringProperty.Metadata>
+  </StringProperty>
+  <StringProperty Name="Link" Visible="false">
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects" Value="true" />
+    </StringProperty.Metadata>
+  </StringProperty>
+</Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DebuggerGeneral.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DebuggerGeneral.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    [ExcludeFromCodeCoverage]
+    partial class DebuggerGeneral
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DebuggerGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DebuggerGeneral.xaml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Copyright, Microsoft Corporation, All rights reserved.-->
+<Rule Name="DebuggerGeneralProperties"
+      DisplayName="Debugger General Properties"
+      Description="General Debugger options"
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
+  <Rule.DataSource>
+    <DataSource Persistence="UserFile" />
+  </Rule.DataSource>
+  
+  <StringProperty Name="SymbolsPath" DisplayName="Symbol Search Path"
+                  Description="The search path used by the debugger to locate symbols.">
+  </StringProperty>
+
+  <StringProperty Name="DebuggerFlavor" Visible="false"
+                  Description="The debug rule selected as the active debugger.">
+  </StringProperty>
+
+  <EnumProperty Name="ImageClrType" Visible="false"
+                  Description="The 'hidden' property we pass to debuggers to let them know if this is a managed project.">
+    <EnumProperty.DataSource>
+      <DataSource Persistence="UserFile" HasConfigurationCondition="false" PersistedName="_TargetImageClrType" />
+    </EnumProperty.DataSource>
+    <EnumValue Name="Native" DisplayName="Native Image" Description="The executable image to debug is a fully native application." />
+    <EnumValue Name="Mixed" DisplayName="Mixed Image" Description="The executable image to debug is a mixture of native and managed code." />
+    <EnumValue Name="Managed" DisplayName="Managed Image" Description="The executable image to debug is a fully managed application." />
+  </EnumProperty>
+</Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DebuggerGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DebuggerGeneral.xaml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--Copyright, Microsoft Corporation, All rights reserved.-->
+<!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
 <Rule Name="DebuggerGeneralProperties"
       DisplayName="Debugger General Properties"
       Description="General Debugger options"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/EmbeddedResource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/EmbeddedResource.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    [ExcludeFromCodeCoverage]
+    partial class EmbeddedResource
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/EmbeddedResource.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/EmbeddedResource.xaml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--Copyright, Microsoft Corporation, All rights reserved.-->
+<!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
 <Rule
 	Name="EmbeddedResource"
 	DisplayName="Embedded Resource"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/EmbeddedResource.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/EmbeddedResource.xaml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Copyright, Microsoft Corporation, All rights reserved.-->
+<Rule
+	Name="EmbeddedResource"
+	DisplayName="Embedded Resource"
+	PageTemplate="generic"
+	Description="Embedded resources"
+	xmlns="http://schemas.microsoft.com/build/2009/properties">
+  <Rule.DataSource>
+    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="EmbeddedResource" />
+  </Rule.DataSource>
+  <Rule.Categories>
+    <Category Name="Advanced" DisplayName="Advanced" />
+    <Category Name="Misc" DisplayName="Misc" />
+  </Rule.Categories>
+
+  <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Build Action"  Category="Advanced"
+                     Description="How the file relates to the build and deployment processes."
+                     EnumProvider="ItemTypes" />
+  <EnumProperty
+      Name="CopyToOutputDirectory"
+      DisplayName="Copy to Output Directory"
+      Category="Advanced"
+      Description="Specifies the source file will be copied to the output directory.">
+    <EnumValue Name="Never" DisplayName="Do not copy" />
+    <EnumValue Name="Always" DisplayName="Copy always" />
+    <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
+  </EnumProperty>
+
+  <StringProperty
+      Name="Generator"
+      Category="Advanced"
+      DisplayName="Custom Tool"
+      Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty
+      Name="CustomToolNamespace"
+      Category="Advanced"
+      DisplayName="Custom Tool Namespace"
+      Description="The namespace into which the output of the custom tool is placed." />
+
+  <StringProperty
+      Name="Identity"
+      Visible="false"
+      ReadOnly="true"
+      Category="Misc"
+      Description="The item specified in the Include attribute.">
+    <StringProperty.DataSource>
+      <DataSource Persistence="Intrinsic" ItemType="EmbeddedResource" PersistedName="Identity" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty
+      Name="FullPath"
+      DisplayName="Full Path"
+      ReadOnly="true"
+      Category="Misc"
+      Description="Location of the file.">
+    <StringProperty.DataSource>
+      <DataSource Persistence="Intrinsic" ItemType="EmbeddedResource" PersistedName="FullPath" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty
+      Name="FileNameAndExtension"
+      DisplayName="File Name"
+      ReadOnly="true"
+      Category="Misc"
+      Description="Name of the file or folder.">
+    <StringProperty.DataSource>
+      <DataSource Persistence="Intrinsic" ItemType="EmbeddedResource" PersistedName="FileNameAndExtension" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="URL" ReadOnly="true" Visible="false">
+    <StringProperty.DataSource>
+      <DataSource Persistence="Intrinsic" ItemType="EmbeddedResource" PersistedName="FullPath" />
+    </StringProperty.DataSource>
+  </StringProperty>
+  <BoolProperty Name="Visible" Visible="false" />
+  <StringProperty Name="DependentUpon" Visible="false" />
+  <StringProperty Name="Link" Visible="false" />
+  <StringProperty Name="Extension" Visible="False" ReadOnly="true">
+    <StringProperty.DataSource>
+      <DataSource Persistence="Intrinsic" ItemType="EmbeddedResource" PersistedName="Extension" />
+    </StringProperty.DataSource>
+  </StringProperty>
+  <StringProperty Name="LastGenOutput" Visible="false" Description="The filename of the last file generated as a result of the SFG." />
+  <BoolProperty Name="DesignTime" Visible="false" Description="A value indicating whether this file has a designer." />
+  <BoolProperty Name="AutoGen" Visible="false" Description="A value indicating whether this is a generated file." />
+  <StringProperty Name="CustomTool" Visible="false" Description="DTE Property for accessing the Generator property.">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" ItemType="EmbeddedResource" PersistedName="Generator" HasConfigurationCondition="False" />
+    </StringProperty.DataSource>
+  </StringProperty>
+</Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Folder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Folder.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    [ExcludeFromCodeCoverage]
+    partial class Folder
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Folder.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Folder.xaml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Copyright, Microsoft Corporation, All rights reserved.-->
+<Rule
+  Name="Folder"
+  DisplayName="General"
+  PageTemplate="generic"
+  Description="Empty folder placeholders"
+  xmlns="http://schemas.microsoft.com/build/2009/properties">
+  <Rule.DataSource>
+    <DataSource Persistence="ProjectInstance" HasConfigurationCondition="False" ItemType="Folder" />
+  </Rule.DataSource>
+
+  <StringProperty Name="Identity" Visible="false" ReadOnly="true" Category="Misc" />
+  <StringProperty Name="FullPath" DisplayName="Full Path" ReadOnly="true" Category="Misc" />
+  <StringProperty Name="FileNameAndExtension" DisplayName="Folder Name" ReadOnly="true" Category="Misc">
+      <StringProperty.DataSource>
+            <DataSource Persistence="ProjectInstance" ItemType="Folder" PersistedName="FileNameAndExtension" />
+      </StringProperty.DataSource>
+  </StringProperty>
+</Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Folder.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Folder.xaml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--Copyright, Microsoft Corporation, All rights reserved.-->
+<!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
 <Rule
   Name="Folder"
   DisplayName="General"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SourceControl.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SourceControl.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    [ExcludeFromCodeCoverage]
+    partial class SourceControl
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SourceControl.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SourceControl.xaml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--Copyright, Microsoft Corporation, All rights reserved.-->
+<!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
 <Rule
   Name="SourceControl"
   DisplayName="Source control"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SourceControl.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SourceControl.xaml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Copyright, Microsoft Corporation, All rights reserved.-->
+<Rule
+  Name="SourceControl"
+  DisplayName="Source control"
+  PageTemplate="generic"
+  Description="General"
+  xmlns="http://schemas.microsoft.com/build/2009/properties">
+  <Rule.DataSource>
+    <DataSource Persistence="ProjectFile" Label="Globals" HasConfigurationCondition="False" />
+  </Rule.DataSource>
+  <StringProperty Name="SccProjectName" />
+  <StringProperty Name="SccProvider" />
+  <StringProperty Name="SccAuxPath" />
+  <StringProperty Name="SccLocalPath" />
+</Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SpecialFolder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SpecialFolder.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    [ExcludeFromCodeCoverage]
+    partial class SpecialFolder
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SpecialFolder.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SpecialFolder.xaml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--Copyright, Microsoft Corporation, All rights reserved.-->
+<!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
 <Rule
 	Name="SpecialFolder"
 	DisplayName="General"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SpecialFolder.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SpecialFolder.xaml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Copyright, Microsoft Corporation, All rights reserved.-->
+<Rule
+	Name="SpecialFolder"
+	DisplayName="General"
+	PageTemplate="generic"
+	Description="Special folders"
+	xmlns="http://schemas.microsoft.com/build/2009/properties">
+	<Rule.DataSource>
+		<DataSource Persistence="ProjectInstance" HasConfigurationCondition="False" ItemType="SpecialFolder" />
+	</Rule.DataSource>
+
+	<StringProperty Name="Identity" Visible="false" ReadOnly="true" Category="Misc" />
+	<StringProperty Name="FullPath" DisplayName="Full Path" ReadOnly="true" Category="Misc" />
+    <StringProperty Name="FileNameAndExtension" DisplayName="Folder Name" ReadOnly="true" Category="Misc">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectInstance" ItemType="SpecialFolder" PersistedName="FileNameAndExtension" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <EnumProperty Name="DisableAddItem" Visible="False">
+        <EnumValue Name="Recursive" />
+        <EnumValue Name="TopDirectoryOnly" />
+    </EnumProperty>
+</Rule>

--- a/src/Targets/Microsoft.Managed.DesignTime.targets
+++ b/src/Targets/Microsoft.Managed.DesignTime.targets
@@ -14,6 +14,7 @@
     <DefineCommonReferenceSchemas>false</DefineCommonReferenceSchemas>
 
     <DefineCommonManagedCapabilities Condition=" '$(DefineCommonManagedCapabilities)' == '' ">true</DefineCommonManagedCapabilities>
+    <DefineCommonManagedItemSchemas Condition=" '$(DefineCommonManagedItemSchemas)' == '' ">true</DefineCommonManagedItemSchemas>
     <DefineCommonManagedReferenceSchemas Condition=" '$(DefineCommonManagedReferenceSchemas)' == '' ">true</DefineCommonManagedReferenceSchemas>
     
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
@@ -56,8 +57,8 @@
     <ProjectCapability Include="ProjectConfigurationsInferredFromUsage" />
  </ItemGroup>
 
-  <!-- Common Project System rules that override rules defined in CPS. These are exact copy of the rules defined in CPS. -->
-  <ItemGroup>
+  <!-- Common Project System rules that override rules defined in msbuild. These are exact copy of the rules defined in msbuild. -->
+  <ItemGroup Condition="'$(DefineCommonManagedItemSchemas)' == 'true'">
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)DebuggerGeneral.xaml">
       <Context>Project</Context>
     </PropertyPageSchema>

--- a/src/Targets/Microsoft.Managed.DesignTime.targets
+++ b/src/Targets/Microsoft.Managed.DesignTime.targets
@@ -86,10 +86,7 @@
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)SpecialFolder.xaml">
       <Context>File;ProjectSubscriptionService</Context>
     </PropertyPageSchema>
-  </ItemGroup>
 
-  <!-- CPS Project Properties -->
-  <ItemGroup>
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)AppDesigner.xaml">
       <Context>ProjectSubscriptionService</Context>
     </PropertyPageSchema>

--- a/src/Targets/Microsoft.Managed.DesignTime.targets
+++ b/src/Targets/Microsoft.Managed.DesignTime.targets
@@ -9,7 +9,8 @@
   <PropertyGroup>
   <!-- Turn off capabilities from Microsoft.Common.CurrentVersions.targets and explicitly include the ones we want. The list below
        currently matches what is in common targets, but removes BuildWindowsDesktopTarget -->
-    <DefineCommonCapabilities>false</DefineCommonCapabilities>    
+    <DefineCommonItemSchemas>false</DefineCommonItemSchemas>
+    <DefineCommonCapabilities>false</DefineCommonCapabilities>
     <DefineCommonReferenceSchemas>false</DefineCommonReferenceSchemas>
 
     <DefineCommonManagedCapabilities Condition=" '$(DefineCommonManagedCapabilities)' == '' ">true</DefineCommonManagedCapabilities>
@@ -54,7 +55,38 @@
     <ProjectCapability Include="LanguageService" />
     <ProjectCapability Include="ProjectConfigurationsInferredFromUsage" />
  </ItemGroup>
-  
+
+  <!-- Common Project System rules that override rules defined in CPS. These are exact copy of the rules defined in CPS. -->
+  <ItemGroup>
+    <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)DebuggerGeneral.xaml">
+      <Context>Project</Context>
+    </PropertyPageSchema>
+
+    <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)ConfigurationGeneralFile.xaml">
+      <Context>File</Context>
+    </PropertyPageSchema>
+
+    <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)SourceControl.xaml">
+      <Context>Invisible</Context>
+    </PropertyPageSchema>
+
+    <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)Folder.xaml">
+      <Context>File;BrowseObject</Context>
+    </PropertyPageSchema>
+
+    <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)Content.xaml">
+      <Context>File;BrowseObject</Context>
+    </PropertyPageSchema>
+
+    <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)EmbeddedResource.xaml">
+      <Context>File;BrowseObject</Context>
+    </PropertyPageSchema>
+
+    <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)SpecialFolder.xaml">
+      <Context>File;ProjectSubscriptionService</Context>
+    </PropertyPageSchema>
+  </ItemGroup>
+
   <!-- CPS Project Properties -->
   <ItemGroup>
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)AppDesigner.xaml">


### PR DESCRIPTION
#### Customer scenario
Project Guids get stamped into the project. Many property pages show up disabled. Many other features that depend on getting project properties are broken. The reason is that because of a change in order of files being imported, our CPS rules for project properties weren't getting imported.
#### Bug this fixes
Fixes #681, Fixes #676 
#### Workarounds, if any
Users have to hand edit the target files which is risky
#### Risk
This change is creating a replica of all the common xaml rules in Roslyn Project System. So minimal risk.
#### Performance impact
None
#### Is this a regression from a previous update?
Yes
#### Root cause analysis:  
A recent change that we made to change the order of importing targets files in MSBuild caused this regression. We need integration tests to catch these issues.
#### How was the bug found?
Ad hoc testing

@srivatsn @333fred @jinujoseph @dotnet/project-system for review
