### PR TITLE
Stop double scaling MaximumSize/MinimumSize

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.vb
@@ -20,9 +20,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
             'Add any initialization after the InitializeComponent() call
             AddChangeHandlers()
-
-            Me.MaximumSize = DpiHelper.LogicalToDeviceUnits(Me.MaximumSize)
-            Me.MinimumSize = DpiHelper.LogicalToDeviceUnits(Me.Size)
         End Sub
 
 


### PR DESCRIPTION
The Debug property page was manually scaling the MaximumSize and MinimumSize properties - yet these are automatically scaled by the WinForms layout engine. This was resulting in the Debug property page in being forced into either too large or too size than normal.

I suspect this is the root cause of #427, but been unable to actually get VS in a state where it will down scale the property pages enough to repro. It looks like to do this would require a combination of a smaller Icon font size (which VS uses for its font) plus a smaller DPI than 96 (something Win10 no longer lets you do). This requires more investigation and plan on finding a machine in this state.

Here's an example of up scaling (this is on a Surface book where it's screen is Primary set to 200%, and opening VS on the secondary screen set to 100%):

Before:
![image](https://cloud.githubusercontent.com/assets/1103906/20553248/cc0d0a44-b107-11e6-88c2-5174e3095991.png)

After:
![image](https://cloud.githubusercontent.com/assets/1103906/20553256/d89dd96e-b107-11e6-96cf-d664efd4e58f.png)

