### PR TITLE
Remove reference capabilities from the design time target.

### DIFF
--- a/src/Targets/Microsoft.Managed.DesignTime.targets
+++ b/src/Targets/Microsoft.Managed.DesignTime.targets
@@ -41,11 +41,6 @@
       References capability, but everything else we want back.
     -->
     <ProjectCapability Include="
-                          AssemblyReferences;
-                          COMReferences;
-                          ProjectReferences;
-                          PackageReferences;
-                          SharedProjectReferences;
                           OutputGroups;
                           AllTargetOutputGroups;
                           VisualStudioWellKnownOutputGroups;


### PR DESCRIPTION
Remove reference capabilities from the design time target. They will now be coming from the targets in the SDK (see https://github.com/dotnet/sdk/pull/406)

Related to #400, #399 

