### PR TITLE
Move the jenkins machine to RC

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -31,7 +31,7 @@ build.cmd /${configuration.toLowerCase()}""")
         archiveSettings.setFailIfNothingArchived()
         archiveSettings.setArchiveOnFailure()
         Utilities.addArchival(newJob, archiveSettings)
-        Utilities.setMachineAffinity(newJob, 'Windows_NT', 'latest-or-auto-dev15-preview5')
+        Utilities.setMachineAffinity(newJob, 'Windows_NT', 'latest-or-auto-dev15-rc')
         Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
         Utilities.addXUnitDotNETResults(newJob, "**/*TestResults.xml")
         if (isPR) {


### PR DESCRIPTION
With this change, the Jenkins machines will be moved to RC build. VSIX project will have to go through a fix to build on RC, without which any other PR Jenkins build will fail. The fix will be checked-in as soon as this change gets in.

@srivatsn @dotnet/project-system for review