### PR TITLE
Change the persistence of the Version of the Package Reference to be …

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
@@ -22,7 +22,7 @@
                     DisplayName="Version"
                     Description="Version of dependency.">
         <StringProperty.DataSource>
-            <DataSource Persistence="ProjectFile" PersistenceStyle="Attribute" />
+            <DataSource PersistenceStyle="Attribute" />
         </StringProperty.DataSource>
     </StringProperty>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
@@ -21,6 +21,9 @@
                     ReadOnly="True"
                     DisplayName="Version"
                     Description="Version of dependency.">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFile" PersistenceStyle="Attribute" />
+        </StringProperty.DataSource>
     </StringProperty>
 
     <StringProperty Name="IncludeAssets" 


### PR DESCRIPTION
…an Attribute

With this change, the Version of a packagereference will be added as a Attribute rather than a Metadata.

This will help us in having smaller project files with less space and less lines for Package references.

We need change from CPS and Msbuild to make this works. The CPS changes are already in the WPT branch and the msbuild changes to fix a vital bug is almost there(waiting to be merged) in WPT.

@srivatsn @dotnet/project-system for review