### PR TITLE
Update folder rule from the msbuild copy so that properties work

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Folder.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Folder.xaml
@@ -1,20 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
+<!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule
   Name="Folder"
   DisplayName="General"
   PageTemplate="generic"
-  Description="Empty folder placeholders"
+  Description="Folder Properties"
   xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectInstance" HasConfigurationCondition="False" ItemType="Folder" />
+    <DataSource Persistence="ProjectFileFolderItems" HasConfigurationCondition="False" ItemType="Folder" />
   </Rule.DataSource>
 
   <StringProperty Name="Identity" Visible="false" ReadOnly="true" Category="Misc" />
-  <StringProperty Name="FullPath" DisplayName="Full Path" ReadOnly="true" Category="Misc" />
-  <StringProperty Name="FileNameAndExtension" DisplayName="Folder Name" ReadOnly="true" Category="Misc">
-      <StringProperty.DataSource>
-            <DataSource Persistence="ProjectInstance" ItemType="Folder" PersistedName="FileNameAndExtension" />
-      </StringProperty.DataSource>
-  </StringProperty>
+  <StringProperty Name="FullPath" DisplayName="Full Path" ReadOnly="true" Category="Misc" Description="Location of the folder"/>
+  <StringProperty Name="FolderName" DisplayName="Folder Name" ReadOnly="true" Category="Misc" Description="Name of this folder"/>
 </Rule>


### PR DESCRIPTION
It looks like the Folder rule was updated in the MSBuild location after we forked. Update it in the project system so that folders show properties.

@dotnet/project-system @adrianvmsft

Fixes #751