### PR TITLE
Handle failure in DeepCopyFrom when reloading project

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Reload/ReloadableProject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Reload/ReloadableProject.cs
@@ -106,10 +106,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                     {
                         ProjectCollection thisCollection = new ProjectCollection();
                         var newProject = ProjectRootElement.Open(_projectVsServices.Project.FullPath, thisCollection);
-                        var tempProject = ProjectRootElement.Create();
 
                         // First copy to a temp project, so that any failures will not corrupt the users project.
-                        tempProject.DeepCopyFrom(newProject);
+                        ProjectRootElement.Create().DeepCopyFrom(newProject);
 
                         msbuildProject.RemoveAllChildren();
                         msbuildProject.DeepCopyFrom(newProject);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Reload/ReloadableProject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Reload/ReloadableProject.cs
@@ -106,6 +106,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                     {
                         ProjectCollection thisCollection = new ProjectCollection();
                         var newProject = ProjectRootElement.Open(_projectVsServices.Project.FullPath, thisCollection);
+                        var tempProject = ProjectRootElement.Create();
+
+                        // First copy to a temp project, so that any failures will not corrupt the users project.
+                        tempProject.DeepCopyFrom(newProject);
 
                         msbuildProject.RemoveAllChildren();
                         msbuildProject.DeepCopyFrom(newProject);


### PR DESCRIPTION
Prevent corrupting the users project in the event of DeepCopyFrom throwing. We do this by testing DeepCopyFrom on a temp project, so that if it does throw we will not have touched the users project yet. This is a slight performance hit, but this code is not run often and it is much more preferable than the alternative of several error dialogs being shown. In the event it does throw the user will be prompted to reload the project.

DeepCopyFrom _shouldn't_ throw and if it does it is a bug on MSBuild. However, there is currently an issue with it always throwing if there is any metadata as an attribute in the project. Microsoft/msbuild#1319