### PR TITLE
Fix Watson crash caused by project unload while ProjectLockFileWatcher.FilesChanged is running

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectLockFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectLockFileWatcher.cs
@@ -165,12 +165,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                     {
                         using (var access = await _projectLockService.WriteLockAsync())
                         {
-                        // notify all the loaded configured projects
-                        var currentProjects = _projectServices.Project.LoadedConfiguredProjects;
+                            // notify all the loaded configured projects
+                            var currentProjects = _projectServices.Project.LoadedConfiguredProjects;
                             foreach (var configuredProject in currentProjects)
                             {
-                            // Inside a write lock, we should get back to the same thread.
-                            var project = await access.GetProjectAsync(configuredProject).ConfigureAwait(true);
+                                // Inside a write lock, we should get back to the same thread.
+                                var project = await access.GetProjectAsync(configuredProject).ConfigureAwait(true);
                                 project.MarkDirty();
                                 configuredProject.NotifyProjectChange();
                             }


### PR DESCRIPTION
As diagnosed by @lifengl, an ObjectDisposedException can happen when the project is unloading while the forked task in `ProjectLockFileWatcher.FilesChanged` is running.
Put forked notify project change task into a LoadedProjectAsync() context 
Fixes [#296591](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/296591)

**Customer scenario** – A Watson is reported when project is unloaded while project system is responding to changes in project assets file (e.g. soon after a restore.) NOTE: I have not been able to repro this manually.
**Bugs this fixes**:  [#296591](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/296591)
**Workarounds** - N/A
**Risk** – Low
**Fix** - We wrap the FileChanged handler in a LoadedProjectAsync context as recommended by CPS team, and further wrap that in a Try-Catch.
**Performance impact**  - Low
**Is this a regression?** - No
**Root cause analysis** - This was a missed CPS pattern. If project is unloaded before certain CPS operations are performed, an ObjectDisposedException is thrown
**How was the bug found?** - New Watson Report

/cc @srivatsn @lifengl