### PR TITLE
Quickfix updates

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.cs
@@ -70,7 +70,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
             }
 
             if (parent == null)
+#pragma warning disable IDE0016 // Use 'throw' expression
                 throw _tokenizer.FormatException(ProjectTreeFormatError.MultipleRoots, "Encountered another project root, when tree can only have one.");
+#pragma warning restore IDE0016 // Use 'throw' expression
 
             var tree = ReadProjectItem();
             tree.Parent = parent;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectDebuggerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectDebuggerProvider.cs
@@ -34,11 +34,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             LaunchSettingsProvider = launchSettingsProvider;
 
             // We want it sorted so that higher numbers come first (is the default for these collections but explicitly expressed here)
-            ProfileLaunchTargetsProviders = new OrderPrecedenceImportCollection<IDebugProfileLaunchTargetsProvider>(ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesFirst, 
+            ProfileLaunchTargetsProviders = new OrderPrecedenceImportCollection<IDebugProfileLaunchTargetsProvider>(ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesFirst,
                                                                                                                     configuredProject.UnconfiguredProject);
         }
 
-        public ProjectDebuggerProvider(ConfiguredProject configuredProject, ILaunchSettingsProvider launchSettingsProvider, 
+        public ProjectDebuggerProvider(ConfiguredProject configuredProject, ILaunchSettingsProvider launchSettingsProvider,
                                        OrderPrecedenceImportCollection<IDebugProfileLaunchTargetsProvider> providers)
             : base(configuredProject)
         {
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             // The engine depends on the framework
             if (IsDotNetCoreFramework(targetFramework))
             {
-                return  DebuggerEngines.ManagedCoreEngine;
+                return DebuggerEngines.ManagedCoreEngine;
             }
             else
             {
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// TODO: This is a placeholder until issue https://github.com/dotnet/roslyn-project-system/issues/423 is addressed. 
         /// This information should come from the targets file.
         /// </summary>
-        public static bool IsDotNetCoreFramework( string targetFramework)
+        public static bool IsDotNetCoreFramework(string targetFramework)
         {
             const string NetStandardAppPrefix = ".NetStandardApp";
             const string NetStandardPrefix = ".NetStandard";
@@ -107,17 +107,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             ILaunchProfile activeProfile = LaunchSettingsProvider.ActiveProfile;
 
             // Should have a profile
-            if(activeProfile == null)
+            if (activeProfile == null)
             {
                 throw new Exception(VSResources.ActiveLaunchProfileNotFound);
             }
 
             // Now find the DebugTargets provider for this profile
-            var launchProvider = GetLaunchTargetsProvider(activeProfile);
-            if(launchProvider == null)
-            {
+            var launchProvider = GetLaunchTargetsProvider(activeProfile) ??
                 throw new Exception(string.Format(VSResources.DontKnowHowToRunProfile, activeProfile.Name));
-            }
 
             var launchSettings = await launchProvider.QueryDebugTargetsAsync(launchOptions, activeProfile).ConfigureAwait(true);
             LastLaunchProvider = launchProvider;
@@ -130,9 +127,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         public IDebugProfileLaunchTargetsProvider GetLaunchTargetsProvider(ILaunchProfile profile)
         {
             // We search through the imports in order to find the one which supports the profile
-            foreach(var provider in ProfileLaunchTargetsProviders)
+            foreach (var provider in ProfileLaunchTargetsProviders)
             {
-                if(provider.Value.SupportsProfile(profile))
+                if (provider.Value.SupportsProfile(profile))
                 {
                     return provider.Value;
                 }
@@ -152,17 +149,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             ILaunchProfile activeProfile = LaunchSettingsProvider.ActiveProfile;
 
             var targetProfile = GetLaunchTargetsProvider(activeProfile);
-            if(targetProfile != null)
+            if (targetProfile != null)
             {
                 await targetProfile.OnBeforeLaunchAsync(launchOptions, activeProfile).ConfigureAwait(true);
-            } 
-                                                                                   
+            }
+
             await DoLaunchAsync(targets.ToArray()).ConfigureAwait(true);
 
-            if(targetProfile != null)
+            if (targetProfile != null)
             {
                 await targetProfile.OnAfterLaunchAsync(launchOptions, activeProfile).ConfigureAwait(true);
-            }                                                                        
+            }
         }
 
         /// <summary>
@@ -192,7 +189,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 }
             }
         }
-        
+
         /// <summary>
         /// Copy information over from the contract struct to the native one.
         /// </summary>
@@ -329,7 +326,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             // Just delegate to the last provider. It needs to figure out how best to map the items
             localPath = null;
             var deployedItemMapper = LastLaunchProvider as IDeployedProjectItemMappingProvider;
-            if(deployedItemMapper != null)
+            if (deployedItemMapper != null)
             {
                 return deployedItemMapper.TryGetProjectItemPathFromDeployedPath(deployedPath, out localPath);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Generators/ClassRegistrationAttribute.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Generators/ClassRegistrationAttribute.cs
@@ -13,8 +13,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Generators
 
         public ClassRegistrationAttribute(string clsId, string classInfo)
         {
-            _clsId = clsId ?? throw new ArgumentNullException(nameof(clsId));
-            _classInfo = classInfo ?? throw new ArgumentNullException(nameof(classInfo));
+            Requires.NotNull(clsId, nameof(clsId));
+            Requires.NotNull(classInfo, nameof(classInfo));
+
+            _clsId = clsId;
+            _classInfo = classInfo;
         }
 
         public override void Register(RegistrationContext context)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Generators/ClassRegistrationAttribute.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Generators/ClassRegistrationAttribute.cs
@@ -13,13 +13,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Generators
 
         public ClassRegistrationAttribute(string clsId, string classInfo)
         {
-            if (clsId == null)
-                throw new ArgumentNullException(nameof(clsId));
-            if (classInfo == null)
-                throw new ArgumentNullException(nameof(classInfo));
-
-            _clsId = clsId;
-            _classInfo = classInfo;
+            _clsId = clsId ?? throw new ArgumentNullException(nameof(clsId));
+            _classInfo = classInfo ?? throw new ArgumentNullException(nameof(classInfo));
         }
 
         public override void Register(RegistrationContext context)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Generators/GeneratorExtensionRegistrationAttribute.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Generators/GeneratorExtensionRegistrationAttribute.cs
@@ -14,16 +14,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Generators
 
         public GeneratorExtensionRegistrationAttribute(string extension, string generator, string contextGuid)
         {
-            if (extension == null)
-                throw new ArgumentNullException(nameof(extension));
-            if (generator == null)
-                throw new ArgumentNullException(nameof(generator));
-            if (contextGuid == null)
-                throw new ArgumentNullException(nameof(contextGuid));
-
-            _extension = extension;
-            _generator = generator;
-            _contextGuid = contextGuid;
+            _extension = extension ?? throw new ArgumentNullException(nameof(extension));
+            _generator = generator ?? throw new ArgumentNullException(nameof(generator));
+            _contextGuid = contextGuid ?? throw new ArgumentNullException(nameof(contextGuid));
         }
 
         public override void Register(RegistrationContext context)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Generators/RemoteCodeGeneratorRegistrationAttribute.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Generators/RemoteCodeGeneratorRegistrationAttribute.cs
@@ -29,11 +29,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Generators
         /// <param name="contextGuid">The context GUID this code generator would appear under.</param>
         public RemoteCodeGeneratorRegistrationAttribute(string generatorGuid, string generatorClassName, string generatorName, string contextGuid)
         {
-            if (generatorGuid == null)
-                throw new ArgumentNullException("generatorGuid");
-            _contextGuid = contextGuid ?? throw new ArgumentNullException("contextGuid");
-            _generatorName = generatorName ?? throw new ArgumentNullException("generatorName");
-            _generatorRegKeyName = generatorClassName ?? throw new ArgumentNullException("generatorClassName");
+            Requires.NotNull(generatorGuid, nameof(generatorGuid));
+            Requires.NotNull(contextGuid, nameof(contextGuid));
+            Requires.NotNull(generatorName, nameof(generatorName));
+            Requires.NotNull(generatorClassName, nameof(generatorClassName));
+
+            _contextGuid = contextGuid;
+            _generatorName = generatorName;
+            _generatorRegKeyName = generatorClassName;
             if (!Guid.TryParse(generatorGuid, out _generatorGuid))
                 throw new ArgumentException($"{generatorGuid} is not a valid GUID!", generatorGuid);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Generators/RemoteCodeGeneratorRegistrationAttribute.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Generators/RemoteCodeGeneratorRegistrationAttribute.cs
@@ -31,16 +31,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Generators
         {
             if (generatorGuid == null)
                 throw new ArgumentNullException("generatorGuid");
-            if (generatorClassName == null)
-                throw new ArgumentNullException("generatorClassName");
-            if (generatorName == null)
-                throw new ArgumentNullException("generatorName");
-            if (contextGuid == null)
-                throw new ArgumentNullException("contextGuid");
-
-            _contextGuid = contextGuid;
-            _generatorName = generatorName;
-            _generatorRegKeyName = generatorClassName;
+            _contextGuid = contextGuid ?? throw new ArgumentNullException("contextGuid");
+            _generatorName = generatorName ?? throw new ArgumentNullException("generatorName");
+            _generatorRegKeyName = generatorClassName ?? throw new ArgumentNullException("generatorClassName");
             if (!Guid.TryParse(generatorGuid, out _generatorGuid))
                 throw new ArgumentException($"{generatorGuid} is not a valid GUID!", generatorGuid);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageViewModel.cs
@@ -44,11 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             {
                 PushIgnoreEvents();
             }
-            PropertyChangedEventHandler handler = PropertyChanged;
-            if (handler != null)
-            {
-                handler(this, new PropertyChangedEventArgs(propertyName));
-            }
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
             if (suppressInvalidation)
             {
                 PopIgnoreEvents();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/DelegateCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/DelegateCommand.cs
@@ -40,10 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
 
         public void RaiseCanExecuteChanged()
         {
-            if (CanExecuteChanged != null)
-            {
-                CanExecuteChanged(this, EventArgs.Empty);
-            }
+            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/NameValuePair.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/NameValuePair.cs
@@ -55,11 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
 
         public void NotifyPropertyChanged(string propertyName)
         {
-            PropertyChangedEventHandler handler = PropertyChanged;
-            if (handler != null)
-            {
-                handler(this, new PropertyChangedEventArgs(propertyName));
-            }
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
         #region IDataErrorInfo

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -88,6 +88,9 @@
     <Compile Include="ProjectSystem\Rules\AnalyzerReference.xaml.cs">
       <DependentUpon>AnalyzerReference.xaml</DependentUpon>
     </Compile>
+    <Compile Include="ProjectSystem\Rules\ProjectDebugger.xaml.cs">
+      <DependentUpon>ProjectDebugger.xaml</DependentUpon>
+    </Compile>
     <Compile Include="ProjectSystem\Rules\ResolvedAnalyzerReference.xaml.cs">
       <DependentUpon>ResolvedAnalyzerReference.xaml</DependentUpon>
     </Compile>
@@ -184,7 +187,7 @@
     </Compile>
     <Compile Include="ProjectSystem\Rules\SpecialFolder.cs">
       <DependentUpon>SpecialFolder.xaml</DependentUpon>
-    </Compile>    
+    </Compile>
     <Compile Include="ProjectSystem\Rules\SubProject.cs">
       <DependentUpon>SubProject.xaml</DependentUpon>
     </Compile>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AnalyzerReference.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AnalyzerReference.xaml.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class AnalyzerReference
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AppDesigner.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AppDesigner.xaml.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class AppDesigner
     {
         internal static string[] SchemaNameArray = new string[] { SchemaName };

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AssemblyReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AssemblyReference.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class AssemblyReference
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/COMReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/COMReference.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class ComReference
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CSharp.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CSharp.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class CSharp
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CompilerCommandLineArgs.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CompilerCommandLineArgs.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class CompilerCommandLineArgs
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class ConfigurationGeneral
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneralFile.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneralFile.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class ConfigurationGeneralFile
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DebuggerGeneral.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DebuggerGeneral.cs
@@ -5,7 +5,8 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
-    partial class DebuggerGeneral
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
+    partial class DebuggerGeneralProperties
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DotNetCliToolReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DotNetCliToolReference.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class DotNetCliToolReference
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/EmbeddedResource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/EmbeddedResource.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class EmbeddedResource
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Folder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Folder.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class Folder
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.cs
@@ -5,7 +5,8 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
-    partial class GeneralBrowseObject
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
+    partial class ConfigurationGeneralBrowseObject
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/None.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/None.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class None
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class NuGetRestore
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class PackageReference
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectDebugger.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectDebugger.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Diagnostics.CodeAnalysis;
 
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class Content
+    partial class ProjectDebugger
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class ProjectReference
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAnalyzerReference.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAnalyzerReference.xaml.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class ResolvedAnalyzerReference
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAssemblyReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAssemblyReference.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class ResolvedAssemblyReference
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCOMReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCOMReference.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class ResolvedCOMReference
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class ResolvedPackageReference
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class ResolvedProjectReference
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class ResolvedSdkReference
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class SdkReference
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SourceControl.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SourceControl.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class SourceControl
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SpecialFolder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SpecialFolder.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class SpecialFolder
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SubProject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SubProject.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class SubProject
     {
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/VisualBasic.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/VisualBasic.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     partial class VisualBasic
     {
 


### PR DESCRIPTION
Simplifies a few places we can replace with `?.` invocation and throw expressions. Also annotates the auto-generated code to suppress the use throw invocation message, as it warns 91 times from that code. Depends on #709.
@dotnet/project-system 