### PR TITLE
Filter updating the xml by msbuild path. This fixes internal bug 3593…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Editor/MsBuildModelWatcherTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Editor/MsBuildModelWatcherTests.cs
@@ -41,13 +41,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
             var file = @"C:\Test\Test.proj";
             var msbuildAccessor = IMsBuildAccessorFactory.ImplementGetProjectXmlAndXmlChangedEvents(xml, newSub => subscription = newSub,
                 sub => Assert.False(true, "Should not have called Unsubscribe in this test, as dispose isn't called."));
-            var project = IUnconfiguredProjectFactory.Create();
+            var project = IUnconfiguredProjectFactory.Create(filePath: file);
 
             var watcher = new MsBuildModelWatcher(threadingService, fileSystem, msbuildAccessor, project);
             await watcher.InitializeAsync(file, "");
 
             Assert.NotNull(subscription);
-            watcher.XmlHandler(xml);
+            watcher.XmlHandler(xml, file);
             Assert.True(fileSystem.FileExists(file));
             Assert.Equal(xml, fileSystem.ReadAllText(file));
         }
@@ -63,13 +63,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
             var file = @"C:\Test\Test.proj";
             var msbuildAccessor = IMsBuildAccessorFactory.ImplementGetProjectXmlAndXmlChangedEvents(xml, newSub => subscription = newSub,
                 sub => unsubscription = sub);
-            var project = IUnconfiguredProjectFactory.Create();
+            var project = IUnconfiguredProjectFactory.Create(filePath: file);
 
             var watcher = new MsBuildModelWatcher(threadingService, fileSystem, msbuildAccessor, project);
             await watcher.InitializeAsync(file, "");
 
             Assert.NotNull(subscription);
-            watcher.XmlHandler(xml);
+            watcher.XmlHandler(xml, file);
             Assert.True(fileSystem.FileExists(file));
             Assert.Equal(xml, fileSystem.ReadAllText(file));
 
@@ -92,20 +92,40 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
             var file = @"C:\Test\Test.proj";
             var msbuildAccessor = IMsBuildAccessorFactory.ImplementGetProjectXmlAndXmlChangedEvents(xml, newSub => subscription = newSub,
                 sub => Assert.False(true, "Should not have called Unsubscribe in this test, as dispose isn't called."));
-            var project = IUnconfiguredProjectFactory.Create();
+            var project = IUnconfiguredProjectFactory.Create(filePath: file);
 
             var watcher = new MsBuildModelWatcher(threadingService, fileSystem, msbuildAccessor, project);
             await watcher.InitializeAsync(file, "");
 
             Assert.NotNull(subscription);
-            watcher.XmlHandler(xml);
+            watcher.XmlHandler(xml, file);
             Assert.True(fileSystem.FileExists(file));
             Assert.Equal(xml, fileSystem.ReadAllText(file));
 
             // If we delete the underlying xml from the file system, a consectutive call to XmlHandler with the same xml should not regenerate
             // it.
             fileSystem.RemoveFile(file);
-            watcher.XmlHandler(xml);
+            watcher.XmlHandler(xml, file);
+            Assert.False(fileSystem.FileExists(file));
+        }
+
+        [Fact]
+        public async Task MsBuildModelWatcher_DifferentFile_DoesNotWriteToDisk()
+        {
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var fileSystem = new IFileSystemMock();
+            HandlerCallback subscription = null;
+            var xml = @"<Project></Project>";
+            var file = @"C:\Test\Test.proj";
+            var msbuildAccessor = IMsBuildAccessorFactory.ImplementGetProjectXmlAndXmlChangedEvents(xml, newSub => subscription = newSub,
+                sub => Assert.False(true, "Should not have called Unsubscribe in this test, as dispose isn't called."));
+            var project = IUnconfiguredProjectFactory.Create(filePath: file);
+
+            var watcher = new MsBuildModelWatcher(threadingService, fileSystem, msbuildAccessor, project);
+            await watcher.InitializeAsync(file, "");
+
+            Assert.NotNull(subscription);
+            watcher.XmlHandler(xml, @"C:\Test\AnotherTest.proj");
             Assert.False(fileSystem.FileExists(file));
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/MsBuildModelWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/MsBuildModelWatcher.cs
@@ -40,15 +40,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
 
         public void ProjectXmlHandler(object sender, ProjectXmlChangedEventArgs args)
         {
-            XmlHandler(args.ProjectXml.RawXml);
+            XmlHandler(args.ProjectXml.RawXml, args.ProjectXml.FullPath);
         }
 
         /// <summary>
         /// Because we can't construct an instance of ProjectxmlChangedEventArgs for testing purposes, I've extracted this functionality, and set up ProjectXmlHandler
         /// as a forwarder for the actual project xml.
         /// </summary>
-        internal void XmlHandler(string xml)
+        internal void XmlHandler(string xml, string projectPath)
         {
+            // Only write to the file if the project path matches the path for the project we're watching
+            if (!projectPath.Equals(_unconfiguredProject.FullPath)) return;
+
             // Dedup writes if the XML hasn't changed between now and the last write. We normalize the xml to remove all whitespace, and only compare the actual
             // xml content.
             var normalizedXml = Regex.Replace(xml, @"\s", "");

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/MsBuildModelWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/MsBuildModelWatcher.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         internal void XmlHandler(string xml, string projectPath)
         {
             // Only write to the file if the project path matches the path for the project we're watching
-            if (!projectPath.Equals(_unconfiguredProject.FullPath)) return;
+            if (!StringComparers.Paths.Equals(projectPath, _unconfiguredProject.FullPath)) return;
 
             // Dedup writes if the XML hasn't changed between now and the last write. We normalize the xml to remove all whitespace, and only compare the actual
             // xml content.


### PR DESCRIPTION
…73, where subscribing to ProjectCollection causes projects to overwrite each other.

@dotnet/project-system @davkean @jinujoseph for review. @MattGertz for servicing approval.

**Escrow Template**:
**Customer scenario** - Editing multiple project files at the same time can cause data loss.
**Bugs this fixes** - https://devdiv.visualstudio.com/DevDiv/_workitems?id=359373, https://github.com/dotnet/roslyn-project-system/issues/922
**Workarounds** - Only edit one project file at a time. This isn't something we can reasonably expect customers to do, and if customers aren't careful this can cause significant data loss.
**Risk** - Very low. This only adds an additional if check for short-circuiting when we shouldn't overwrite the temp file.
**Performance impact** - Negligible. This only adds a simple string comparison.
**Is this a regression** - Yes. 
**Root cause analysis** - Insufficient manual testing. We should add an integration test for this now that we have the ability to.
**How was the bug found?** - vsfeedback.