### PR TITLE
C# 7

### DIFF
--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -9,14 +9,14 @@
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == '' and
                                  '$(OS)' != 'Windows_NT'">$(HOME)\.nuget\packages\</NuGetPackageRoot>
 
-    <!-- 
+    <!--
         $(OS) is only specific enough for windows builds.  For non-windows builds the identifier
         is specified on the command line of MSBuild
     -->
     <BaseNuGetRuntimeIdentifier Condition="'$(OS)' == 'Windows_NT'">win7</BaseNuGetRuntimeIdentifier>
   </PropertyGroup>
 
-  <Import Project="$(NuGetPackageRoot)\Microsoft.Net.Compilers\1.2.1\build\Microsoft.Net.Compilers.props" Condition="Exists('$(NuGetPackageRoot)\Microsoft.Net.Compilers\1.2.1\build\Microsoft.Net.Compilers.props')" />
+  <Import Project="$(NuGetPackageRoot)\Microsoft.Net.Compilers\2.0.0-rc2-61102-09\build\Microsoft.Net.Compilers.props" Condition="Exists('$(NuGetPackageRoot)\Microsoft.Net.Compilers\2.0.0-rc2-61102-09\build\Microsoft.Net.Compilers.props')" />
 
   <!-- Import the global NuGet packages -->
   <PropertyGroup>
@@ -84,12 +84,12 @@
   <PropertyGroup Condition="'$(VSCOMNTOOLS)' == ''">
     <VSCOMNTOOLS>$([System.Environment]::ExpandEnvironmentVariables("%VS$(VisualStudioReferenceMajorVersion)0COMNTOOLS%"))</VSCOMNTOOLS>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(DevEnvDir)' == ''">
     <DevEnvDir>$(VSCOMNTOOLS)\..\IDE</DevEnvDir>
     <DevEnvDir>$([System.IO.Path]::GetFullPath('$(DevEnvDir)'))</DevEnvDir>
   </PropertyGroup>
-  
+
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '12.0'">
       <PropertyGroup>
@@ -237,8 +237,8 @@
     <AuthenticodeCertificateName>Microsoft402</AuthenticodeCertificateName>
   </PropertyGroup>
 
-  <!-- 
-    When running our determinism tests we need to copy the diagnostic file from the intermediate directory 
+  <!--
+    When running our determinism tests we need to copy the diagnostic file from the intermediate directory
     to the location of the binary.  This ensures .dll and .dll.key are next to each other to be picked up
     by our test scripts
   -->

--- a/build/build.proj
+++ b/build/build.proj
@@ -7,7 +7,7 @@
     <RepositoryRootDirectory>$(MSBuildThisFileDirectory)..\</RepositoryRootDirectory>
     <TestsDirectory>$(RepositoryRootDirectory)bin\$(Configuration)\Tests\</TestsDirectory>
 
-    <!-- Make note NUGET_PACKAGES is environment variable respected 
+    <!-- Make note NUGET_PACKAGES is environment variable respected
          by NuGet.exe, so don't be tempted to change the name.-->
     <NUGET_PACKAGES Condition="'$(NUGET_PACKAGES)' == ''">$(UserProfile)\.nuget\packages</NUGET_PACKAGES>
 
@@ -22,17 +22,22 @@
     <VsManProjectFile Include="$(RepositoryRootDirectory)src\VsixV3\ProjectSystemPackage\Microsoft.VisualStudio.ProjectSystem.Managed.vsmanproj" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <!-- NuGet will not automatically find the correct version of MSBuild. We need to specify the path. -->
+    <NugetArguments>-verbosity quiet -msbuildpath &quot;$(DevenvDir)\..\..\MSBuild\15.0\bin&quot;</NugetArguments>
+  </PropertyGroup>
+
   <Target Name="RestorePackages">
 
     <Message Text="Restoring packages for %(SolutionFile.Filename)" Importance="high" />
-    
-    <Exec Command="&quot;$(RepositoryRootDirectory)build\bin\NuGet.exe&quot; restore -verbosity quiet &quot;@(SolutionFile)&quot;" />
+
+    <Exec Command="&quot;$(RepositoryRootDirectory)build\bin\NuGet.exe&quot; restore $(NugetArguments) &quot;@(SolutionFile)&quot;" />
   </Target>
 
   <Target Name="BuildSolution">
 
     <Message Text="Building %(SolutionFile.Filename) [$(Configuration)]" Importance="high" />
-    
+
     <MSBuild BuildInParallel="true"
              Projects="@(SolutionFile)"
              Targets="Build"
@@ -66,7 +71,7 @@
       <XmlTestFile Include="$(TestsDirectory)TestResults.xml" />   <!-- For Jenkins to read -->
       <HtmlTestFile Include="$(TestsDirectory)TestResults.html" /> <!-- For Humans to read -->
     </ItemGroup>
-    
+
     <Message Text="Running tests for %(SolutionFile.Filename) [$(Configuration)]" Importance="high" />
 
     <Exec Command="&quot;$(NUGET_PACKAGES)\xunit.runner.console\2.1.0\tools\xunit.console.x86.exe&quot; &quot;@(TestAssembly, '&quot; &quot;')&quot; -quiet -nologo -noshadow -parallel all -xml &quot;@(XmlTestFile)&quot; -html &quot;@(HtmlTestFile)&quot;"

--- a/src/Dependencies/Roslyn/project.json
+++ b/src/Dependencies/Roslyn/project.json
@@ -1,7 +1,8 @@
 {
   "supports": {},
   "dependencies": {
-    "Microsoft.VisualStudio.LanguageServices": "2.0.0-beta5-60909-09"
+    "Microsoft.VisualStudio.LanguageServices": "2.0.0-beta5-60909-09",
+    "System.ValueTuple": "4.0.1-beta-24425-02"
   },
   "frameworks": {
     ".NETFramework,Version=v4.6": { }

--- a/src/Dependencies/Toolset/project.json
+++ b/src/Dependencies/Toolset/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "MicroBuild.Core": "0.2.0",
     "Microsoft.Net.Compilers": {
-      "version": "1.2.1",
+      "version": "2.0.0-rc2-61102-09",
       "exclude": "build"
     },
     "Microsoft.Net.RoslynDiagnostics": {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -181,11 +181,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 
                 // Get the executable to run, the arguments and the default working directory
                 var runData = await GetRunnableProjectInformationAsync().ConfigureAwait(false);
-                executable = runData.Item1;
-                arguments = runData.Item2;
-                if(!string.IsNullOrWhiteSpace(runData.Item3))
+                executable = runData.exeToRun;
+                arguments = runData.arguments;
+                if(!string.IsNullOrWhiteSpace(runData.workingDir))
                 {
-                    defaultWorkingDir = runData.Item3;
+                    defaultWorkingDir = runData.workingDir;
                 }
 
                 if(!string.IsNullOrWhiteSpace(resolvedProfile.CommandLineArgs))
@@ -262,7 +262,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// Queries properties from the project to get information on how to run the application. The returned Tuple contains:
         /// exeToRun, arguments, workingDir
         /// </summary>
-        private async Task<Tuple<string, string, string>> GetRunnableProjectInformationAsync()
+        private async Task<(string exeToRun, string arguments, string workingDir)> GetRunnableProjectInformationAsync()
         {
             var properties = ConfiguredProject.Services.ProjectPropertiesProvider.GetCommonProperties();
 
@@ -297,7 +297,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             {
                 runWorkingDirectory = Path.Combine(Path.GetDirectoryName(ConfiguredProject.UnconfiguredProject.FullPath), runWorkingDirectory);
             }
-            return new Tuple<string, string, string>(runCommand, runArguments, runWorkingDirectory);
+            return (runCommand, runArguments, runWorkingDirectory);
         }
 
         private async Task<Guid> GetDebuggingEngineAsync()


### PR DESCRIPTION
This brings the project system to C# 7. I've moved a use of Tuple over to the language feature, to be sure that it's working correctly. I'll go through and apply quick fixes in a separate PR, as there will probably be quite a few. This also fixes the command line build by updating to NuGet version 3.6.0-beta1, and setting the `-msbuildpath` variable to point at the local install. Tagging @dotnet/project-system @srivatsn for review.