### PR TITLE
Output type designer error

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
+++ b/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
@@ -193,5 +193,11 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Dependencies\CPS\CPS.csproj">
+      <Project>{03ab838c-1b9d-4eca-856f-476616c35f0c}</Project>
+      <Name>CPS</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="..\..\build\Targets\VSL.Imports.targets" />
 </Project>

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyControlData.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyControlData.vb
@@ -1,11 +1,12 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.ComponentModel
 Imports System.ComponentModel.Design
 Imports System.Windows.Forms
-Imports Common = Microsoft.VisualStudio.Editors.AppDesCommon
 Imports Microsoft.VisualStudio.Shell.Interop
-Imports System.ComponentModel
+Imports Microsoft.VisualStudio.ProjectSystem.Properties
 
+Imports Common = Microsoft.VisualStudio.Editors.AppDesCommon
 Imports VSITEMID = Microsoft.VisualStudio.Editors.VSITEMIDAPPDES
 
 Namespace Microsoft.VisualStudio.Editors.PropertyPages
@@ -1537,9 +1538,24 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Debug.Assert(Extender IsNot Nothing)
 
             'Note: For property get we must pass in the extended object as the component.
-            Return Descriptor.GetValue(Extender)
+            Return GetValue(Descriptor, Extender)
         End Function
 
+        ''' <summary>
+        ''' Gets the value of the specified property.
+        ''' </summary>
+        ''' <param name="Descriptor">Property descriptor used to retrieve the value</param>
+        ''' <param name="obj">Object containing the property data.</param>
+        ''' <returns>Value of the property to be used by the property control.</returns>
+        Private Shared Function GetValue(Descriptor As PropertyDescriptor, obj As Object) As Object
+            Dim descriptorValue As Object = Descriptor.GetValue(obj)
+            Dim valueAsIEnumValue As IEnumValue = TryCast(descriptorValue, IEnumValue)
+            If valueAsIEnumValue Is Nothing Then
+                Return descriptorValue
+            Else
+                Return valueAsIEnumValue.DisplayName
+            End If
+        End Function
 
         ''' <summary>
         ''' Sets the current value of this property (into the project system, not into the 
@@ -1836,7 +1852,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Public Shared Function GetCommonPropertyValueNative(Descriptor As PropertyDescriptor, ProjectCommonPropertiesObject As Object) As Object
             Debug.Assert(Descriptor IsNot Nothing, "Calling GetCommonPropertyValue() on a property that could not be found [Descriptor Is Nothing]")
             Debug.Assert(ProjectCommonPropertiesObject IsNot Nothing)
-            Return Descriptor.GetValue(ProjectCommonPropertiesObject)
+            Return GetValue(Descriptor, ProjectCommonPropertiesObject)
         End Function
 
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/OutputTypeEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/OutputTypeEnumProvider.cs
@@ -48,13 +48,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             public Task<IEnumValue> TryCreateEnumValueAsync(string userSuppliedValue)
             {
+                string lowercasedValue = userSuppliedValue.ToLowerInvariant();
                 IEnumValue value;
-                if (_listedOutputTypeValues.TryGetValue(userSuppliedValue, out value))
+                if (_listedOutputTypeValues.TryGetValue(lowercasedValue, out value))
                 {
                     return Task.FromResult(value);
                 }
 
-                if (_mappedOutputTypeValues.TryGetValue(userSuppliedValue, out value))
+                if (_mappedOutputTypeValues.TryGetValue(lowercasedValue, out value))
                 {
                     return Task.FromResult(value);
                 }


### PR DESCRIPTION
This fixes #813 which was preventing the right output type from showing and causing cascading failures on anything that was comparing the output type value.