### PR TITLE
Removing the UseSpecificRuntime option from debug properties page

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
@@ -264,18 +264,7 @@
                     </MultiBinding>
                 </local:WatermarkTextBox.IsEnabled>
             </local:WatermarkTextBox>
-            <CheckBox 
-                Grid.Row="7"
-                Margin="9,10,3,8"
-                VerticalAlignment="Top"
-                VerticalContentAlignment="Center"
-                x:Name="chkSpecificRuntime"
-                x:Uid="chkSpecificRuntime"
-                IsChecked="{Binding Path=UseSpecificRuntime, Mode=TwoWay}"
-                IsEnabled="{Binding Path=IsProfileSelected, Mode=OneWay}"
-                Visibility="{Binding Path=ShowVersionSelector, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
-                Content="Use Specific _Runtime:"/>
-             <Label 
+            <Label 
                 Grid.Row="8"
                 x:Uid="envVarsLabel"
                 Margin="4,4,3,0"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -51,19 +51,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             _useTaskFactory = useTaskFactory;
             UnconfiguredProject = unconfiguredProject;
         }
-        private bool _useSpecificRuntime;
-        public bool UseSpecificRuntime
-        {
-            get
-            {
-                return _useSpecificRuntime;
-            }
-            set
-            {
-                OnPropertyChanged(ref _useSpecificRuntime, value);
-            }
-        }
-
+        
         public string SelectedCommandName
         {
             get
@@ -441,8 +429,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 OnPropertyChanged(nameof(IsProject));
                 OnPropertyChanged(nameof(IsProfileSelected));
                 OnPropertyChanged(nameof(DeleteProfileEnabled));
-                
-                UseSpecificRuntime = true;
                 
                 SetEnvironmentGrid(oldProfile);
 


### PR DESCRIPTION
fixes #647 