### PR TITLE
Revert "Use the shared project AddItemTemplatesGuid for shared projects."

### DIFF
--- a/src/Targets/Microsoft.CSharp.DesignTime.targets
+++ b/src/Targets/Microsoft.CSharp.DesignTime.targets
@@ -15,8 +15,6 @@
     <AppDesignerFolderContentsVisibleOnlyInShowAllFiles Condition="'$(AppDesignerFolderContentsVisibleOnlyInShowAllFiles)' == ''">false</AppDesignerFolderContentsVisibleOnlyInShowAllFiles>
     <LanguageServiceName Condition="'$(LanguageServiceName)' == ''">C#</LanguageServiceName>
     <TemplateLanguage Condition="'$(TemplateLanguage)' == ''">CSharp</TemplateLanguage>
-    <!-- Shared Projects need to use the shared project item template guid. We determine shared projects by the shproj extension of the project file. -->
-    <AddItemTemplatesGuid Condition="('$(AddItemTemplatesGuid)' == '') AND ('$(ProjectExt)' == '.shproj'">{DDDDC6BE-451D-46DD-A712-A5D07027E072}</AddItemTemplatesGuid>
     <AddItemTemplatesGuid Condition="'$(AddItemTemplatesGuid)' == ''">{FAE04EC0-301F-11d3-BF4B-00C04F79EFBC}</AddItemTemplatesGuid>
   </PropertyGroup>
 

--- a/src/Targets/Microsoft.VisualBasic.DesignTime.targets
+++ b/src/Targets/Microsoft.VisualBasic.DesignTime.targets
@@ -15,8 +15,6 @@
     <AppDesignerFolderContentsVisibleOnlyInShowAllFiles Condition="'$(AppDesignerFolderContentsVisibleOnlyInShowAllFiles)' == ''">true</AppDesignerFolderContentsVisibleOnlyInShowAllFiles>
     <LanguageServiceName Condition="'$(LanguageServiceName)' == ''">Visual Basic</LanguageServiceName>
     <TemplateLanguage Condition="'$(TemplateLanguage)' == ''">VisualBasic</TemplateLanguage>
-    <!-- Shared Projects need to use the shared project item template guid. We determine shared projects by the shproj extension of the project file. -->
-    <AddItemTemplatesGuid Condition="('$(AddItemTemplatesGuid)' == '') AND ('$(ProjectExt)' == '.shproj'">{2F4D68AA-6DA4-465E-88DE-2B0F67AFC98D}</AddItemTemplatesGuid>
     <AddItemTemplatesGuid Condition="'$(AddItemTemplatesGuid)' == ''">{F184B08F-C81C-45F6-A57F-5ABD9991F28F}</AddItemTemplatesGuid>
   </PropertyGroup>
 


### PR DESCRIPTION
Reverts dotnet/roslyn-project-system#727. This is apparently unnecessary, as #606 no longer repros.