### PR TITLE
Preserving the Executable path field in debug properties page.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -118,12 +118,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                         SelectedDebugProfile.CommandName = _selectedLaunchType.CommandName;
                         if (_selectedLaunchType.CommandName == ProfileCommandNames.Executable)
                         {
-                            ExecutablePath = String.Empty;
-                        }
-                        else if (_selectedLaunchType.CommandName == ProfileCommandNames.IISExpress)
-                        {
-                            ExecutablePath = String.Empty;
-                            HasLaunchOption = true;
+                            if (ExecutablePath == null)
+                            {
+                                ExecutablePath = String.Empty;
+                            }
                         }
                         else
                         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -695,7 +695,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                         using (var dialog = new System.Windows.Forms.OpenFileDialog())
                         {
                             var file = ExecutablePath;
-                            if (Path.IsPathRooted(file))
+                            if ((file.IndexOfAny(Path.GetInvalidPathChars()) == -1) && Path.IsPathRooted(file))
                             {
                                 dialog.InitialDirectory = Path.GetDirectoryName(file);
                                 dialog.FileName = file;


### PR DESCRIPTION
fixes #657   & fixes #656 

IISExpress is not supported so taking that out of the condition too.
@dsplaisted 