### PR TITLE
Fix signed build by suppressing CS7035/BC42366

### DIFF
--- a/build/Targets/GenerateAssemblyInfo.targets
+++ b/build/Targets/GenerateAssemblyInfo.targets
@@ -3,6 +3,14 @@
     <GeneratedAssemblyInfoFile>$(IntermediateOutputPath)GeneratedAssemblyInfo_$(BuildVersion)$(DefaultLanguageSourceExtension)</GeneratedAssemblyInfoFile>
   </PropertyGroup>
 
+  <!-- Disable build warning CS7035/BC42366: "The specified version string does not conform to the recommended format - major.minor.build.revision" -->
+  <PropertyGroup Condition=" '$(Language)' == 'C#' ">
+    <NoWarn>$(NoWarn);CS7035</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Language)' == 'VB' ">
+    <NoWarn>$(NoWarn);BC42366</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <AssemblyVersionAttribute Include="System.Reflection.AssemblyCompanyAttribute">
       <_Parameter1>Microsoft Corporation</_Parameter1>


### PR DESCRIPTION
Our signed builds are currently blocked by following category of errors:
`2016-11-22T22:35:48.6280082Z obj\Release\GeneratedAssemblyInfo_2.0.0.2016112201.cs(17,59): error CS7035: The specified version string does not conform to the recommended format - major.minor.build.revision [E:\A\_work\1\s\src\Dependencies\Composition\Composition.csproj]`

Unblocking the build by suppressing this error and also starting a discussion with VS setup team to figure out if the build version number really matters, and if so what is the recommended value for it.