### PR TITLE
Stop creating zero byte files to get temp dir name

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -213,7 +213,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             _tempFile = tempFile;
         }
 
-        public string GetTempFileName()
+        public string GetTempDirectoryOrFileName()
         {
             return _tempFile;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/EditProjectFileCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/EditProjectFileCommand.cs
@@ -159,7 +159,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 
         private string GetTempFileName(string projectFileName)
         {
-            string tempDirectory = _fileSystem.GetTempFileName();
+            string tempDirectory = _fileSystem.GetTempDirectoryOrFileName();
             _fileSystem.CreateDirectory(tempDirectory);
             return $"{tempDirectory}\\{projectFileName}";
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/FileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/FileSystem.cs
@@ -112,22 +112,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
             return Directory.EnumerateFiles(path, searchPattern, searchOption);
         }
 
-        public string GetTempFileName()
+        public string GetTempDirectoryOrFileName()
         {
-            var tempFileName = Path.GetTempFileName();
-            try
-            {
-                if (File.Exists(tempFileName))
-                {
-                    File.Delete(tempFileName);
-                }
-            }
-            catch
-            {
-                // do nothing - its a temporary file
-            }
+            var fileNameWithoutPath = Path.GetRandomFileName();
 
-            return tempFileName;
+            return Path.Combine(Path.GetTempPath(), fileNameWithoutPath);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/IFileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/IFileSystem.cs
@@ -34,6 +34,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
         IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption);
         IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption);
 
-        string GetTempFileName();
+        /// <summary>
+        ///     Returns a name suitable for usage as a file or directory name.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="string"/> containing a name suitable for usage as a file or directory name.
+        /// </returns>
+        /// <remarks>
+        ///     NOTE: Unlike <see cref="Path.GetTempFileName"/>, this method does not create a zero byte file on disk.
+        /// </remarks>
+        string GetTempDirectoryOrFileName();
     }
 }


### PR DESCRIPTION
We were calling through Path.GetTempFileName which creates a zero byte file on disk, only to delete it so that it was suitable for a directory name.

tag @dotnet/project-system @333fred 