### PR TITLE
Construct a path with just the folder name of the project root filepath

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectItemProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectItemProviderFactory.cs
@@ -28,7 +28,8 @@ namespace Microsoft.VisualStudio.Mocks
                     // Find the node that has the parent folder and add the new node as a child.
                     foreach (var node in inputTree.GetSelfAndDescendentsBreadthFirst())
                     {
-                        if (node.FilePath.TrimEnd(Path.DirectorySeparatorChar).Equals(parentFolder))
+                        string nodeFolderPath = node.IsFolder ? node.FilePath : Path.GetDirectoryName(node.FilePath);
+                        if (nodeFolderPath.TrimEnd(Path.DirectorySeparatorChar).Equals(parentFolder))
                         {
                             IProjectTree child;
                             if (node.TryFindImmediateChild(fileName, out child) && !child.Flags.IsIncludedInProject())

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviderTests.cs
@@ -41,30 +41,30 @@ namespace Microsoft.VisualStudio.ProjectSystem
         [Theory]
         // No file - return default path.
         [InlineData(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder AppDesignerFolder}), FilePath: ""C:\Foo\Properties""
 ", @"C:\Foo\Settings.settings")]
         // File in app designer folder
         [InlineData(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder AppDesignerFolder}), FilePath: ""C:\Foo\Properties""
         Settings.settings, FilePath: ""C:\Foo\Properties\Settings.settings""
 ", @"C:\Foo\Properties\Settings.settings")]
         // File in root folder.
         [InlineData(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder AppDesignerFolder}), FilePath: ""C:\Foo\Properties""
     Settings.settings, FilePath: ""C:\Foo\Settings.settings""
 ", @"C:\Foo\Settings.settings")]
         // Linked file inside app designer folder.
         [InlineData(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder AppDesignerFolder}), FilePath: ""C:\Foo\Properties""
         Settings.settings (flags: {Linked}), FilePath: ""C:\SomeOtherPath\Settings.settings""
 ", @"C:\SomeOtherPath\Settings.settings")]
         // File inside a non-app designer folder - return default path.
         [InlineData(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder}), FilePath: ""C:\Foo\Properties""
         Settings.settings, FilePath: ""C:\Foo\Properties\Settings.settings""
 ", @"C:\Foo\Settings.settings")]
@@ -85,13 +85,13 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
         [Theory]
         // File exists in the root folder.
         [InlineData(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder AppDesignerFolder}), FilePath: ""C:\Foo\Properties""
     App.config, FilePath: ""C:\Foo\App.config""
 ", @"C:\Foo\App.config")]
         // File exists in the app designer folder - should return default path under root.
         [InlineData(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder AppDesignerFolder}), FilePath: ""C:\Foo\Properties""
         App.config, FilePath: ""C:\Foo\Properties\App.config""
 ", @"C:\Foo\App.config")]
@@ -112,7 +112,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
         [Theory]
         // A folder with the right name exists at the right place - should return default path under root.
         [InlineData(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder AppDesignerFolder}), FilePath: ""C:\Foo\Properties""
         Settings.settings (flags: {Folder}), FilePath: ""C:\Foo\Properties\Settings.settings""
 ", @"C:\Foo\Settings.settings")]
@@ -133,13 +133,13 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
         [Theory]
         // A file exists in the tree but not in the file system
         [InlineData(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder AppDesignerFolder}), FilePath: ""C:\Foo\Properties""
         Settings.settings, FilePath: ""C:\Foo\Properties\Settings.settings""
 ", /*fileExistsOnDisk*/ false, @"C:\Foo\Settings.settings")]
         // A file exists on disk but is not included in the project.
         [InlineData(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder AppDesignerFolder}), FilePath: ""C:\Foo\Properties""
         Settings.settings (flags: {IncludeInProjectCandidate}), FilePath: ""C:\Foo\Properties\Settings.settings""
 ", /*fileExistsOnDisk*/ true, @"C:\Foo\Settings.settings")]
@@ -159,10 +159,10 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
 
         [Theory]
         [InlineData(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder AppDesignerFolder}), FilePath: ""C:\Foo\Properties""
 ", @"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder AppDesignerFolder}), FilePath: ""C:\Foo\Properties""
         Settings.settings, FilePath: ""C:\Foo\Properties\Settings.settings""
 ", @"C:\Foo\Properties\Settings.settings")]
@@ -190,10 +190,10 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
 
         [Theory]
         [InlineData(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder AppDesignerFolder}), FilePath: ""C:\Foo\Properties""
 ", @"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder AppDesignerFolder}), FilePath: ""C:\Foo\Properties""
     App.config, FilePath: ""C:\Foo\App.config""
 ", @"C:\Foo\App.config")]
@@ -222,21 +222,21 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
         [Theory]
         // A file exists in the tree but not in the file system
         [InlineData(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder AppDesignerFolder}), FilePath: ""C:\Foo\Properties""
         Settings.settings, FilePath: ""C:\Foo\Properties\Settings.settings""
 ", @"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder AppDesignerFolder}), FilePath: ""C:\Foo\Properties""
         Settings.settings, FilePath: ""C:\Foo\Properties\Settings.settings""
 ", /*fileExistsOnDisk*/ false, @"C:\Foo\Properties\Settings.settings")]
         // A file exists on disk but is not included in the project.
         [InlineData(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder AppDesignerFolder}), FilePath: ""C:\Foo\Properties""
         Settings.settings (flags: {IncludeInProjectCandidate}), FilePath: ""C:\Foo\Properties\Settings.settings""
 ", @"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder AppDesignerFolder}), FilePath: ""C:\Foo\Properties""
         Settings.settings, FilePath: ""C:\Foo\Properties\Settings.settings""
 ", /*fileExistsOnDisk*/ true, @"C:\Foo\Properties\Settings.settings")]
@@ -267,10 +267,10 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
         [Theory]
         // A file exists in the tree but not in the file system
         [InlineData(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder AppDesignerFolder}), FilePath: ""C:\Foo\Properties""
 ", @"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\""
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder AppDesignerFolder}), FilePath: ""C:\Foo\Properties""
         Settings.settings, FilePath: ""C:\Foo\Properties\Settings.settings""
 ", @"C:\Foo\Properties\Settings.settings")]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
@@ -99,7 +99,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
             // We haven't found the file but return the default file path as that's the contract.
             IProjectTree rootNode = _projectTreeService.CurrentTree.Tree;
             string rootFilePath = _projectTreeService.CurrentTree.TreeProvider.GetPath(rootNode);
-            string fullPath = Path.Combine(Path.GetDirectoryName(rootFilePath), specialFileName);
+            string fullPath = Path.Combine(
+                rootNode.IsFolder ? rootFilePath : Path.GetDirectoryName(rootFilePath),
+                specialFileName);
             return fullPath;
         }
 
@@ -216,7 +218,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
             else
             {
                 var parentPath = _projectTreeService.CurrentTree.TreeProvider.GetPath(parentNode);
-                var specialFilePath = Path.Combine(parentPath, specialFileName);
+                var specialFilePath = Path.Combine(
+                    parentNode.IsFolder ? parentPath : Path.GetDirectoryName(parentPath),
+                    specialFileName);
                 _fileSystem.Create(specialFilePath);
                 IProjectItem item = await _sourceItemsProvider.AddAsync(specialFilePath).ConfigureAwait(false);
                 if (item != null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
@@ -99,9 +99,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
             // We haven't found the file but return the default file path as that's the contract.
             IProjectTree rootNode = _projectTreeService.CurrentTree.Tree;
             string rootFilePath = _projectTreeService.CurrentTree.TreeProvider.GetPath(rootNode);
-            string fullPath = Path.Combine(
-                rootNode.IsFolder ? rootFilePath : Path.GetDirectoryName(rootFilePath),
-                specialFileName);
+            string fullPath = Path.Combine(Path.GetDirectoryName(rootFilePath), specialFileName);
             return fullPath;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
             // We haven't found the file but return the default file path as that's the contract.
             IProjectTree rootNode = _projectTreeService.CurrentTree.Tree;
             string rootFilePath = _projectTreeService.CurrentTree.TreeProvider.GetPath(rootNode);
-            string fullPath = Path.Combine(rootFilePath, specialFileName);
+            string fullPath = Path.Combine(Path.GetDirectoryName(rootFilePath), specialFileName);
             return fullPath;
         }
 


### PR DESCRIPTION
Without the fix, we were always assuming that the Root node's file path is the folder containing the project file but the root node is actually the project file. Hence, when constructing the file path for new files, check if the filepath for the node, which is used for calculating the path, is a folder or a file and extract the folder path appropriately.

@dotnet/project-system @srivatsn for review

This change will fix the [Bug 286604:Adding Settings file crashes VS](https://devdiv.visualstudio.com/DevDiv/_workitems?id=286604&triage=true&_a=edit) but the issue #572 will be there.