### PR TITLE
Hide the targetframework selection option for projects which have multiple targetframeworks defined.

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageInternalBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageInternalBase.vb
@@ -125,7 +125,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 VSErrorHandler.ThrowOnFailure(MyBase.ProjectHierarchy.GetSite(siteServiceProvider))
                 Dim sp As New Microsoft.VisualStudio.Shell.ServiceProvider(siteServiceProvider)
                 Dim vsFrameworkMultiTargeting As IVsFrameworkMultiTargeting = TryCast(sp.GetService(GetType(SVsFrameworkMultiTargeting).GUID), IVsFrameworkMultiTargeting)
-                If vsFrameworkMultiTargeting IsNot Nothing Then
+                ' TODO: Remove IsTargetFrameworksDefined check after issue #800 is resolved.
+                If (TargetFrameworksDefined() = False And vsFrameworkMultiTargeting IsNot Nothing) Then
 
                     Dim supportedFrameworks As IEnumerable(Of TargetFrameworkMoniker) = TargetFrameworkMoniker.GetSupportedTargetFrameworkMonikers(vsFrameworkMultiTargeting, DTEProject)
 
@@ -151,6 +152,18 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
+        Private Function TargetFrameworksDefined() As Boolean
+            Dim obj As Object
+            Dim propTargetFrameworks As PropertyDescriptor
+            Dim stTargetFrameworks As String = Nothing
+            propTargetFrameworks = GetPropertyDescriptor("TargetFrameworks")
+            obj = TryGetNonCommonPropertyValue(propTargetFrameworks)
+            stTargetFrameworks = TryCast(obj, String)
+            If (String.IsNullOrEmpty(stTargetFrameworks)) Then
+                Return False
+            End If
+            Return True
+        End Function
         ''' <summary>
         ''' Takes the current value of the TargetFrameworkMoniker property (in string format), and sets
         '''   the current dropdown list to that value.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -30,7 +30,12 @@
       <DataSource PersistedName="RootNamespace" Persistence="ProjectFile" Label="Configuration" HasConfigurationCondition="false" />
     </StringProperty.DataSource>
   </StringProperty>
-  <IntProperty Name="TargetFramework" ReadOnly="True" Visible="False">
+  <StringProperty Name="TargetFrameworks" DisplayName="Target Frameworks" Visible="False">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFile" PersistedName="TargetFrameworks" HasConfigurationCondition="False" />
+        </StringProperty.DataSource>
+  </StringProperty>
+    <IntProperty Name="TargetFramework" ReadOnly="True" Visible="False">
     <IntProperty.DataSource>
       <DataSource Persistence="ProjectFileWithInterception" PersistedName="TargetFramework" />
     </IntProperty.DataSource>


### PR DESCRIPTION
@srivatsn @davkean @dotnet/project-system