### PR TITLE
Simplify special file/template name lookup

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp/ProjectSystem/SpecialFileProviders/CSharpAssemblyInfoSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp/ProjectSystem/SpecialFileProviders/CSharpAssemblyInfoSpecialFileProvider.cs
@@ -19,14 +19,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         {
         }
 
-        protected override string GetFileNameOfSpecialFile(SpecialFiles fileId)
-        {
-            return "AssemblyInfo.cs";
-        }
+        protected override string Name => "AssemblyInfo.cs";
 
-        protected override string GetTemplateForSpecialFile(SpecialFiles fileId)
-        {
-            return "AssemblyInfoInternal.zip";
-        }
+        protected override string TemplateName => "AssemblyInfoInternal.zip";
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppConfigFileSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppConfigFileSpecialFileProvider.cs
@@ -20,17 +20,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         {
         }
 
-        protected override string GetFileNameOfSpecialFile(SpecialFiles fileId)
-        {
-            Assert(fileId == SpecialFiles.AppConfig);
-            return "App.config";
-        }
+        protected override string Name => "App.config";
 
-        protected override string GetTemplateForSpecialFile(SpecialFiles fileId)
-        {
-            Assert(fileId == SpecialFiles.AppConfig);
-            return "AppConfigurationInternal.zip";
-        }
+        protected override string TemplateName => "AppConfigurationInternal.zip";
 
         protected override bool CreatedByDefaultUnderAppDesignerFolder => false;
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/ResourcesFileSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/ResourcesFileSpecialFileProvider.cs
@@ -20,16 +20,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         {
         }
 
-        protected override string GetFileNameOfSpecialFile(SpecialFiles fileId)
-        {
-            Assert(fileId == SpecialFiles.AssemblyResource);
-            return "Resources.resx";
-        }
+        protected override string Name => "Resources.resx";
 
-        protected override string GetTemplateForSpecialFile(SpecialFiles fileId)
-        {
-            Assert(fileId == SpecialFiles.AssemblyResource);
-            return "ResourceInternal.zip";
-        }
+        protected override string TemplateName => "ResourceInternal.zip";
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/SettingsFileSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/SettingsFileSpecialFileProvider.cs
@@ -20,16 +20,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         {
         }
 
-        protected override string GetFileNameOfSpecialFile(SpecialFiles fileId)
-        {
-            Assert(fileId == SpecialFiles.AppSettings);
-            return "Settings.settings";
-        }
+        protected override string Name => "Settings.settings";
 
-        protected override string GetTemplateForSpecialFile(SpecialFiles fileId)
-        {
-            Assert(fileId == SpecialFiles.AppSettings);
-            return "SettingsInternal.zip";
-        }
+        protected override string TemplateName => "SettingsInternal.zip";
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic/ProjectSystem/SpecialFileProviders/BasicAssemblyInfoSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic/ProjectSystem/SpecialFileProviders/BasicAssemblyInfoSpecialFileProvider.cs
@@ -19,14 +19,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         {
         }
 
-        protected override string GetFileNameOfSpecialFile(SpecialFiles fileId)
-        {
-            return "AssemblyInfo.vb";
-        }
+        protected override string Name => "AssemblyInfo.vb";
 
-        protected override string GetTemplateForSpecialFile(SpecialFiles fileId)
-        {
-            return "AssemblyInfoInternal.zip";
-        }
+        protected override string TemplateName => "AssemblyInfoInternal.zip";
     }
 }


### PR DESCRIPTION
We never diff the filename/template based on the special file - so turn methods -> properties. I suspect this was done to original differ between C#/VB, however, now we have separate components for those.