### PR TITLE
Adding .netcoreapp1.1 to the list of tfms

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkMoniker.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkMoniker.vb
@@ -55,6 +55,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Next
 
             supportedFrameworksList.Add(".NETCoreApp,Version=v1.0")
+            supportedFrameworksList.Add(".NETCoreApp,Version=v1.1")
             supportedFrameworksList.Add(".NETStandard,Version=v1.0")
             supportedFrameworksList.Add(".NETStandard,Version=v1.1")
             supportedFrameworksList.Add(".NETStandard,Version=v1.2")


### PR DESCRIPTION
fixes #869 
Already reviewed at #863

**Escrow Template:**

Customer scenario – Properties page missing .net core app 1.1 from the list of options.
Bugs this fixes: #869
Workarounds - none
Risk – Low.
Performance impact - None.
Is this a regression? - No
Root cause analysis - The option was missed out from the list of options provided.
How was the bug found? - Internal testing.

@MattGertz for RC.2 Approval