### PR TITLE
Reverting the change to turn BrowseObject Visibility to false.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -16,33 +16,33 @@
     <DataSource Persistence="ProjectFile" Label="Configuration" HasConfigurationCondition="False" />
   </Rule.DataSource>
 
-  <StringProperty Name="ApplicationIcon" DisplayName="Application Icon" Visible="False" />
-  <StringProperty Name="TargetFrameworkMoniker" DisplayName="Target Framework Moniker" Visible="False">
+  <StringProperty Name="ApplicationIcon" DisplayName="Application Icon" Visible="True" />
+  <StringProperty Name="TargetFrameworkMoniker" DisplayName="Target Framework Moniker" Visible="True">
     <StringProperty.DataSource>
       <DataSource Persistence="ProjectFileWithInterception" PersistedName="TargetFrameworkMoniker" HasConfigurationCondition="False" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="AssemblyName" DisplayName="Assembly Name" Visible="False"/>
-  <StringProperty Name="Name" Visible="False" />
-  <StringProperty Name="RootNamespace" DisplayName="Root namespace" Visible="False"/>
-  <StringProperty Name="DefaultNamespace" DisplayName="Default namespace" Visible="False">
+  <StringProperty Name="AssemblyName" DisplayName="Assembly Name" Visible="True"/>
+  <StringProperty Name="Name" Visible="True" />
+  <StringProperty Name="RootNamespace" DisplayName="Root namespace" Visible="True"/>
+  <StringProperty Name="DefaultNamespace" DisplayName="Default namespace" Visible="True">
     <StringProperty.DataSource>
       <DataSource PersistedName="RootNamespace" Persistence="ProjectFile" Label="Configuration" HasConfigurationCondition="false" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="TargetFrameworks" DisplayName="Target Frameworks" Visible="False">
+  <StringProperty Name="TargetFrameworks" DisplayName="Target Frameworks" Visible="True">
         <StringProperty.DataSource>
             <DataSource Persistence="ProjectFile" PersistedName="TargetFrameworks" HasConfigurationCondition="False" />
         </StringProperty.DataSource>
   </StringProperty>
-    <IntProperty Name="TargetFramework" ReadOnly="True" Visible="False">
+    <IntProperty Name="TargetFramework" ReadOnly="True" Visible="True">
     <IntProperty.DataSource>
       <DataSource Persistence="ProjectFileWithInterception" PersistedName="TargetFramework" />
     </IntProperty.DataSource>
   </IntProperty>
-  <StringProperty Name="OutputName" Visible="False" />
-  <DynamicEnumProperty Name="OutputType" DisplayName="Output Type" EnumProvider="OutputTypeEnumProvider" Visible="False"/>
-  <EnumProperty Name="OutputTypeEx" DisplayName="Output Type" Visible="False">
+  <StringProperty Name="OutputName" Visible="True" />
+  <DynamicEnumProperty Name="OutputType" DisplayName="Output Type" EnumProvider="OutputTypeEnumProvider" Visible="True"/>
+  <EnumProperty Name="OutputTypeEx" DisplayName="Output Type" Visible="True">
     <EnumValue Name="winexe" DisplayName="0" />
     <EnumValue Name="exe" DisplayName="1" />
     <EnumValue Name="library" DisplayName="2" />
@@ -52,50 +52,50 @@
       <DataSource Persistence="ProjectFile" PersistedName="OutputType" />
     </EnumProperty.DataSource>
   </EnumProperty>
-  <StringProperty Name="StartupObject" DisplayName="Type that contains the entry point" Visible="False"/>
-  <StringProperty Name="ApplicationManifest" DisplayName="Application Manifest" Visible="False">
+  <StringProperty Name="StartupObject" DisplayName="Type that contains the entry point" Visible="True"/>
+  <StringProperty Name="ApplicationManifest" DisplayName="Application Manifest" Visible="True">
     <StringProperty.DataSource>
       <DataSource Persistence="ProjectFileWithInterception" PersistedName="ApplicationManifest" HasConfigurationCondition="false" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="Win32ResourceFile" DisplayName="Win32 Resource File" Visible="False">
+  <StringProperty Name="Win32ResourceFile" DisplayName="Win32 Resource File" Visible="True">
     <StringProperty.DataSource>
       <DataSource Persistence="ProjectFile" PersistedName="Win32Resource" HasConfigurationCondition="False" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="DefineConstants" DisplayName="Define Constants" Visible="False"/>
-  <EnumProperty Name="PlatformTarget" DisplayName="Platform Target" Visible="False"/>
-  <StringProperty Name="Prefer32Bit" DisplayName="Prefer 32Bit" Visible="False"/>
-  <StringProperty Name="AllowUnsafeBlocks"  Default="False"  DisplayName="Allow unsafe code" Visible="False"/>
-  <StringProperty Name="Optimize" DisplayName="Optimize" Visible="False"/>
-  <EnumProperty Name="WarningLevel" DisplayName="Warning Level" Visible="False"/>
-  <StringProperty Name="NoWarn" DisplayName="Supress Warning" Visible="False"/>
-  <BoolProperty Name="TreatWarningsAsErrors"  Default="False" Description="Treat warnings as errors" Visible="False"/>
-  <StringProperty Name="OutputPath" DisplayName="Output Path" Visible="False"/>
-  <StringProperty Name="DocumentationFile" DisplayName="Documentation file" Visible="False"/>
-  <EnumProperty Name="GenerateSerializationAssemblies" DisplayName="Generate serialization assemblies" Visible="False">
+  <StringProperty Name="DefineConstants" DisplayName="Define Constants" Visible="True"/>
+  <EnumProperty Name="PlatformTarget" DisplayName="Platform Target" Visible="True"/>
+  <StringProperty Name="Prefer32Bit" DisplayName="Prefer 32Bit" Visible="True"/>
+  <StringProperty Name="AllowUnsafeBlocks"  Default="False"  DisplayName="Allow unsafe code" Visible="True"/>
+  <StringProperty Name="Optimize" DisplayName="Optimize" Visible="True"/>
+  <EnumProperty Name="WarningLevel" DisplayName="Warning Level" Visible="True"/>
+  <StringProperty Name="NoWarn" DisplayName="Supress Warning" Visible="True"/>
+  <BoolProperty Name="TreatWarningsAsErrors"  Default="False" Description="Treat warnings as errors" Visible="True"/>
+  <StringProperty Name="OutputPath" DisplayName="Output Path" Visible="True"/>
+  <StringProperty Name="DocumentationFile" DisplayName="Documentation file" Visible="True"/>
+  <EnumProperty Name="GenerateSerializationAssemblies" DisplayName="Generate serialization assemblies" Visible="True">
     <EnumValue Name="Auto" DisplayName="Auto" IsDefault="True" />
     <EnumValue Name="On" DisplayName="On" />
     <EnumValue Name="Off" DisplayName="Off" />
   </EnumProperty>
-  <EnumProperty Name="LanguageVersion" DisplayName="Language version" Visible="False"/>
-  <EnumProperty Name="ErrorReport" DisplayName="Error report" Visible="False"/>
-  <EnumProperty Name="DebugInfo" DisplayName="Debug Info" Visible="False">
+  <EnumProperty Name="LanguageVersion" DisplayName="Language version" Visible="True"/>
+  <EnumProperty Name="ErrorReport" DisplayName="Error report" Visible="True"/>
+  <EnumProperty Name="DebugInfo" DisplayName="Debug Info" Visible="True">
     <EnumProperty.DataSource>
       <DataSource Persistence="ProjectFile" PersistedName="DebugType" />
     </EnumProperty.DataSource>
   </EnumProperty>
-  <StringProperty Name="DebugSymbols" DisplayName="Debug symbols" Visible="False"/>
-  <EnumProperty Name="FileAlignment" DisplayName="File Alignment" Visible="False"/>
-  <StringProperty Name="BaseAddress" DisplayName="Base address" Visible="False"/>
-  <StringProperty Name="PreBuildEvent" DisplayName="Pre Build Event" Visible="False"/>
-  <StringProperty Name="PostBuildEvent" DisplayName="Post Build Event" Visible="False"/>
-  <EnumProperty Name="RunPostBuildEvent" DisplayName="Run Post Build Event" Visible="False">
+  <StringProperty Name="DebugSymbols" DisplayName="Debug symbols" Visible="True"/>
+  <EnumProperty Name="FileAlignment" DisplayName="File Alignment" Visible="True"/>
+  <StringProperty Name="BaseAddress" DisplayName="Base address" Visible="True"/>
+  <StringProperty Name="PreBuildEvent" DisplayName="Pre Build Event" Visible="True"/>
+  <StringProperty Name="PostBuildEvent" DisplayName="Post Build Event" Visible="True"/>
+  <EnumProperty Name="RunPostBuildEvent" DisplayName="Run Post Build Event" Visible="True">
     <EnumValue Name="Always" DisplayName="Always" />
     <EnumValue Name="OnBuildSuccess" DisplayName="On successful build"  IsDefault="True" />
     <EnumValue Name="OnOutputUpdated" DisplayName="When the build updates the project output" />
   </EnumProperty>
-  <StringProperty Name="ReferencePath" DisplayName="Reference Path" Visible="False"/>
+  <StringProperty Name="ReferencePath" DisplayName="Reference Path" Visible="True"/>
   <StringProperty Name="FileName" DisplayName="Project File" ReadOnly="True">
     <StringProperty.DataSource>
       <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectFile" />
@@ -106,71 +106,71 @@
       <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="LocalPath" ReadOnly="True" Visible="False">
+  <StringProperty Name="LocalPath" ReadOnly="True" Visible="True">
     <StringProperty.DataSource>
       <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" />
     </StringProperty.DataSource>
   </StringProperty>
 
   <!--AssemblyInfo properties-->
-  <StringProperty Name="Title" DisplayName="Assembly Title" Visible="False">
+  <StringProperty Name="Title" DisplayName="Assembly Title" Visible="True">
     <StringProperty.DataSource>
       <DataSource Persistence="SourceFile" HasConfigurationCondition="False" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="Description" DisplayName="Assembly Description" Visible="False">
+  <StringProperty Name="Description" DisplayName="Assembly Description" Visible="True">
     <StringProperty.DataSource>
       <DataSource Persistence="SourceFile" HasConfigurationCondition="False" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="Company" DisplayName="Company" Visible="False">
+  <StringProperty Name="Company" DisplayName="Company" Visible="True">
     <StringProperty.DataSource>
       <DataSource Persistence="SourceFile" HasConfigurationCondition="False" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="Product" DisplayName="Product" Visible="False">
+  <StringProperty Name="Product" DisplayName="Product" Visible="True">
     <StringProperty.DataSource>
       <DataSource Persistence="SourceFile" HasConfigurationCondition="False" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="Copyright" DisplayName="Copyright" Visible="False">
+  <StringProperty Name="Copyright" DisplayName="Copyright" Visible="True">
     <StringProperty.DataSource>
       <DataSource Persistence="SourceFile" HasConfigurationCondition="False" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="Trademark" DisplayName="Trademark" Visible="False" >
+  <StringProperty Name="Trademark" DisplayName="Trademark" Visible="True" >
     <StringProperty.DataSource>
       <DataSource Persistence="SourceFile" HasConfigurationCondition="False" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="AssemblyVersion" DisplayName="Assembly Version" Visible="False">
+  <StringProperty Name="AssemblyVersion" DisplayName="Assembly Version" Visible="True">
     <StringProperty.DataSource>
       <DataSource Persistence="SourceFile" HasConfigurationCondition="False" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="AssemblyFileVersion" DisplayName="Assembly FileVersion" Visible="False">
+  <StringProperty Name="AssemblyFileVersion" DisplayName="Assembly FileVersion" Visible="True">
     <StringProperty.DataSource>
       <DataSource Persistence="SourceFile" HasConfigurationCondition="False" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="AssemblyGuid" DisplayName="Assembly Guid" Visible="False">
+  <StringProperty Name="AssemblyGuid" DisplayName="Assembly Guid" Visible="True">
     <StringProperty.DataSource>
       <DataSource Persistence="SourceFile" HasConfigurationCondition="False" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="NeutralResourcesLanguage" DisplayName="Neutral Resources Language" Visible="False">
+  <StringProperty Name="NeutralResourcesLanguage" DisplayName="Neutral Resources Language" Visible="True">
     <StringProperty.DataSource>
       <DataSource Persistence="SourceFile" HasConfigurationCondition="False" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="ComVisible" DisplayName="ComVisible" Visible="False">
+  <StringProperty Name="ComVisible" DisplayName="ComVisible" Visible="True">
     <StringProperty.DataSource>
       <DataSource Persistence="SourceFile" HasConfigurationCondition="False" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="SignAssembly" DisplayName="Sign the assembly" Visible="False"/>
-  <StringProperty Name="DelaySign" DisplayName="Delay sign only" Visible="False"/>
-  <StringProperty Name="AssemblyOriginatorKeyFile" DisplayName="Strong name key file" Visible="False">
+  <StringProperty Name="SignAssembly" DisplayName="Sign the assembly" Visible="True"/>
+  <StringProperty Name="DelaySign" DisplayName="Delay sign only" Visible="True"/>
+  <StringProperty Name="AssemblyOriginatorKeyFile" DisplayName="Strong name key file" Visible="True">
     <StringProperty.DataSource>
       <DataSource Persistence="ProjectFileWithInterception" PersistedName="AssemblyOriginatorKeyFile" />
     </StringProperty.DataSource>


### PR DESCRIPTION
I turned Visibility to False to address #389 , which hides the property from the browse object but CPS doesn't handle the changes to those properties due to a different descriptor being fired. Till we find a better fix, reverting the change to address #841, #814 

@srivatsn @davkean 

**Escrow Template:**

Customer scenario – Edit to the property pages are not persisted.
Bugs this fixes: #841, #814 
Workarounds - none
Risk – Low.
Performance impact - None.
Is this a regression? - Yes
Root cause analysis - Turning the visibility to false to hide from browser object , triggers different descriptor which CPS needs to handle. This is reverting the changes i did #775
How was the bug found? - Internal testing.

@MattGertz  for RC.2 Approval
