### PR TITLE
Update BuildAndTest.cmd args for VSI runs to match roslyn-internal

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -73,7 +73,9 @@ set TEMP=%WORKSPACE%\\roslyn-internal\\Open\\Binaries\\Temp
 mkdir %TEMP%
 set TMP=%TEMP%
 
-BuildAndTest.cmd -build:true -clean:false -deployExtensions:true -trackFileAccess:false -officialBuild:false -realSignBuild:false -parallel:true -release:true -delaySignBuild:true -dependencies:true -samples:false -devDivInsertionFiles:false -unit:false -eta:false -vs:true -cibuild:true -x64:false -netcoretestrun
+set EchoOn=true
+
+BuildAndTest.cmd -build:true -clean:false -deployExtensions:false -trackFileAccess:false -officialBuild:false -realSignBuild:false -parallel:true -release:true -delaySignBuild:true -samples:false -unit:false -eta:false -vs:true -cibuild:true -x64:false -netcoretestrun
 popd""")
     }
 }

--- a/netci.groovy
+++ b/netci.groovy
@@ -75,7 +75,7 @@ set TMP=%TEMP%
 
 set EchoOn=true
 
-BuildAndTest.cmd -build:true -clean:false -deployExtensions:false -trackFileAccess:false -officialBuild:false -realSignBuild:false -parallel:true -release:true -delaySignBuild:true -samples:false -unit:false -eta:false -vs:true -cibuild:true -x64:false -netcoretestrun
+BuildAndTest.cmd -build:true -clean:false -deployExtensions:true -trackFileAccess:false -officialBuild:false -realSignBuild:false -parallel:true -release:true -delaySignBuild:true -samples:false -unit:false -eta:false -vs:true -cibuild:true -x64:false -netcoretestrun
 popd""")
     }
 }


### PR DESCRIPTION
See https://github.com/dotnet/roslyn-internal/blob/master/netci.groovy#L163 for reference.