### PR TITLE
Move mocks from "Mocks" namespace

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ICreateFileFromTemplateServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ICreateFileFromTemplateServiceFactory.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.IO;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.ProjectSystem;
 using Moq;
 
-namespace Microsoft.VisualStudio.Mocks
+namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class ICreateFileFromTemplateServiceFactory
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemFactory.cs
@@ -2,10 +2,9 @@
 
 using System;
 using System.IO;
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Moq;
 
-namespace Microsoft.VisualStudio.Mocks
+namespace Microsoft.VisualStudio.ProjectSystem.Utilities
 {
     internal class IFileSystemFactory
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectItemProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectItemProviderFactory.cs
@@ -2,10 +2,9 @@
 
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.ProjectSystem;
 using Moq;
 
-namespace Microsoft.VisualStudio.Mocks
+namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal class IProjectItemProviderFactory
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviderTests.cs
@@ -2,8 +2,8 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.Mocks;
 using Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders;
+using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/DataFlowExtensionMethodWrapperMock.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/DataFlowExtensionMethodWrapperMock.cs
@@ -3,10 +3,8 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks.Dataflow;
-using Microsoft.VisualStudio.ProjectSystem;
-using Microsoft.VisualStudio.ProjectSystem.Utilities.DataFlowExtensions;
 
-namespace Microsoft.VisualStudio.Mocks
+namespace Microsoft.VisualStudio.ProjectSystem.Utilities.DataFlowExtensions
 {
     public class DataFlowExtensionMethodWrapperMock : IDataFlowExtensionWrapper
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveConfiguredProjectSubscriptionServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveConfiguredProjectSubscriptionServiceFactory.cs
@@ -1,12 +1,8 @@
-﻿using Microsoft.VisualStudio.ProjectSystem;
-using Moq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-namespace Microsoft.VisualStudio.Mocks
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
 {
     public class IActiveConfiguredProjectSubscriptionServiceFactory
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDebugLaunchProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDebugLaunchProviderFactory.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Moq;
 
-namespace Microsoft.VisualStudio.Mocks
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
     public class IDebugLaunchProviderFactory
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDebugLaunchProviderMetadataViewFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDebugLaunchProviderMetadataViewFactory.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Moq;
 
-namespace Microsoft.VisualStudio.Mocks
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
     public class IDebugLaunchProviderMetadataViewFactory
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectValueDataSourceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectValueDataSourceFactory.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.VisualStudio.ProjectSystem;
 using Moq;
 
-namespace Microsoft.VisualStudio.Mocks
+namespace Microsoft.VisualStudio.ProjectSystem
 {
     public class IProjectValueDataSourceFactory
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsAddProjectItemDlgFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsAddProjectItemDlgFactory.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.VisualStudio.Shell.Interop;
 using Moq;
 using System;
 
-namespace Microsoft.VisualStudio.Mocks
+namespace Microsoft.VisualStudio.Shell.Interop
 {
     internal static class IVsAddProjectItemDlgFactory
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsStartupProjectsListServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsStartupProjectsListServiceFactory.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.VisualStudio.Shell.Interop;
 using Moq;
 
-namespace Microsoft.VisualStudio.Mocks
+namespace Microsoft.VisualStudio.Shell.Interop
 {
     public static class IVsStartupProjectsListServiceFactory
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/RegistrationContextFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/RegistrationContextFactory.cs
@@ -2,7 +2,7 @@
 using System;
 using static Microsoft.VisualStudio.Shell.RegistrationAttribute;
 
-namespace Microsoft.VisualStudio.Mocks
+namespace Microsoft.VisualStudio.Shell
 {
     internal class RegistrationContextFactory
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/CreateFileFromTemplateServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/CreateFileFromTemplateServiceTests.cs
@@ -4,7 +4,6 @@ using System;
 using System.Threading.Tasks;
 using EnvDTE;
 using EnvDTE80;
-using Microsoft.VisualStudio.Mocks;
 using Microsoft.VisualStudio.Shell.Interop;
 using Xunit;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DebugTests/StartupProjectRegistrarTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DebugTests/StartupProjectRegistrarTests.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.VisualStudio.Mocks;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.ProjectSystem.Utilities.DataFlowExtensions;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Moq;
 using Xunit;
 using Tasks = System.Threading.Tasks;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DteServicesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DteServicesTests.cs
@@ -3,7 +3,6 @@
 using System;
 using EnvDTE;
 using EnvDTE80;
-using Microsoft.VisualStudio.Mocks;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Moq;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Generators/GeneratorExtensionRegistrationAttributeTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Generators/GeneratorExtensionRegistrationAttributeTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.VisualStudio.Mocks;
 using System;
+using Microsoft.VisualStudio.Shell;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Generators

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Generators/RemoteCodeGenerationRegistrationAttributeTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Generators/RemoteCodeGenerationRegistrationAttributeTests.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.VisualStudio.Mocks;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.VisualStudio.Shell;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Generators

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractAddClassProjectCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractAddClassProjectCommandTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.VisualStudio.Input;
-using Microsoft.VisualStudio.Mocks;
 using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.Collections.Immutable;


### PR DESCRIPTION
Move mocks from "Mocks" namespace to the same namespace as the thing they are mocking. It makes it *much* easier to find them when writing new tests.

tag @dotnet/project-system 