### PR TITLE
Fix Application page layout under high DPI

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.resx
@@ -1011,9 +1011,9 @@
   <data name="overarchingLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="ResourcesGroupBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="TopHalfLayoutPanel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <data name="$this.Localizable" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
+  </data>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
@@ -1025,9 +1025,6 @@
   </data>
   <data name="$this.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
     <value>None</value>
-  </data>
-  <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Tahoma, 8.25pt</value>
   </data>
   <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CSharpApplicationPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CSharpApplicationPropPage.resx
@@ -110,9 +110,6 @@
   <data name="$this.GridSize" type="System.Drawing.Size, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>8, 8</value>
   </data>
-  <data name="$this.Font" type="System.Drawing.Font, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>Tahoma, 8.25pt</value>
-  </data>
   <data name="$this.DrawGrid" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </data>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.resx
@@ -756,9 +756,6 @@
   <data name="$this.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Tahoma, 8.25pt</value>
-  </data>
   <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>


### PR DESCRIPTION
Application page was setting the Font multiple times, causing WinForms to scale the page multiple times, to bad effects. Stop doing that across all pages.

This is one that I noticed and figured out the cause while I was investigating the Debug property page scaling issue.

Before: 
![image](https://cloud.githubusercontent.com/assets/1103906/20512518/a0e461f6-b034-11e6-9f8d-0dcc95f74a45.png)

After:
![image](https://cloud.githubusercontent.com/assets/1103906/20512575/0acbce92-b035-11e6-9b86-6a7ff6700efa.png)
