### PR TITLE
[WIP] Migration cleanup

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests.csproj
@@ -42,6 +42,10 @@
       <Project>{c7ec63f8-f96a-4a8f-b879-d572516746b4}</Project>
       <Name>Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj">
+      <Project>{469b50e9-fe67-459e-8afa-44cbe523dbf6}</Project>
+      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS\Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj">
       <Project>{1c5666ea-24a4-4ec2-b8fb-faedf6b14697}</Project>
       <Name>Microsoft.VisualStudio.ProjectSystem.Managed.VS</Name>
@@ -68,6 +72,8 @@
     <Compile Include="ProjectSystem\VS\Properties\CSharpProjectGuidProviderTests.cs" />
     <Compile Include="ProjectSystem\VS\CSharpProjectCompatibilityProviderTests.cs" />
     <Compile Include="ProjectSystem\VS\Xproj\MigrateXprojProjectFactoryTests.cs" />
+    <Compile Include="ProjectSystem\VS\Xproj\MigrationCleanerTests.cs" />
+    <Compile Include="ProjectSystem\VS\Xproj\MigrationCleanStoreTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\Common\Test\App.config">

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrationCleanStoreTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrationCleanStoreTests.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
+{
+    [ProjectSystemTrait]
+    public class MigrationCleanStoreTests
+    {
+        [Fact]
+        public void MigrationCleanStore_AddFiles_AddsFilesToSet()
+        {
+            var store = new MigrationCleanStore();
+            store.AddFiles(@"C:\file1.csproj", @"C:\file1.csproj", @"C:\file2.csproj");
+            Assert.Equal(2, store.Files.Count);
+            Assert.Contains(@"C:\file1.csproj", store.Files);
+            Assert.Contains(@"C:\file2.csproj", store.Files);
+        }
+
+        [Fact]
+        public void MigrationCleanStore_DrainFiles_RemovesAllFiles()
+        {
+            var store = new MigrationCleanStore();
+            store.Files.Add(@"C:\file.csproj");
+            var files = store.DrainFiles();
+            Assert.Equal(1, files.Count);
+            Assert.Contains(@"C:\file.csproj", files);
+            Assert.Empty(store.Files);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrationCleanerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrationCleanerTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Mocks;
+using Moq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
+{
+    [ProjectSystemTrait]
+    public class MigrationCleanerTests
+    {
+        [Fact]
+        public async Task MigrationCleaner_GivenFilesToClean_RemovesFiles()
+        {
+            var store = new MigrationCleanStore();
+            store.AddFiles(@"C:\project1\project1.xproj", @"C:\project1\project.json");
+            var fileSystemMock = new IFileSystemMock();
+            fileSystemMock.Create(@"C:\project1\project1.xproj");
+            fileSystemMock.Create(@"C:\project1\project.json");
+
+            var cleaner = new MigrationCleaner(store, fileSystemMock);
+            await cleaner.CleanupFiles();
+            Assert.False(fileSystemMock.FileExists(@"C:\project1\project1.xproj"));
+            Assert.False(fileSystemMock.FileExists(@"C:\project1\project.json"));
+        }
+
+        [Fact]
+        public async Task MigrationCleaner_NoFilesToClean_DoesNotCallRemoveFile()
+        {
+            var store = new MigrationCleanStore();
+            var fileSystem = IFileSystemFactory.Create();
+            var cleaner = new MigrationCleaner(store, fileSystem);
+            await cleaner.CleanupFiles();
+            Mock.Get(fileSystem).Verify(f => f.RemoveFile(It.IsAny<string>()), Times.Never);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj
@@ -54,7 +54,10 @@
     </Compile>
     <Compile Include="ProjectSystem\VS\LanguageServices\CSharpLanguageFeaturesProvider.cs" />
     <Compile Include="ProjectSystem\VS\CSharpProjectGuidProvider.cs" />
+    <Compile Include="ProjectSystem\VS\Xproj\IMigrationCleanStore.cs" />
     <Compile Include="ProjectSystem\VS\Xproj\MigrateXprojProjectFactory.cs" />
+    <Compile Include="ProjectSystem\VS\Xproj\MigrationCleaner.cs" />
+    <Compile Include="ProjectSystem\VS\Xproj\MigrationCleanStore.cs" />
     <Compile Include="ProjectSystem\VS\Xproj\ProcessRunner.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.Packaging
 
         protected override Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
-            _factory = new MigrateXprojProjectFactory(new ProcessRunner(), new FileSystem());
+            _factory = new MigrateXprojProjectFactory(new ProcessRunner(), new FileSystem(), this);
             _factory.SetSite(this);
             RegisterProjectFactory(_factory);
             return Task.CompletedTask;

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/IMigrationCleanStore.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/IMigrationCleanStore.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
+{
+    internal interface IMigrationCleanStore
+    {
+        /// <summary>
+        /// The list of files that need to be cleaned, clearing the list after return.
+        /// </summary>
+        ISet<string> DrainFiles();
+
+        /// <summary>
+        /// Adds a new file to the list of files that need to be cleaned.
+        /// </summary>
+        void AddFiles(params string[] files);
+
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrationCleanStore.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrationCleanStore.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
+{
+    [Export(typeof(IMigrationCleanStore))]
+    class MigrationCleanStore : IMigrationCleanStore
+    {
+        private readonly object _lock = new object();
+
+        private ISet<string> _files = new HashSet<string>();
+
+        public ISet<string> DrainFiles()
+        {
+            lock (_lock)
+            {
+                var files = _files;
+                if (files.Count > 0)
+                {
+                    _files = new HashSet<string>();
+                }
+                return files;
+            }
+        }
+
+        public void AddFiles(params string[] fullPaths)
+        {
+            lock (_lock)
+            {
+                _files.AddRange(fullPaths);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrationCleanStore.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrationCleanStore.cs
@@ -12,6 +12,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
 
         private ISet<string> _files = new HashSet<string>();
 
+        // Test accessor code
+        internal ISet<string> Files => _files;
+
         public ISet<string> DrainFiles()
         {
             lock (_lock)

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrationCleaner.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrationCleaner.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.ProjectSystem.Utilities;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
+{
+    internal class MigrationCleaner
+    {
+        private readonly IMigrationCleanStore _migrationStore;
+        private readonly IFileSystem _fileSystem;
+
+        [ImportingConstructor]
+        public MigrationCleaner(IMigrationCleanStore migrationStore, IFileSystem fileSystem)
+        {
+            _migrationStore = migrationStore;
+            _fileSystem = fileSystem;
+        }
+
+        [ProjectAutoLoad(startAfter: ProjectLoadCheckpoint.ProjectFactoryCompleted)]
+        [AppliesTo(ProjectCapability.CSharp)]
+        public Task CleanupFiles()
+        {
+            var toDelete = _migrationStore.DrainFiles();
+            foreach (var file in toDelete)
+            {
+                _fileSystem.RemoveFile(file);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemFactory.cs
@@ -9,6 +9,8 @@ namespace Microsoft.VisualStudio.Mocks
 {
     internal class IFileSystemFactory
     {
+        public static IFileSystem Create() => Mock.Of<IFileSystem>();
+
         public static IFileSystem Create(Func<string, bool> existsFunc, Func<string, FileStream> createFunc = null)
         {
             var mock = new Mock<IFileSystem>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -52,6 +52,7 @@
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Mocks\DteFactory.cs" />
     <Compile Include="Mocks\IActiveConfiguredProjectSubscriptionServiceFactory.cs" />
+    <Compile Include="Mocks\IComponentModelFactory.cs" />
     <Compile Include="Mocks\IDebugLaunchProviderFactory.cs" />
     <Compile Include="Mocks\IDebugLaunchProviderMetadataViewFactory.cs" />
     <Compile Include="Mocks\IDteServicesFactory.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IComponentModelFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IComponentModelFactory.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ComponentModelHost
+{
+    internal static class IComponentModelFactory
+    {
+        public static IComponentModel ImplementGetService<T>(T o)
+            where T : class
+        {
+            var mock = new Mock<IComponentModel>();
+            mock.Setup(c => c.GetService<T>()).Returns(o);
+            return mock.Object;
+        }
+    }
+}


### PR DESCRIPTION
This fixes #734 by adding all migrated files to a list that the project will clean on load. We can't just delete the xprojs and project.json files after running dotnet migrate because other projects might depend on those files.

Tagging @dotnet/project-system @jinujoseph for review. /cc @piotrpMSFT. 
@MattGertz, I'm not sure if this scenario meets the bar for escrow. The scenario is that after migration, we currently leave the old project.json and .xproj files on disk, as well as backing them up. This adds deletion of those files after migration is complete. If you think that meets the bar, I'll retarget to dev15-rc2 and add the full escrow template.