### PR TITLE
Changes to netci.groovy for VSI tests

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -60,13 +60,13 @@ SET VSSDKInstall=%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\Enterprise\
 build.cmd /release""")
         
         // Patch all the MSBuild xaml and targets files from the current roslyn-project-system commit into VS install.
-        batchFile("""SET VS_MSBUILD_MANAGED=%VSINSTALLDIR%\MSBuild\Microsoft\VisualStudio\Managed
+        batchFile("""SET VS_MSBUILD_MANAGED=%VSINSTALLDIR%\\MSBuild\\Microsoft\\VisualStudio\\Managed
 
 mkdir backup
-xcopy /SIY "%VS_MSBUILD_MANAGED%" backup\Managed
+xcopy /SIY "%VS_MSBUILD_MANAGED%" .\\backup\\Managed
 
-xcopy /SIY .\src\Targets\*.targets "%VS_MSBUILD_MANAGED%"
-xcopy /SIY .\bin\Release\Rules\*.xaml "%VS_MSBUILD_MANAGED%"
+xcopy /SIY .\\src\\Targets\\*.targets "%VS_MSBUILD_MANAGED%"
+xcopy /SIY .\\bin\\Release\\Rules\\*.xaml "%VS_MSBUILD_MANAGED%"
 """)
 
         // Build sdk repo and install templates into RoslynDev hive.
@@ -112,9 +112,9 @@ BuildAndTest.cmd -build:true -clean:false -deployExtensions:true -trackFileAcces
 popd""")
 
        // Revert patched targets and rules from backup.
-        batchFile("""SET VS_MSBUILD_MANAGED=%VSINSTALLDIR%\MSBuild\Microsoft\VisualStudio\Managed
-del /SQ "%VS_MSBUILD_MANAGED%\"
-xcopy /SIY backup\Managed "%VS_MSBUILD_MANAGED%"
+        batchFile("""SET VS_MSBUILD_MANAGED=%VSINSTALLDIR%\\MSBuild\\Microsoft\\VisualStudio\\Managed
+del /SQ "%VS_MSBUILD_MANAGED%\\"
+xcopy /SIY .\\backup\\Managed "%VS_MSBUILD_MANAGED%"
 rmdir /S /Q backup
 """)
     }

--- a/netci.groovy
+++ b/netci.groovy
@@ -58,6 +58,39 @@ SET VSSDK150Install=%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\Enterpri
 SET VSSDKInstall=%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\Enterprise\\VSSDK\\
 
 build.cmd /release""")
+        
+        // Patch all the MSBuild xaml and targets files from the current roslyn-project-system commit into VS install.
+        batchFile("""SET VS_MSBUILD_MANAGED=%VSINSTALLDIR%\MSBuild\Microsoft\VisualStudio\Managed
+
+mkdir backup
+xcopy /SIY "%VS_MSBUILD_MANAGED%" backup\Managed
+
+xcopy /SIY .\src\Targets\*.targets "%VS_MSBUILD_MANAGED%"
+xcopy /SIY .\bin\Release\Rules\*.xaml "%VS_MSBUILD_MANAGED%"
+""")
+
+        // Build sdk repo and install templates into RoslynDev hive.
+        batchFile("""SET VS150COMNTOOLS=%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\Enterprise\\Common7\\Tools\\
+SET DeveloperCommandPrompt=%VS150COMNTOOLS%\\VsMSBuildCmd.bat
+
+call "%DeveloperCommandPrompt%" || goto :BuildFailed
+
+pushd %WORKSPACE%\\sdk
+build.cmd -Configuration release
+
+pushd %WORKSPACE%\\roslyn-internal\\Closed\\Tools\\Source\\VsixExpInstaller
+msbuild /p:Configuration=Release
+SET VSIXExpInstallerExe=%WORKSPACE%\\roslyn-internal\\Open\\Binaries\\Release\\Exes\\VsixExpInstaller\\VsixExpInstaller.exe
+%VSIXExpInstallerExe% /rootsuffix:RoslynDev %WORKSPACE%\\sdk\\bin\\Release\\Microsoft.VisualStudio.ProjectSystem.CSharp.Templates.vsix
+%VSIXExpInstallerExe% /rootsuffix:RoslynDev %WORKSPACE%\\sdk\\bin\\Release\\Microsoft.VisualStudio.ProjectSystem.VisualBasic.Templates.vsix
+
+exit /b %ERRORLEVEL%
+
+:BuildFailed
+echo Build failed with ERRORLEVEL %ERRORLEVEL%
+exit /b 1
+BuildFailed
+""")
 
         // Build roslyn-internal and run netcore VSI tao tests.
         batchFile("""SET VS150COMNTOOLS=%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\Enterprise\\Common7\\Tools\\
@@ -77,6 +110,13 @@ set EchoOn=true
 
 BuildAndTest.cmd -build:true -clean:false -deployExtensions:true -trackFileAccess:false -officialBuild:false -realSignBuild:false -parallel:true -release:true -delaySignBuild:true -samples:false -unit:false -eta:false -vs:true -cibuild:true -x64:false -netcoretestrun
 popd""")
+
+       // Revert patched targets and rules from backup.
+        batchFile("""SET VS_MSBUILD_MANAGED=%VSINSTALLDIR%\MSBuild\Microsoft\VisualStudio\Managed
+del /SQ "%VS_MSBUILD_MANAGED%\"
+xcopy /SIY backup\Managed "%VS_MSBUILD_MANAGED%"
+rmdir /S /Q backup
+""")
     }
 }
 
@@ -109,6 +149,16 @@ static void addVsiMultiScm(def myJob, def project) {
                 }
                 // Pull from the desired branch input branch passed as a parameter (set up by standardJobSetup)
                 branch('${GitBranchOrCommit}')
+            }
+            git {
+                remote {
+                    url('https://github.com/dotnet/sdk')
+                }
+                extensions {
+                    relativeTargetDirectory('sdk')
+                }
+                // pull in a specific LKG commit from master.
+                branch('aca5d1556f7c9b3e2182a38844d66be663ff26fb')
             }
             git {
                 remote {


### PR DESCRIPTION
1. Enlist into SDK repo and install templates to RoslynDev hive
2. Patch all the MSBuild xaml and targets files from the current roslyn-project-system commit into VS install dirs.