### PR TITLE
Updating Vsix manifests to include a PackageId

### DIFF
--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -105,7 +105,7 @@
   </Choose>
 
   <PropertyGroup>
-    <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.25907-RC2</VisualStudioBuildToolsNuGetPackagePath>
+    <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.25914-RC2</VisualStudioBuildToolsNuGetPackagePath>
   </PropertyGroup>
   <Import Project="$(VisualStudioBuildToolsNuGetPackagePath)\build\Microsoft.VsSDK.BuildTools.props"
           Condition="'$(OS)' == 'Windows_NT' And Exists('$(VisualStudioBuildToolsNuGetPackagePath)\build\Microsoft.VsSDK.BuildTools.props')" />

--- a/src/Dependencies/Toolset/project.json
+++ b/src/Dependencies/Toolset/project.json
@@ -11,7 +11,7 @@
       "exclude": "build"
     }, 
     "Microsoft.VSSDK.BuildTools": { 
-      "version": "15.0.25907-RC2", 
+      "version": "15.0.25914-RC2", 
       "exclude": "build" 
      }
   },

--- a/src/ProjectSystemSetup/source.extension.vsixmanifest
+++ b/src/ProjectSystemSetup/source.extension.vsixmanifest
@@ -5,6 +5,7 @@
     <Identity Id="EDDCB5BE-3C18-444E-8E50-AE06CD345872" Version="|%CurrentProject%;GetBuildVersion|" Language="en-US" Publisher="Microsoft" />
     <DisplayName>CSharp and Visual Basic project systems</DisplayName>
     <Description xml:space="preserve">CSharp and Visual Basic project systems.</Description>
+    <PackageId>Microsoft.VisualStudio.ProjectSystem.Managed</PackageId>
   </Metadata>
   <Installation SystemComponent="true" >
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.Pro" />

--- a/src/VisualStudioEditorsSetup/source.extension.vsixmanifest
+++ b/src/VisualStudioEditorsSetup/source.extension.vsixmanifest
@@ -5,6 +5,7 @@
     <DisplayName>VisualStudio Editors </DisplayName>
     <Description>Microsoft VisualStudio Editors</Description>
     <ShortcutPath>..\CommonExtensions\Microsoft\VisualStudio\Editors</ShortcutPath>
+    <PackageId>Microsoft.VisualStudio.Editors</PackageId>
   </Metadata>
   <Installation SystemComponent="true" >
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.Pro" />

--- a/src/VsixV3/EditorsPackage/Microsoft.VisualStudio.Editors.vsmanproj
+++ b/src/VsixV3/EditorsPackage/Microsoft.VisualStudio.Editors.vsmanproj
@@ -23,13 +23,13 @@
 
   <Target Name="BeforeBuild">
     <ItemGroup>
-      <VisualStudioEditorsSetupVsixFilesToCopy Include="$(OutDir)\F6B5EACA-7FA1-4591-8D40-A38234763621.json;$(OutDir)\VisualStudioEditorsSetup.vsix" />
+      <VisualStudioEditorsSetupVsixFilesToCopy Include="$(OutDir)\Microsoft.VisualStudio.Editors.json;$(OutDir)\VisualStudioEditorsSetup.vsix" />
     </ItemGroup>
     <Copy SourceFiles="@(VisualStudioEditorsSetupVsixFilesToCopy)" DestinationFolder="$(OutputPath)" />
   </Target>
 
   <ItemGroup>
-    <MergeManifest Include="$(OutputPath)\F6B5EACA-7FA1-4591-8D40-A38234763621.json" />
+    <MergeManifest Include="$(OutputPath)\Microsoft.VisualStudio.Editors.json" />
   </ItemGroup>
 
   <Target Name="ValidateManifest" />

--- a/src/VsixV3/ProjectSystemPackage/Microsoft.VisualStudio.ProjectSystem.Managed.vsmanproj
+++ b/src/VsixV3/ProjectSystemPackage/Microsoft.VisualStudio.ProjectSystem.Managed.vsmanproj
@@ -18,7 +18,7 @@
 
   <Target Name="BeforeBuild">
     <ItemGroup>
-      <ProjectSystemVsixFilesToCopy Include="$(OutDir)\EDDCB5BE-3C18-444E-8E50-AE06CD345872.json;$(OutDir)\ProjectSystem.vsix" />
+      <ProjectSystemVsixFilesToCopy Include="$(OutDir)\Microsoft.VisualStudio.ProjectSystem.Managed.json;$(OutDir)\ProjectSystem.vsix" />
     </ItemGroup>
     <Copy SourceFiles="@(ProjectSystemVsixFilesToCopy)" DestinationFolder="$(OutputPath)" />
 
@@ -26,7 +26,7 @@
   </Target>
 
   <ItemGroup>
-    <MergeManifest Include="$(OutputPath)\EDDCB5BE-3C18-444E-8E50-AE06CD345872.json" />
+    <MergeManifest Include="$(OutputPath)\Microsoft.VisualStudio.ProjectSystem.Managed.json" />
     <MergeManifest Include="$(OutputPath)\Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles.json" />
   </ItemGroup>
 


### PR DESCRIPTION
The VSSDK that we were consuming so far produced a V3 packageid using the ID of the VSIX which is a guid. The VS authoring however uses human readable names. The latest RC VSSDK lets us specify a human-readable packageid. Updating to that version.

@dotnet/project-system @basoundr 