### PR TITLE
Fixed migration to allow opening a .xproj directly

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.Packaging
 {
     [Guid(PackageGuid)]
     [PackageRegistration(AllowsBackgroundLoading = true, RegisterUsing = RegistrationMethod.CodeBase, UseManagedResourcesOnly = true)]
-    [ProvideProjectFactory(typeof(MigrateXprojProjectFactory), null, null, null, null, null)]
+    [ProvideProjectFactory(typeof(MigrateXprojProjectFactory), null, "#8", "xproj", "xproj", null)]
     [RemoteCodeGeneratorRegistration(SingleFileGenerators.ResXGuid, SingleFileGenerators.ResXGeneratorName,
         SingleFileGenerators.ResXDescription, ProjectTypeGuidFormatted, GeneratesDesignTimeSource = true)]
     [RemoteCodeGeneratorRegistration(SingleFileGenerators.PublicResXGuid, SingleFileGenerators.PublicResXGeneratorName,

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.resx
@@ -139,6 +139,6 @@
     <value>Loaded Project File Editor</value>
   </data>
   <data name="8" xml:space="preserve">
-    <value>Unmigrated .NET Core Project Files (*.xproj);*.xproj</value>
+    <value>.NET Core 2015 Project Files (*.xproj);*.xproj</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.resx
@@ -138,4 +138,7 @@
   <data name="7" xml:space="preserve">
     <value>Loaded Project File Editor</value>
   </data>
+  <data name="8" xml:space="preserve">
+    <value>Unmigrated .NET Core Project Files (*.xproj);*.xproj</value>
+  </data>
 </root>


### PR DESCRIPTION
#### Customer scenario
When a user attempts to open an xproj directly, they cannot see it (if using VS->Open Project), or get an error (if they use any other method).

#### Bug
#691

#### Workarounds
The user can open the solution file instead of opening the project file. However, we think this is a core scenario that should work correctly, and there is no way to open the project file directly without modifying the registry manually.

#### Risk
This is low risk. It's just affecting the generated pkgdef for the xproj type, no other project types are affected.

#### Performance impact
Very low. The only change is that instead of parsing through 65 (as of this PR) types of projects, initial load will have to parse through 66.

#### Is this a regression from a previous update?
Not a regression.

#### How was the bug found?
This was found by internal adhoc testing.

Tagging @dotnet/project-system.