### PR TITLE
Fix resource fault

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CreateFileFromTemplateService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CreateFileFromTemplateService.cs
@@ -55,7 +55,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             {
                 var parentId = parentNode.GetHierarchyId();
                 var result = new VSADDRESULT[1];
-                _projectVsServices.VsProject.AddItemWithSpecific(parentId, VSADDITEMOPERATION.VSADDITEMOP_RUNWIZARD, fileName, 0, new string[] { templateFilePath }, IntPtr.Zero, 0, Guid.Empty, null, Guid.Empty, result);
+                var files = new string[] { templateFilePath };
+                _projectVsServices.VsProject.AddItemWithSpecific(parentId, VSADDITEMOPERATION.VSADDITEMOP_RUNWIZARD, fileName, (uint)files.Length, files, IntPtr.Zero, 0, Guid.Empty, null, Guid.Empty, result);
 
                 if (result[0] == VSADDRESULT.ADDRESULT_Success)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
@@ -50,6 +50,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         protected virtual bool CreatedByDefaultUnderAppDesignerFolder => true;
 
         /// <summary>
+        /// If true, and <see cref="CreatedByDefaultUnderAppDesignerFolder"/> is true,
+        /// then the file will be created in the root folder if the App Designer folder
+        /// doesn't exist.
+        /// </summary>
+        protected virtual bool FallBackIfNoAppDesignerFolder => true;
+
+        /// <summary>
         /// Gets the name of a special file.
         /// </summary>
         protected abstract string GetFileNameOfSpecialFile(SpecialFiles fileId);
@@ -199,12 +206,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
             IProjectTree rootNode = _projectTreeService.CurrentTree.Tree;
             IProjectTree appDesignerFolder = rootNode.Children.FirstOrDefault(child => child.IsFolder && child.Flags.HasFlag(ProjectTreeFlags.Common.AppDesignerFolder));
 
-            if (appDesignerFolder == null && CreatedByDefaultUnderAppDesignerFolder)
+            if (appDesignerFolder == null && CreatedByDefaultUnderAppDesignerFolder && !FallBackIfNoAppDesignerFolder)
             {
                 return null;
             }
 
-            var parentNode = CreatedByDefaultUnderAppDesignerFolder ? appDesignerFolder : rootNode;
+            var parentNode = CreatedByDefaultUnderAppDesignerFolder ? appDesignerFolder ?? rootNode : rootNode;
 
             bool fileCreated = false;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
@@ -98,7 +98,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
 
             // We haven't found the file but return the default file path as that's the contract.
             IProjectTree rootNode = _projectTreeService.CurrentTree.Tree;
-            string rootFilePath = _projectTreeService.CurrentTree.TreeProvider.GetPath(rootNode);
+            string rootFilePath = Path.GetDirectoryName(_projectTreeService.CurrentTree.TreeProvider.GetPath(rootNode));
             string fullPath = Path.Combine(rootFilePath, specialFileName);
             return fullPath;
         }


### PR DESCRIPTION
This fixes #576. A parameter was incorrect to a COM call, causing the project fault. Additionally, the calculated return path was incorrect. Finally, when the project has no app designer folder, the special files provider will fall back to using the project root as the target folder. Tagging @dotnet/project-system for review. //cc @jviau.