### PR TITLE
Change CreateFileTemplateService to take document moniker

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ICreateFileFromTemplateServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ICreateFileFromTemplateServiceFactory.cs
@@ -13,11 +13,9 @@ namespace Microsoft.VisualStudio.Mocks
         {
             var mock = new Mock<ICreateFileFromTemplateService>();
 
-            mock.Setup(s => s.CreateFileAsync(It.IsAny<string>(), It.IsAny<IProjectTree>(), It.IsAny<string>()))
-                .Returns<string, IProjectTree, string>((templateFile, parentNode, specialFileName) =>
+            mock.Setup(s => s.CreateFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns<string, string, string>((templateFile, parentNode, specialFileName) =>
                 {
-                    var newNode = ProjectTreeParser.Parse($@"{specialFileName}, FilePath: ""{Path.Combine(parentNode.FilePath, specialFileName)}""");
-                    parentNode.Add(newNode);
                     return Task.FromResult(true);
                 });
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviderTests.cs
@@ -294,7 +294,6 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
             var filePath = await provider.GetFileAsync(SpecialFiles.AppSettings, SpecialFileFlags.CreateIfNotExist);
 
             Assert.Equal(expectedFilePath, filePath);
-            AssertAreEquivalent(expectedTree, inputTree);
         }
 
         private void AssertAreEquivalent(IProjectTree expected, IProjectTree actual)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/CreateFileFromTemplateServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/CreateFileFromTemplateServiceTests.cs
@@ -50,22 +50,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         public async Task CreateFile_NullTemplateFile_ThrowsArgumentNull()
         {
             var service = CreateInstance();
-            var parentNode = ProjectTreeParser.Parse("Properties");
 
             await Assert.ThrowsAsync<ArgumentNullException>("templateFile", () =>
             {
-                return service.CreateFileAsync(null, parentNode, "FileName");
+                return service.CreateFileAsync(null, "ParentNode", "FileName");
             });
         }
 
         [Fact]
-        public async Task CreateFile_NullParentNode_ThrowsArgumentNull()
+        public async Task CreateFile_NullAsParentNode_ThrowsArgumentNull()
         {
             var service = CreateInstance();
 
-            await Assert.ThrowsAsync<ArgumentNullException>("parentNode", () =>
+            await Assert.ThrowsAsync<ArgumentNullException>("parentDocumentMoniker", () =>
             {
                 return service.CreateFileAsync("SomeFile", null, "FileName");
+            });
+        }
+
+        [Fact]
+        public async Task CreateFile_EmptyAsParentNode_ThrowsArgument()
+        {
+            var service = CreateInstance();
+
+            await Assert.ThrowsAsync<ArgumentException>("parentDocumentMoniker", () =>
+            {
+                return service.CreateFileAsync("SomeFile", string.Empty, "FileName");
             });
         }
 
@@ -73,11 +83,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         public async Task CreateFile_NullFileName_ThrowsArgumentNull()
         {
             var service = CreateInstance();
-            var parentNode = ProjectTreeParser.Parse("Properties");
 
             await Assert.ThrowsAsync<ArgumentNullException>("fileName", async () =>
             {
-                await service.CreateFileAsync("SomeFile", parentNode, null);
+                await service.CreateFileAsync("SomeFile", "ParentNode", null);
             });
         }
 
@@ -91,7 +100,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             string templateName = "SettingsInternal.zip";
             string fileName = "Settings.settings";
-            var inputTree = ProjectTreeParser.Parse(input);
 
             var hierarchy = IVsHierarchyFactory.Create();
             var solution = SolutionFactory.CreateWithGetProjectItemTemplate((templateFile, language) => 
@@ -104,7 +112,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             var vsProject = (IVsProject4)IVsHierarchyFactory.Create();
             vsProject.ImplementAddItemWithSpecific((itemId, itemOperation, itemName, cOpen, files, result) =>
             {
-                Assert.Equal((uint)inputTree.GetHierarchyId(), itemId);
                 Assert.Equal(VSADDITEMOPERATION.VSADDITEMOP_RUNWIZARD, itemOperation);
                 Assert.Equal(fileName, itemName);
                 Assert.Equal((uint)1, cOpen);
@@ -121,11 +128,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             var properties = CreateProperties();
             var service = new CreateFileFromTemplateService(projectVsServices, dteServices, properties);
 
-            bool returnValue = await service.CreateFileAsync(templateName, inputTree, fileName);
+            bool returnValue = await service.CreateFileAsync(templateName, "Moniker", fileName);
             Assert.Equal(returnValue, expectedResult);
         }
-
-        
 
         private CreateFileFromTemplateService CreateInstance()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CreateFileFromTemplateService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CreateFileFromTemplateService.cs
@@ -34,13 +34,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// Create a file with the given template file and add it to the parent node.
         /// </summary>
         /// <param name="templateFile">The name of the template zip file.</param>
-        /// <param name="parentNode">The node to which the new file will be added.</param>
+        /// <param name="parentDocumentMoniker">The path to the node to which the new file will be added.</param>
         /// <param name="fileName">The name of the file to be created.</param>
         /// <returns>true if file is added successfully.</returns>
-        public async Task<bool> CreateFileAsync(string templateFile, IProjectTree parentNode, string fileName)
+        public async Task<bool> CreateFileAsync(string templateFile, string parentDocumentMoniker, string fileName)
         {
             Requires.NotNull(templateFile, nameof(templateFile));
-            Requires.NotNull(parentNode, nameof(parentNode));
+            Requires.NotNullOrEmpty(parentDocumentMoniker, nameof(parentDocumentMoniker));
             Requires.NotNull(fileName, nameof(fileName));
 
             string templateLanguage = await GetTemplateLanguageAsync().ConfigureAwait(false);
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             if (templateFilePath != null)
             {
-                var parentId = parentNode.GetHierarchyId();
+                HierarchyId parentId = _projectVsServices.VsProject.GetHierarchyId(parentDocumentMoniker);
                 var result = new VSADDRESULT[1];
                 var files = new string[] { templateFilePath };
                 _projectVsServices.VsProject.AddItemWithSpecific(parentId, VSADDITEMOPERATION.VSADDITEMOP_RUNWIZARD, fileName, (uint)files.Length, files, IntPtr.Zero, 0, Guid.Empty, null, Guid.Empty, result);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ICreateFileFromTemplateService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ICreateFileFromTemplateService.cs
@@ -13,9 +13,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// Create a file with the given template file and add it to the parent node.
         /// </summary>
         /// <param name="templateFile">The name of the template zip file.</param>
-        /// <param name="parentNode">The node to which the new file will be added.</param>
+        /// <param name="parentDocumentMoniker">The path to the node to which the new file will be added.</param>
         /// <param name="fileName">The name of the file to be created.</param>
         /// <returns>true if file is added successfully.</returns>
-        Task<bool> CreateFileAsync(string templateFile, IProjectTree parentNode, string fileName);
+        Task<bool> CreateFileAsync(string templateFile, string parentDocumentMoniker, string fileName);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
@@ -118,7 +118,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
             IProjectTree specialFileNode;
 
             // First, we look in the AppDesigner folder.
-            IProjectTree appDesignerFolder = rootNode.Children.FirstOrDefault(child => child.IsFolder && child.Flags.HasFlag(ProjectTreeFlags.Common.AppDesignerFolder));
+            IProjectTree appDesignerFolder = GetAppDesignerFolder();
             if (appDesignerFolder != null && CreatedByDefaultUnderAppDesignerFolder)
             {
                 specialFileNode = FindFileWithinNode(appDesignerFolder, specialFileName);
@@ -199,8 +199,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         private async Task<string> CreateFileAsync(SpecialFiles fileId, string specialFileName)
         {
             IProjectTree rootNode = _projectTreeService.CurrentTree.Tree;
-            IProjectTree appDesignerFolder = rootNode.Children.FirstOrDefault(child => child.IsFolder && child.Flags.HasFlag(ProjectTreeFlags.Common.AppDesignerFolder));
-
+            IProjectTree appDesignerFolder = GetAppDesignerFolder();
             if (appDesignerFolder == null && CreatedByDefaultUnderAppDesignerFolder)
             {
                 return null;
@@ -243,6 +242,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
             }
 
             return null;
+        }
+
+        private IProjectTree GetAppDesignerFolder()
+        {
+            IProjectTree rootNode = _projectTreeService.CurrentTree.Tree;
+
+            return rootNode.Children.FirstOrDefault(child => child.IsFolder && child.Flags.HasFlag(ProjectTreeFlags.Common.AppDesignerFolder));
         }
     }
 }


### PR DESCRIPTION
In preparation for retrieving app designer folder from a special file handler (in a future change), which returns a path, we now take a "parentDocumentMoniker" instead of a IProjectTree to CreateFileFromTemplateService to avoid having to look up in the tree multiple times.