### PR TITLE
Ngen the editor binaries

### DIFF
--- a/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
+++ b/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
@@ -29,6 +29,11 @@
     <ProjectSystemLayer>VisualStudio</ProjectSystemLayer>
     <ProducingSignedVsix>true</ProducingSignedVsix>
     <IsProductComponent>true</IsProductComponent>
+    <InstallRoot>Default</InstallRoot>
+    <Ngen>true</Ngen>
+    <NgenApplication>vsn.exe</NgenApplication>
+    <NgenArchitecture>All</NgenArchitecture>
+    <NgenPriority>3</NgenPriority>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>
@@ -41,6 +46,10 @@
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
       <Private>True</Private>
+      <Ngen>true</Ngen>
+      <NgenApplication>vsn.exe</NgenApplication>
+      <NgenArchitecture>All</NgenArchitecture>
+      <NgenPriority>3</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.VisualStudio.Editors\Microsoft.VisualStudio.Editors.vbproj">
       <Project>{CD6E5D00-7B0B-442D-9F5D-EAEC1A71838A}</Project>
@@ -48,6 +57,10 @@
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3bPkgdefProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
       <Private>True</Private>
+      <Ngen>true</Ngen>
+      <NgenApplication>vsn.exe</NgenApplication>
+      <NgenArchitecture>All</NgenArchitecture>
+      <NgenPriority>3</NgenPriority>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/VisualStudioEditorsSetup/source.extension.vsixmanifest
+++ b/src/VisualStudioEditorsSetup/source.extension.vsixmanifest
@@ -13,12 +13,6 @@
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VWDExpress" />
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VSWinExpress" />
   </Installation>
-  <Installer>
-    <Actions>
-      <Action Type="Ngen" Path="Microsoft.VisualStudio.Editors.dll" />
-      <Action Type="Ngen" Path="Microsoft.VisualStudio.AppDesigner.dll" />
-    </Actions>
-  </Installer>
   <Prerequisites>
     <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />   
   </Prerequisites>  


### PR DESCRIPTION
VSSDK is no longer using the Ngen Action to Ngen the binaries. This is the new recommended way to ngen the binaries

@mavasani @tannergooding @dotnet/project-system for review