### PR TITLE
Stop throwing first-chance exceptions on startup

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilderTests.cs
@@ -60,7 +60,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             Assert.Equal(1, restoreInfo.TargetFrameworks.Count);
             var tfm = restoreInfo.TargetFrameworks.Item("netcoreapp1.0");
             Assert.Equal(tfm, restoreInfo.TargetFrameworks.Item(0));
-            Assert.Null(restoreInfo.TargetFrameworks.Item(1));
             Assert.Null(restoreInfo.TargetFrameworks.Item("InvalidFrameworkMoniker"));
 
             Assert.Equal("netcoreapp1.0", tfm.TargetFrameworkMoniker);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/VsItemList.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/VsItemList.cs
@@ -26,21 +26,37 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 
         public T Item(Object index)
         {
-            try
+            if (index is string)
             {
-                if (index is string)
-                {
-                    return this[(string)index];
-                }
-                else if (index is int)
-                {
-                    return this[(int)index];
-                }
+                TryGetValue((string)index, out var value);
+                return value;
             }
-            catch (KeyNotFoundException) { }
-            catch (ArgumentOutOfRangeException) { }
 
-            return default(T);
+            return this[(int)index];
         }
+
+    public bool TryGetValue(string key, out T value)
+    {
+        // Until we have https://github.com/dotnet/corefx/issues/4690
+
+        Requires.NotNull(key, nameof(key));
+
+        if (Dictionary != null)
+        {
+            return Dictionary.TryGetValue(key, out value);
+        }
+
+        foreach (T item in Items)
+        {
+            if (Comparer.Equals(GetKeyForItem(item), key))
+            {
+                value = item;
+                return true;
+            }
+        }
+
+        value = default(T);
+        return false;
     }
+}
 }


### PR DESCRIPTION
NuGet was causing us to throw two first-chance exceptions on startup - move to a non-throwing path. Not KeyedCollection doesn't have TryGetValue yet (it's coming soon), so needed to define our own.