### PR TITLE
Fix Auto Restore when Changes are made to TargetFramework(s)

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilderTests.cs
@@ -167,6 +167,61 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         }
 
         [Fact]
+        public void ProjectRestoreInfoBuilder_WithEmptyTargetFramework_ReturnsNull()
+        {
+            var projectSubscriptionUpdates = GetVersionedUpdatesFromJson(@"{
+    ""ProjectConfiguration"": {
+        ""Name"": ""Debug|AnyCPU|netcoreapp1.0"",
+        ""Dimensions"": {
+            ""Configuration"": ""Debug"",            
+            ""Platform"": ""AnyCPU""
+        }
+    },
+    ""ProjectChanges"": {
+        ""NuGetRestore"": {
+            ""Difference"": {
+                ""AnyChanges"": ""true""
+            },
+            ""After"": {
+                ""Properties"": {
+                   ""BaseIntermediateOutputPath"": ""obj\\"",
+                   ""TargetFrameworkMoniker"": "".NETCoreApp,Version=v1.0"",
+                   ""TargetFrameworks"": ""netcoreapp1.0"",
+                   ""TargetFramework"": """"
+                }
+            }
+        },
+        ""PackageReference"": {
+            ""Difference"": {
+                ""AnyChanges"": ""false""
+            },
+            ""After"": {
+                ""Items"": { }
+            }
+        },
+        ""DotNetCliToolReference"": {
+            ""Difference"": {
+                ""AnyChanges"": ""false""
+            },
+            ""After"": {
+                ""Items"": { }
+            }
+        },
+        ""ProjectReference"": {
+            ""Difference"": {
+                ""AnyChanges"": ""false""
+            },
+            ""After"": {
+                ""Items"": { }
+            }
+        }
+    }
+}");
+            var restoreInfo = ProjectRestoreInfoBuilder.Build(projectSubscriptionUpdates);
+            Assert.Null(restoreInfo);
+        }
+
+        [Fact]
         public void ProjectRestoreInfoBuilder_WithTwoIdenticalUpdates_ReturnsSingleTFM()
         {
             var projectSubscriptionUpdates = GetVersionedUpdatesFromJson(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilder.cs
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
                     !update.Value.ProjectConfiguration.Dimensions.TryGetValue(TargetFrameworkProperty, out targetFramework) &&
                     !nugetRestoreChanges.After.Properties.TryGetValue(TargetFrameworkProperty, out targetFramework);
 
-                if (noTargetFramework || string.IsNullOrWhiteSpace(targetFramework))
+                if (noTargetFramework || string.IsNullOrEmpty(targetFramework))
                 {
                     TraceUtilities.TraceWarning("Unable to find TargetFramework Property");
                     continue;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilder.cs
@@ -46,9 +46,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
                 originalTargetFrameworks = originalTargetFrameworks ??
                     nugetRestoreChanges.After.Properties[NuGetRestore.TargetFrameworksProperty];
 
-                string targetFramework; 
-                if (!update.Value.ProjectConfiguration.Dimensions.TryGetValue(TargetFrameworkProperty, out targetFramework) &&
-                    !nugetRestoreChanges.After.Properties.TryGetValue(TargetFrameworkProperty, out targetFramework))
+                string targetFramework;
+                bool noTargetFramework = 
+                    !update.Value.ProjectConfiguration.Dimensions.TryGetValue(TargetFrameworkProperty, out targetFramework) &&
+                    !nugetRestoreChanges.After.Properties.TryGetValue(TargetFrameworkProperty, out targetFramework);
+
+                if (noTargetFramework || string.IsNullOrWhiteSpace(targetFramework))
                 {
                     TraceUtilities.TraceWarning("Unable to find TargetFramework Property");
                     continue;
@@ -78,13 +81,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
                 }
             }
 
-            return new ProjectRestoreInfo
-            {
-                BaseIntermediatePath = baseIntermediatePath,
-                OriginalTargetFrameworks = originalTargetFrameworks,
-                TargetFrameworks = targetFrameworks,
-                ToolReferences = toolReferences
-            };
+            // return nominate restore information if any target framework entries are found
+            return targetFrameworks.Any()
+                ? new ProjectRestoreInfo
+                {
+                    BaseIntermediatePath = baseIntermediatePath,
+                    OriginalTargetFrameworks = originalTargetFrameworks,
+                    TargetFrameworks = targetFrameworks,
+                    ToolReferences = toolReferences
+                }
+                : null;
         }
 
         private static IVsProjectProperties GetProperties(IImmutableDictionary<String, String> items)


### PR DESCRIPTION
Refresh active configuration when TargetFramework(s) changes so that subscriptions are properly reset; do not nominate restore during intermediate states when targetframework is unavailable following a change from TF to TFs.

Fixes #750 

/cc @dotnet/project-system 