### PR TITLE
Switch LoadedProject to LoadedProjectAsync to avoid a deadlock

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -113,10 +113,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             // TODO: https://github.com/dotnet/roslyn-project-system/issues/353
             await _commonServices.ThreadingService.SwitchToUIThread();
 
-            using (_tasksService.LoadedProject())
+            await _tasksService.LoadedProjectAsync(async () =>
             {
                 await HandleAsync(e, handlerType).ConfigureAwait(false);
-            }
+            });
 
             // If "TargetFrameworks" property has changed, we need to refresh the project context and subscriptions.
             if (HasTargetFrameworksChanged(e))


### PR DESCRIPTION
This is the same as #713 but against master