### PR TITLE
Added --skip-backup to migration calls.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
@@ -145,7 +145,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
                 Level = (uint)__VSUL_ERRORLEVEL.VSUL_ERROR,
                 Project = "XprojMigrationTests",
                 File = XprojLocation,
-                Message = $"Failed to migrate XProj project XprojMigrationTests. 'dotnet migrate -s -p \"{RootLocation}\" -x \"{XprojLocation}\"' exited with error code {VSConstants.E_FAIL}."
+                Message = $"Failed to migrate XProj project XprojMigrationTests. 'dotnet migrate --skip-backup -s -p \"{RootLocation}\" -x \"{XprojLocation}\"' exited with error code {VSConstants.E_FAIL}."
             }, loggedMessages[0]);
         }
 
@@ -239,7 +239,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         private void ProcessVerifier(ProcessStartInfo info)
         {
             Assert.Equal("dotnet.exe", info.FileName);
-            Assert.Equal($"migrate -s -x \"{XprojLocation}\" \"{RootLocation}\"", info.Arguments);
+            Assert.Equal($"migrate --skip-backup -s -x \"{XprojLocation}\" \"{RootLocation}\"", info.Arguments);
             Assert.True(info.EnvironmentVariables.ContainsKey("DOTNET_SKIP_FIRST_TIME_EXPERIENCE"));
             Assert.Equal("true", info.EnvironmentVariables["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"]);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         internal bool MigrateProject(string projectDirectory, string xprojLocation, string projectName, IVsUpgradeLogger pLogger)
         {
             // We count on dotnet.exe being on the path
-            var pInfo = new ProcessStartInfo("dotnet.exe", $"migrate -s -x \"{xprojLocation}\" \"{projectDirectory}\"");
+            var pInfo = new ProcessStartInfo("dotnet.exe", $"migrate --skip-backup -s -x \"{xprojLocation}\" \"{projectDirectory}\"");
             pInfo.UseShellExecute = false;
             pInfo.RedirectStandardError = true;
             pInfo.RedirectStandardOutput = true;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -451,7 +451,7 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to migrate XProj project {0}. &apos;dotnet migrate -s -p &quot;{1}&quot; -x &quot;{2}&quot;&apos; exited with error code {3}..
+        ///   Looks up a localized string similar to Failed to migrate XProj project {0}. &apos;dotnet migrate --skip-backup -s -p &quot;{1}&quot; -x &quot;{2}&quot;&apos; exited with error code {3}..
         /// </summary>
         internal static string XprojMigrationFailed {
             get {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -247,7 +247,7 @@ In order to debug this project, add an executable project to this solution which
     <value>Expected to find migrated cpsroj in {0}, but did not find any.</value>
   </data>
   <data name="XprojMigrationFailed" xml:space="preserve">
-    <value>Failed to migrate XProj project {0}. 'dotnet migrate -s -p "{1}" -x "{2}"' exited with error code {3}.</value>
+    <value>Failed to migrate XProj project {0}. 'dotnet migrate --skip-backup -s -p "{1}" -x "{2}"' exited with error code {3}.</value>
   </data>
   <data name="MigrationBackupFile" xml:space="preserve">
     <value>Backing up {0} to {1}.</value>


### PR DESCRIPTION
#### Customer scenario

When a user opens a solution with multiple .xproj projects in it, they expect all to migrate successfully. Currently, they might not, depending on ordering.

#### Bug

#703.

#### Workarounds

The user can migrate from the command line instead of using VS and manually edit their .sln file, but this is a very bad experience.

#### Risk

This is low risk. It's only affecting migration code paths, which only run the first time an xproj is opened.

#### Performance impact

Negligible. This simply adds another flag to the call to dotnet migrate.

#### Is this a regression from a previous update?

Yes.

#### Root Cause Analysis and Mitigation

This was caused when dotnet/cli added the backup feature, which deletes the original `project.json`, causing issues later on as we migrate project-by-project. Integration tests are needed to ensure that the cli command keeps working.

#### How was the bug found?

This was found by @jinujoseph as part of build validation.

Tagging @dotnet/project-system, @jinujoseph, @piotrpMSFT. /cc @MattGertz for approval.