### PR TITLE
Introduce Code Marker that is fired when project restore completes

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
@@ -140,7 +140,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
                     {
                         await _solutionRestoreService
                                .NominateProjectAsync(_projectVsServices.Project.FullPath, projectRestoreInfo, CancellationToken.None)
-                               .ConfigureAwait(true);
+                               .ConfigureAwait(false);
 
                         Microsoft.Internal.Performance.CodeMarkers.Instance.CodeMarker(perfPackageRestoreEnd);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
@@ -25,6 +25,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         private IDisposable _evaluationSubscriptionLink;
         private IDisposable _targetFrameworkSubscriptionLink;
 
+        private const int perfPackageRestoreEnd = 7343;
+
         private static ImmutableHashSet<string> _targetFrameworkWatchedRules = Empty.OrdinalIgnoreCaseStringSet
             .Add(NuGetRestore.SchemaName);
 
@@ -134,9 +136,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             if (projectRestoreInfo != null)
             {
                 _projectVsServices.Project.Services.ProjectAsynchronousTasks
-                    .RegisterCriticalAsyncTask(JoinableFactory.RunAsync(() => _solutionRestoreService
-                            .NominateProjectAsync(_projectVsServices.Project.FullPath, projectRestoreInfo, CancellationToken.None)),
-                            registerFaultHandler: true);
+                    .RegisterCriticalAsyncTask(JoinableFactory.RunAsync(async () =>
+                    {
+                        await _solutionRestoreService
+                               .NominateProjectAsync(_projectVsServices.Project.FullPath, projectRestoreInfo, CancellationToken.None)
+                               .ConfigureAwait(true);
+
+                        Microsoft.Internal.Performance.CodeMarkers.Instance.CodeMarker(perfPackageRestoreEnd);
+
+                    }), registerFaultHandler: true);
             }
 
             return Task.CompletedTask;


### PR DESCRIPTION
Introduce Code Marker that is fired when project restore completes for Performance tests

Fixes #590

WIP: Currently validating if this approach works

