### PR TITLE
Reactive changes to switch from ShortcutPath to ExtensionInstallation Root

### DIFF
--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -105,7 +105,7 @@
   </Choose>
 
   <PropertyGroup>
-    <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.25914-RC2</VisualStudioBuildToolsNuGetPackagePath>
+    <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.25929-RC2</VisualStudioBuildToolsNuGetPackagePath>
   </PropertyGroup>
   <Import Project="$(VisualStudioBuildToolsNuGetPackagePath)\build\Microsoft.VsSDK.BuildTools.props"
           Condition="'$(OS)' == 'Windows_NT' And Exists('$(VisualStudioBuildToolsNuGetPackagePath)\build\Microsoft.VsSDK.BuildTools.props')" />

--- a/src/Dependencies/Toolset/project.json
+++ b/src/Dependencies/Toolset/project.json
@@ -9,11 +9,11 @@
     "Microsoft.Net.RoslynDiagnostics": {
       "version": "1.2.0-beta2",
       "exclude": "build"
-    }, 
-    "Microsoft.VSSDK.BuildTools": { 
-      "version": "15.0.25914-RC2", 
-      "exclude": "build" 
-     }
+    },
+    "Microsoft.VSSDK.BuildTools": {
+      "version": "15.0.25929-RC2",
+      "exclude": "build"
+    }
   },
   "frameworks": {
     ".NETPortable,Version=v4.5,Profile=Profile7": { }

--- a/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
+++ b/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
@@ -29,6 +29,8 @@
     <ProjectSystemLayer>VisualStudio</ProjectSystemLayer>
     <ProducingSignedVsix>true</ProducingSignedVsix>
     <IsProductComponent>true</IsProductComponent>
+    <ExtensionInstallationRoot>CommonExtensions</ExtensionInstallationRoot> 
+    <ExtensionInstallationFolder>Microsoft\VisualStudio\Editors</ExtensionInstallationFolder> 
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>

--- a/src/VisualStudioEditorsSetup/source.extension.vsixmanifest
+++ b/src/VisualStudioEditorsSetup/source.extension.vsixmanifest
@@ -4,7 +4,6 @@
     <Identity Id="F6B5EACA-7FA1-4591-8D40-A38234763621" Version="|%CurrentProject%;GetBuildVersion|" Language="en-US" Publisher="Microsoft" />
     <DisplayName>VisualStudio Editors </DisplayName>
     <Description>Microsoft VisualStudio Editors</Description>
-    <ShortcutPath>..\CommonExtensions\Microsoft\VisualStudio\Editors</ShortcutPath>
     <PackageId>Microsoft.VisualStudio.Editors</PackageId>
   </Metadata>
   <Installation SystemComponent="true" >


### PR DESCRIPTION
VSIX V3 installs through the setup engine and doesn't get installed via VSIXinstaller.exe anymore. This breaks the 'ShortcutPath' . The recommend way is to use ExtensionInstallationFolder and ExtensionInstallationRoot instead to place the extension under commonextensions. This also introduces the dependency on RC.2 Nuget package from VSSDK.
.
@srivatsn @basoundr @dotnet/project-system 

**Escrow Template**:

Customer scenario – Property pages are not showing up localized.
Bugs this fixes: https://devdiv.visualstudio.com/DevDiv/_workitems?id=296733&_a=edit
Workarounds - none
Risk – Low. 
Performance impact - None. 
Is this a regression? - Yes
Root cause analysis -VSIX V3 used to be installed by VSIXinstaller.exe and use to respect the 'Shortcut path'. This is currently being installed by setup engine and looks for  ExtensionInstallationRoot instead of shortcutpath.
How was the bug found? - Internal testing.

