### PR TITLE
Fix build events crash

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ConfiguredProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ConfiguredProjectFactory.cs
@@ -6,11 +6,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class ConfiguredProjectFactory
     {
-        public static ConfiguredProject Create(IProjectCapabilitiesScope capabilities = null, ProjectConfiguration projectConfiguration = null)
+        public static ConfiguredProject Create(IProjectCapabilitiesScope capabilities = null, ProjectConfiguration projectConfiguration = null, IConfiguredProjectServices services = null)
         {
             var mock = new Mock<ConfiguredProject>();
             mock.Setup(c => c.Capabilities).Returns(capabilities);
             mock.Setup(c => c.ProjectConfiguration).Returns(projectConfiguration);
+            mock.Setup(c => c.Services).Returns(services);
             return mock.Object;
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -121,6 +121,7 @@
     <Compile Include="ProjectSystem\VS\Editor\MsBuildModelWatcherTests.cs" />
     <Compile Include="ProjectSystem\VS\NuGet\ProjectRestoreInfoBuilderTests.cs" />
     <Compile Include="ProjectSystem\VS\OptionsSettingsTests.cs" />
+    <Compile Include="ProjectSystem\VS\PropertyPages\BuildMacroInfoTests.cs" />
     <Compile Include="ProjectSystem\VS\PropertyPages\DebugPageViewModelTests.cs" />
     <Compile Include="ProjectSystem\VS\PropertyPages\PropertyPageControlTests.cs" />
     <Compile Include="ProjectSystem\VS\PropertyPages\PropertyPageTests.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/BuildMacroInfoTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/BuildMacroInfoTests.cs
@@ -18,10 +18,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             var configuredProjectServices = Mock.Of<IConfiguredProjectServices>(o =>
                 o.ProjectPropertiesProvider == propertiesProvider);
             var configuredProject = ConfiguredProjectFactory.Create(services: configuredProjectServices);
-            var unconfiguredProject = IUnconfiguredProjectFactory.Create(configuredProject: configuredProject);
+            ActiveConfiguredProject<ConfiguredProject> activeConfiguredProject = IActiveConfiguredProjectFactory.ImplementValue(() => configuredProject);
             var threadingService = IProjectThreadingServiceFactory.Create();
 
-            var buildMacroInfo = new BuildMacroInfo(unconfiguredProject, threadingService);
+            var buildMacroInfo = new BuildMacroInfo(activeConfiguredProject, threadingService);
 
             string macroValue;
             int retVal = buildMacroInfo.GetBuildMacroValue(macroName, out macroValue);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/BuildMacroInfoTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/BuildMacroInfoTests.cs
@@ -19,9 +19,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 o.ProjectPropertiesProvider == propertiesProvider);
             var configuredProject = ConfiguredProjectFactory.Create(services: configuredProjectServices);
             var unconfiguredProject = IUnconfiguredProjectFactory.Create(configuredProject: configuredProject);
-            var vsServices = IUnconfiguredProjectVsServicesFactory.Implement();
+            var threadingService = IProjectThreadingServiceFactory.Create();
 
-            var buildMacroInfo = new BuildMacroInfo(unconfiguredProject, vsServices);
+            var buildMacroInfo = new BuildMacroInfo(unconfiguredProject, threadingService);
 
             string macroValue;
             int retVal = buildMacroInfo.GetBuildMacroValue(macroName, out macroValue);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/BuildMacroInfoTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/BuildMacroInfoTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
+{
+    [ProjectSystemTrait]
+    public class BuildMacroInfoTests
+    {
+        [Theory]
+        [InlineData("MyBuildMacro", "MyBuildMacroValue", VSConstants.S_OK)]
+        [InlineData("NonExistantMacro", "", VSConstants.E_FAIL)]
+        public void BuildMacroInfoTests_GetBuildMacroValue(string macroName, string expectedValue, int expectedRetVal)
+        {
+            var projectProperties = IProjectPropertiesFactory.CreateWithPropertyAndValue("MyBuildMacro", "MyBuildMacroValue");
+            var propertiesProvider = IProjectPropertiesProviderFactory.Create(commonProps: projectProperties);
+            var configuredProjectServices = Mock.Of<IConfiguredProjectServices>(o =>
+                o.ProjectPropertiesProvider == propertiesProvider);
+            var configuredProject = ConfiguredProjectFactory.Create(services: configuredProjectServices);
+            var unconfiguredProject = IUnconfiguredProjectFactory.Create(configuredProject: configuredProject);
+            var vsServices = IUnconfiguredProjectVsServicesFactory.Implement();
+
+            var buildMacroInfo = new BuildMacroInfo(unconfiguredProject, vsServices);
+
+            string macroValue;
+            int retVal = buildMacroInfo.GetBuildMacroValue(macroName, out macroValue);
+            Assert.Equal(expectedRetVal, retVal);
+            Assert.Equal(expectedValue, macroValue);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -38,6 +38,7 @@
     <Compile Include="ProjectSystem\VS\Editor\EditProjectFileCleanupFrameNotifyListener.cs" />
     <Compile Include="ProjectSystem\VS\Editor\IMsBuildModelWatcher.cs" />
     <Compile Include="ProjectSystem\VS\Editor\MsBuildModelWatcher.cs" />
+    <Compile Include="ProjectSystem\VS\PropertyPages\BuildMacroInfo.cs" />
     <Compile Include="ProjectSystem\VS\Generators\SingleFileGeneratorFactoryAggregator.cs" />
     <Compile Include="ProjectSystem\VS\NuGet\ProjectProperties.cs" />
     <Compile Include="ProjectSystem\VS\NuGet\ProjectProperty.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/BuildMacroInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/BuildMacroInfo.cs
@@ -48,6 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// <returns>If the method succeeds, it returns S_OK. If it fails, it returns an error code.</returns>
         public int GetBuildMacroValue(string bstrBuildMacroName, out string pbstrBuildMacroValue)
         {
+            pbstrBuildMacroValue = null;
             var configuredProject = _projectVsServices.ThreadingService.ExecuteSynchronously(async delegate
             {
                 return await _unconfiguredProject.GetSuggestedConfiguredProjectAsync().ConfigureAwait(false);
@@ -59,7 +60,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 return await commonProperties.GetEvaluatedPropertyValueAsync(bstrBuildMacroName).ConfigureAwait(false);
             });
 
-            return PropertyPage.NativeMethods.S_OK;
+            if (pbstrBuildMacroValue == null)
+            {
+                pbstrBuildMacroValue = string.Empty;
+                return VSConstants.E_FAIL;
+            }
+            else
+            {
+                return VSConstants.S_OK;
+            }
         }
 
         #endregion

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/BuildMacroInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/BuildMacroInfo.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
+{
+    /// <summary>
+    /// Implements the <see cref="IVsBuildMacroInfo"/> interface to be consumed by project properties.
+    /// </summary>
+    [Export(ExportContractNames.VsTypes.ProjectNodeComExtension)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
+    [ComServiceIid(typeof(IVsBuildMacroInfo))]
+    internal class BuildMacroInfo : IVsBuildMacroInfo
+    {
+        /// <summary>
+        /// Provides access to common Visual Studio project services.
+        /// </summary>
+        private IUnconfiguredProjectVsServices _projectVsServices;
+
+        /// <summary>
+        /// Project components for the configuration being evaluated.
+        /// </summary>
+        private UnconfiguredProject _unconfiguredProject;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BuildMacroInfo"/> class.
+        /// </summary>
+        /// <param name="unconfiguredProject">Project being evaluated.</param>
+        /// <param name="projectVsServices">Visual Studio project services.</param>
+        [ImportingConstructor]
+        public BuildMacroInfo(
+            UnconfiguredProject unconfiguredProject,
+            IUnconfiguredProjectVsServices projectVsServices
+            )
+        {
+            _unconfiguredProject = unconfiguredProject;
+            _projectVsServices = projectVsServices;
+        }
+
+        #region IVsBuildMacroInfo
+
+        /// <summary>
+        /// Retrieves the value or body of a macro based on the macro's name.
+        /// </summary>
+        /// <param name="bstrBuildMacroName">String containing the name of the macro.</param>
+        /// <param name="pbstrBuildMacroValue">String containing the value or body of the macro.</param>
+        /// <returns>If the method succeeds, it returns S_OK. If it fails, it returns an error code.</returns>
+        public int GetBuildMacroValue(string bstrBuildMacroName, out string pbstrBuildMacroValue)
+        {
+            var configuredProject = _projectVsServices.ThreadingService.ExecuteSynchronously(async delegate
+            {
+                return await _unconfiguredProject.GetSuggestedConfiguredProjectAsync().ConfigureAwait(false);
+            });
+
+            var commonProperties = configuredProject.Services.ProjectPropertiesProvider.GetCommonProperties();
+            pbstrBuildMacroValue = _projectVsServices.ThreadingService.ExecuteSynchronously<string>(async delegate
+            {
+                return await commonProperties.GetEvaluatedPropertyValueAsync(bstrBuildMacroName).ConfigureAwait(false);
+            });
+
+            return PropertyPage.NativeMethods.S_OK;
+        }
+
+        #endregion
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/BuildMacroInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/BuildMacroInfo.cs
@@ -21,20 +21,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// <summary>
         /// Project components for the configuration being evaluated.
         /// </summary>
-        private readonly UnconfiguredProject _unconfiguredProject;
+        private readonly ActiveConfiguredProject<ConfiguredProject> _configuredProject;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BuildMacroInfo"/> class.
         /// </summary>
-        /// <param name="unconfiguredProject">Project being evaluated.</param>
+        /// <param name="configuredProject">Project being evaluated.</param>
         /// <param name="threadingService">Project threading service.</param>
         [ImportingConstructor]
         public BuildMacroInfo(
-            UnconfiguredProject unconfiguredProject,
+            ActiveConfiguredProject<ConfiguredProject> configuredProject,
             IProjectThreadingService threadingService)
         {
-            _unconfiguredProject = unconfiguredProject;
             _threadingService = threadingService;
+            _configuredProject = configuredProject;
         }
 
         /// <summary>
@@ -46,8 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         public int GetBuildMacroValue(string bstrBuildMacroName, out string pbstrBuildMacroValue)
         {
             pbstrBuildMacroValue = null;
-            var configuredProject = _threadingService.ExecuteSynchronously(_unconfiguredProject.GetSuggestedConfiguredProjectAsync);
-            var commonProperties = configuredProject.Services.ProjectPropertiesProvider.GetCommonProperties();
+            var commonProperties = _configuredProject.Value.Services.ProjectPropertiesProvider.GetCommonProperties();
             pbstrBuildMacroValue = _threadingService.ExecuteSynchronously<string>(() => commonProperties.GetEvaluatedPropertyValueAsync(bstrBuildMacroName));
 
             if (pbstrBuildMacroValue == null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/BuildMacroInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/BuildMacroInfo.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// <summary>
         /// Project components for the configuration being evaluated.
         /// </summary>
-        private UnconfiguredProject _unconfiguredProject;
+        private readonly UnconfiguredProject _unconfiguredProject;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BuildMacroInfo"/> class.
@@ -36,8 +36,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             _unconfiguredProject = unconfiguredProject;
             _threadingService = threadingService;
         }
-
-        #region IVsBuildMacroInfo
 
         /// <summary>
         /// Retrieves the value or body of a macro based on the macro's name.
@@ -62,7 +60,5 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 return VSConstants.S_OK;
             }
         }
-
-        #endregion
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// </summary>
         private T WaitForAsync<T>(Func<Task<T>> asyncFunc)
         {
-            return _threadHandling.ExecuteSynchronously<T>(asyncFunc);
+            return _threadHandling != null ? _threadHandling.ExecuteSynchronously<T>(asyncFunc) : default(T);
         }
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// </summary>
         private void WaitForAsync(Func<Task> asyncFunc)
         {
-            _threadHandling.ExecuteSynchronously(asyncFunc);
+            _threadHandling?.ExecuteSynchronously(asyncFunc);
         }
 
         ///--------------------------------------------------------------------------------------------

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// </summary>
         private T WaitForAsync<T>(Func<Task<T>> asyncFunc)
         {
-            return _threadHandling != null ? _threadHandling.ExecuteSynchronously<T>(asyncFunc) : default(T);
+            return _threadHandling.ExecuteSynchronously<T>(asyncFunc);
         }
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// </summary>
         private void WaitForAsync(Func<Task> asyncFunc)
         {
-            _threadHandling?.ExecuteSynchronously(asyncFunc);
+            _threadHandling.ExecuteSynchronously(asyncFunc);
         }
 
         ///--------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes the Visual Studio crash when the user tries to edit pre/post build events. Note that they still can't be edited (changes aren't saved) due to #857

Escrow Template:
Customer scenario – Visual Studio crashes when the user tries clicking edit Pre/Post build events. 
Bugs this fixes: #405 
Workarounds - N/A
Risk – Low. This implements a COM interface (IVsBuildMacro) for the IVsHierarchy object for the project
Performance impact - None. This only executes when the hierarchy is casted to the interface  which only happens for the scenario above.
Is this a regression? - From the old project system.
Root cause analysis - The old project system implemented this interface on the IVsHierarchy object and that hadn't been implemented in the new project system.
How was the bug found? - N/A