### PR TITLE
Fix for ProjectDebuggerProvider.QueryDebugTargetsAsync should wait for first snapshot

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectDebuggerProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectDebuggerProviderTests.cs
@@ -42,6 +42,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             _launchProviders.Add(new Lazy<IDebugProfileLaunchTargetsProvider, IOrderPrecedenceMetadataView>(() => _mockExeProvider.Object, mockMetadata.Object));
 
             _LaunchSettingsProviderMoq.Setup(x => x.ActiveProfile).Returns(() => _activeProfile);
+            _LaunchSettingsProviderMoq.Setup(x => x.WaitForFirstSnapshot(It.IsAny<int>())).Returns(() =>
+            {
+                if (_activeProfile != null)
+                {
+                    return Task.FromResult((ILaunchSettings)new LaunchSettings(new List<ILaunchProfile>() { _activeProfile }, null, _activeProfile.Name));
+                }
+
+                return Task.FromResult((ILaunchSettings)new LaunchSettings());
+            });
         }
         
         

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectDebuggerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectDebuggerProvider.cs
@@ -103,8 +103,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// </summary>
         public override async Task<IReadOnlyList<IDebugLaunchSettings>> QueryDebugTargetsAsync(DebugLaunchOptions launchOptions)
         {
-            // Get the active debug profile
-            ILaunchProfile activeProfile = LaunchSettingsProvider.ActiveProfile;
+            // Get the active debug profile (timeout of 5s, though in reality is should never take this long as even in error conditions
+            // a snapshot is produced).
+            var currentProfiles = await LaunchSettingsProvider.WaitForFirstSnapshot(5000).ConfigureAwait(true);
+            ILaunchProfile activeProfile = currentProfiles?.ActiveProfile;
 
             // Should have a profile
             if (activeProfile == null)


### PR DESCRIPTION
Addresses https://github.com/dotnet/roslyn-project-system/issues/740

@srivatsn @abpiskunov 