### PR TITLE
Fix project fault when adding a resource

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsProjectFactory.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
                 .Returns(0);
         }
 
-        public static void ImplementAddItemWithSpecific(this IVsProject4 project, Func<uint, VSADDITEMOPERATION, string, string[], VSADDRESULT[], int> addItemWithSpecificFunc)
+        public static void ImplementAddItemWithSpecific(this IVsProject4 project, Func<uint, VSADDITEMOPERATION, string, uint, string[], VSADDRESULT[], int> addItemWithSpecificFunc)
         {
             var mock = Mock.Get(project);
             Guid guidEditorType = Guid.Empty;
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
             mock.Setup(h => h.AddItemWithSpecific(It.IsAny<uint>(), It.IsAny<VSADDITEMOPERATION>(), It.IsAny<string>(), It.IsAny<uint>(), It.IsAny<string[]>(), It.IsAny<IntPtr>(), It.IsAny<uint>(), ref guidEditorType, It.IsAny<string>(), ref rguidLogicalView, It.IsAny<VSADDRESULT[]>()))
                 .Returns<uint, VSADDITEMOPERATION, string, uint, string[], IntPtr, uint, Guid, string, Guid, VSADDRESULT[]>((itemId, op, itemName, cOpen, arrFiles, handle, flags, editorType, physView, logicalView, result) =>
                 {
-                    return addItemWithSpecificFunc(itemId, op, itemName, arrFiles, result);
+                    return addItemWithSpecificFunc(itemId, op, itemName, cOpen, arrFiles, result);
                 });
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/CreateFileFromTemplateServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/CreateFileFromTemplateServiceTests.cs
@@ -102,11 +102,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             
             var vsProject = (IVsProject4)IVsHierarchyFactory.Create();
-            vsProject.ImplementAddItemWithSpecific((itemId, itemOperation, itemName, files, result) =>
+            vsProject.ImplementAddItemWithSpecific((itemId, itemOperation, itemName, cOpen, files, result) =>
             {
                 Assert.Equal((uint)inputTree.GetHierarchyId(), itemId);
                 Assert.Equal(VSADDITEMOPERATION.VSADDITEMOP_RUNWIZARD, itemOperation);
                 Assert.Equal(fileName, itemName);
+                Assert.Equal((uint)1, cOpen);
                 Assert.Equal(new string[] { templateFilePath }, files);
 
                 result[0] = expectedResult ? VSADDRESULT.ADDRESULT_Success : VSADDRESULT.ADDRESULT_Failure;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CreateFileFromTemplateService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CreateFileFromTemplateService.cs
@@ -55,7 +55,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             {
                 var parentId = parentNode.GetHierarchyId();
                 var result = new VSADDRESULT[1];
-                _projectVsServices.VsProject.AddItemWithSpecific(parentId, VSADDITEMOPERATION.VSADDITEMOP_RUNWIZARD, fileName, 0, new string[] { templateFilePath }, IntPtr.Zero, 0, Guid.Empty, null, Guid.Empty, result);
+                var files = new string[] { templateFilePath };
+                _projectVsServices.VsProject.AddItemWithSpecific(parentId, VSADDITEMOPERATION.VSADDITEMOP_RUNWIZARD, fileName, (uint)files.Length, files, IntPtr.Zero, 0, Guid.Empty, null, Guid.Empty, result);
 
                 if (result[0] == VSADDRESULT.ADDRESULT_Success)
                 {


### PR DESCRIPTION
We weren't setting cFilesToOpen when calling AddItemWithSpecific, causing CPS to end up getting passed an empty array from the shell.

This takes Fred's change from here: https://github.com/dotnet/roslyn-project-system/pull/768 and partially fixes: https://github.com/dotnet/roslyn-project-system/issues/576 when the Properties folder already exists.