### PR TITLE
Project file temp is now put in a temp folder, named correctly. 

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -188,16 +188,20 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return _files[filepath].LastWriteTime;
         }
 
-      
-        /// <summary>
-        /// Mock currently ignores recursive flag
-        /// </summary>
         public void RemoveDirectory(string directoryPath, bool recursive)
         {
             bool found = _folders.Remove(directoryPath);
             if(!found)
             {
                 throw new DirectoryNotFoundException();
+            }
+
+            if (recursive)
+            {
+                foreach (var item in _files.Where(file => file.Key.StartsWith(directoryPath)).ToList())
+                {
+                    _files.Remove(item.Key);
+                }
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/EditProjectFileCleanupFrameNotifyListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/EditProjectFileCleanupFrameNotifyListener.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.Shell.Interop;
+using System.IO;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
 {
@@ -16,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
 
         public int OnClose(ref uint pgrfSaveOptions)
         {
-            _fileSystem.RemoveFile(_tempFile);
+            _fileSystem.RemoveDirectory(Path.GetDirectoryName(_tempFile), true);
             return VSConstants.S_OK;
         }
     }


### PR DESCRIPTION
This fixes #704. Old structure:
`%TEMP%\tmp.1234.csproj`
New structure:
`%TEMP%\tmp.1234\ConsoleApp1.csproj`.

Tagging @dotnet/project-system @jinujoseph for review.