### PR TITLE
Move IFileSystem/FileSystem

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.VisualStudio.Packaging;
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
-using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using Microsoft.VisualStudio.IO;
+using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.Shell.Interop;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
@@ -1,15 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.Packaging;
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.ProjectSystem.VS;
 using Microsoft.VisualStudio.ProjectSystem.VS.Generators;
 using Microsoft.VisualStudio.ProjectSystem.VS.Xproj;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using System;
-using System.Runtime.InteropServices;
-using System.Threading;
 using Task = System.Threading.Tasks.Task;
 
 // We register ourselves as a new CPS "project type"

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.Packaging
 
         protected override Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
-            _factory = new MigrateXprojProjectFactory(new ProcessRunner(), new FileSystem());
+            _factory = new MigrateXprojProjectFactory(new ProcessRunner(), new Win32FileSystem());
             _factory.SetSite(this);
             RegisterProjectFactory(_factory);
             return Task.CompletedTask;

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.VisualStudio.Shell.Interop;
 using System;
-using Microsoft.VisualStudio.Packaging;
-using Microsoft.VisualStudio.Shell.Flavor;
-using System.Runtime.InteropServices;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
+using System.Runtime.InteropServices;
 using System.Text;
+using Microsoft.VisualStudio.IO;
+using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.Shell.Flavor;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp/ProjectSystem/SpecialFileProviders/CSharpAssemblyInfoSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp/ProjectSystem/SpecialFileProviders/CSharpAssemblyInfoSpecialFileProvider.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.ComponentModel.Composition;
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
+using Microsoft.VisualStudio.IO;
 
 namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemFactory.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.IO;
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
+using Microsoft.VisualStudio.IO;
 using Moq;
 
 namespace Microsoft.VisualStudio.Mocks

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -6,9 +6,9 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
+using Microsoft.VisualStudio.IO;
 
-namespace Microsoft.VisualStudio.ProjectSystem
+namespace Microsoft.VisualStudio.IO
 {
     /// <summary>
     /// A useful helper moq for IFileSystem.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using Microsoft.VisualStudio.IO;
 
 namespace Microsoft.VisualStudio.IO
 {
@@ -29,9 +28,9 @@ namespace Microsoft.VisualStudio.IO
 
         public Dictionary<string, FileData> Files { get => _files; }
 
-        public FileStream Create(string filePath)
+        public FileStream Create(string path)
         {
-            WriteAllText(filePath, "");
+            WriteAllText(path, "");
 
             // No way to mock FileStream. Only caller does not check the return value.
             return null;
@@ -61,7 +60,7 @@ namespace Microsoft.VisualStudio.IO
         }
 
 
-        public void SetDirectoryAttribute(string directoryPath, FileAttributes newAttribute)
+        public void SetDirectoryAttribute(string path, FileAttributes newAttribute)
         {
         }
 
@@ -119,27 +118,27 @@ namespace Microsoft.VisualStudio.IO
             return _files.ContainsKey(path);
         }
 
-        public bool DirectoryExists(string dirPath)
+        public bool DirectoryExists(string path)
         {
-            bool val = _folders.Contains(dirPath);
+            bool val = _folders.Contains(path);
             return val;
         }
 
-        public void CreateDirectory(string dirPath)
+        public void CreateDirectory(string path)
         {
-            if (!DirectoryExists(dirPath))
+            if (!DirectoryExists(path))
             {
-                _folders.Add(dirPath);
+                _folders.Add(path);
             }
         }
 
-        public void RemoveFile(string referenceFile)
+        public void RemoveFile(string path)
         {
-            if (!FileExists(referenceFile))
+            if (!FileExists(path))
             {
                 throw new System.IO.FileNotFoundException();
             }
-            _files.Remove(referenceFile);
+            _files.Remove(path);
         }
 
         public void CopyFile(string source, string destination, bool overwrite)
@@ -150,19 +149,19 @@ namespace Microsoft.VisualStudio.IO
             }
         }
 
-        public string ReadAllText(string filePath)
+        public string ReadAllText(string path)
         {
-            if (!FileExists(filePath))
+            if (!FileExists(path))
             {
                 throw new System.IO.FileNotFoundException();
             }
-            return _files[filePath].FileContents;
+            return _files[path].FileContents;
         }
 
-        public void WriteAllText(string filePath, string content)
+        public void WriteAllText(string path, string content)
         {
             FileData curData;
-            if (_files.TryGetValue(filePath, out curData))
+            if (_files.TryGetValue(path, out curData))
             {
                 // This makes sure each write to the file increases the timestamp
                 curData.FileContents = content;
@@ -170,24 +169,24 @@ namespace Microsoft.VisualStudio.IO
             }
             else
             {
-                _files[filePath] = new FileData() { FileContents = content };
-                SetLastWriteTime(_files[filePath]);
+                _files[path] = new FileData() { FileContents = content };
+                SetLastWriteTime(_files[path]);
             }
         }
 
-        public void WriteAllText(string filePath, string content, Encoding encoding)
+        public void WriteAllText(string path, string content, Encoding encoding)
         {
-            WriteAllText(filePath, content);
+            WriteAllText(path, content);
         }
 
-        public DateTime LastFileWriteTime(string filepath)
+        public DateTime LastFileWriteTime(string path)
         {
-            return _files[filepath].LastWriteTime;
+            return _files[path].LastWriteTime;
         }
 
-        public DateTime LastFileWriteTimeUtc(string filepath)
+        public DateTime LastFileWriteTimeUtc(string path)
         {
-            return _files[filepath].LastWriteTime;
+            return _files[path].LastWriteTime;
         }
 
         public void RemoveDirectory(string directoryPath, bool recursive)
@@ -218,7 +217,7 @@ namespace Microsoft.VisualStudio.IO
             return _tempFile;
         }
 
-        public void WriteAllBytes(string filePath, byte[] bytes)
+        public void WriteAllBytes(string path, byte[] bytes)
         {
 
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -28,11 +28,11 @@ namespace Microsoft.VisualStudio.IO
 
         public Dictionary<string, FileData> Files { get => _files; }
 
-        public FileStream Create(string path)
+        public Stream Create(string path)
         {
             WriteAllText(path, "");
 
-            // No way to mock FileStream. Only caller does not check the return value.
+            // Caller does not check the return value.
             return null;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Moq;
@@ -16,7 +17,7 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
-  
+
     [ProjectSystemTrait]
     public class LaunchSettingsProviderTests
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Editor/MsBuildModelWatcherTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Editor/MsBuildModelWatcherTests.cs
@@ -1,8 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 using Moq;
-using System.Threading.Tasks;
 using Xunit;
 using HandlerCallback = System.EventHandler<Microsoft.Build.Evaluation.ProjectXmlChangedEventArgs>;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/EditProjectFileCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/EditProjectFileCommandTests.cs
@@ -1,18 +1,18 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Editor;
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
-using Microsoft.VisualStudio.Text;
-using Xunit;
-using System.Collections.Immutable;
-using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
-using Microsoft.VisualStudio.Shell.Interop;
-using Moq;
-using Microsoft.VisualStudio.ProjectSystem.VS.Editor;
-using Microsoft.VisualStudio.ProjectSystem.VS.Utilities.ExportFactory;
+using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.ProjectSystem.VS.Editor;
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities.ExportFactory;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -4,13 +4,14 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using ExportOrder = Microsoft.VisualStudio.ProjectSystem.OrderAttribute;
 using Task = System.Threading.Tasks.Task;
-using System.Text;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/EditProjectFileVsFrameEvents.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/EditProjectFileVsFrameEvents.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
-using Microsoft.VisualStudio.Shell.Interop;
-using System.IO;
-using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
-using Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands;
 using System;
+using System.IO;
+using Microsoft.VisualStudio.IO;
+using Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands;
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/MsBuildModelWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/MsBuildModelWatcher.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.Build.Evaluation;
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
-using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
-using System.Threading.Tasks;
-using System.Threading;
 using System.ComponentModel.Composition;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Evaluation;
+using Microsoft.VisualStudio.IO;
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/EditProjectFileCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/EditProjectFileCommand.cs
@@ -1,19 +1,19 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.Packaging;
 using Microsoft.VisualStudio.ProjectSystem.Input;
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.ProjectSystem.VS.Editor;
 using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.TextManager.Interop;
-using System;
-using System.ComponentModel.Composition;
-using System.IO;
-using System.Threading.Tasks;
 using IServiceProvider = System.IServiceProvider;
 using Task = System.Threading.Tasks.Task;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/FileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/FileSystem.cs
@@ -9,8 +9,8 @@ using System.Text;
 namespace Microsoft.VisualStudio.IO
 {
     /// <summary>
-    /// A wrapper for <see cref="File"/> that gives us the ability to mock
-    /// the type for testing.
+    ///     Provides an implementation of <see cref="IFileSystem"/> that calls through the <see cref="Directory"/>
+    ///     and <see cref="File"/> classes, and ultimately through Win32 APIs.
     /// </summary>
     [Export(typeof(IFileSystem))]
     internal class FileSystem : IFileSystem

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/FileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/FileSystem.cs
@@ -6,7 +6,7 @@ using System.ComponentModel.Composition;
 using System.IO;
 using System.Text;
 
-namespace Microsoft.VisualStudio.ProjectSystem.Utilities
+namespace Microsoft.VisualStudio.IO
 {
     /// <summary>
     /// A wrapper for <see cref="File"/> that gives us the ability to mock

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
-namespace Microsoft.VisualStudio.ProjectSystem.Utilities
+namespace Microsoft.VisualStudio.IO
 {
     /// <summary>
     /// An interface wrapper for <see cref="File"/> and <see cref="Directory"/> that gives us the ability to mock

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.IO
     /// </summary>
     interface IFileSystem
     {
-        FileStream Create(string path);
+        Stream Create(string path);
 
         bool FileExists(string path);
         void RemoveFile(string path);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
@@ -8,8 +8,7 @@ using System.Text;
 namespace Microsoft.VisualStudio.IO
 {
     /// <summary>
-    /// An interface wrapper for <see cref="File"/> and <see cref="Directory"/> that gives us the ability to mock
-    /// the type for testing.
+    ///     Provides static methods for the creation, copying, deletion, moving of files and directories.
     /// </summary>
     interface IFileSystem
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
@@ -12,23 +12,23 @@ namespace Microsoft.VisualStudio.IO
     /// </summary>
     interface IFileSystem
     {
-        FileStream Create(string filePath);
+        FileStream Create(string path);
 
         bool FileExists(string path);
-        void RemoveFile(string referenceFile);
+        void RemoveFile(string path);
         void CopyFile(string source, string destination, bool overwrite);
-        string ReadAllText(string filePath);
-        void WriteAllText(string filePath, string content);
-        void WriteAllText(string filePath, string content, Encoding encoding);
-        void WriteAllBytes(string filePath, byte[] bytes);
-        DateTime LastFileWriteTime(string filepath);
-        DateTime LastFileWriteTimeUtc(string filepath);
+        string ReadAllText(string path);
+        void WriteAllText(string path, string content);
+        void WriteAllText(string path, string content, Encoding encoding);
+        void WriteAllBytes(string path, byte[] bytes);
+        DateTime LastFileWriteTime(string path);
+        DateTime LastFileWriteTimeUtc(string path);
         long FileLength(string filename);
 
-        bool DirectoryExists(string dirPath);
-        void CreateDirectory(string dirPath);
-        void RemoveDirectory(string directoryPath, bool recursive);
-        void SetDirectoryAttribute(string directoryPath, FileAttributes newAttribute);
+        bool DirectoryExists(string path);
+        void CreateDirectory(string path);
+        void RemoveDirectory(string path, bool recursive);
+        void SetDirectoryAttribute(string path, FileAttributes newAttribute);
         IEnumerable<string> EnumerateDirectories(string path);
         IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption);
         IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
@@ -15,9 +15,9 @@ namespace Microsoft.VisualStudio.IO
     [Export(typeof(IFileSystem))]
     internal class Win32FileSystem : IFileSystem
     {
-        public FileStream Create(string filePath)
+        public FileStream Create(string path)
         {
-            return File.Create(filePath);
+            return File.Create(path);
         }
 
         public bool FileExists(string path)
@@ -25,11 +25,11 @@ namespace Microsoft.VisualStudio.IO
             return File.Exists(path);
         }
 
-        public void RemoveFile(string referenceFile)
+        public void RemoveFile(string path)
         {
-            if (FileExists(referenceFile))
+            if (FileExists(path))
             {
-                File.Delete(referenceFile);
+                File.Delete(path);
             }
         }
 
@@ -38,39 +38,39 @@ namespace Microsoft.VisualStudio.IO
             File.Copy(source, destination, overwrite);
         }
 
-        public string ReadAllText(string filePath)
+        public string ReadAllText(string path)
         {
-            return File.ReadAllText(filePath);
+            return File.ReadAllText(path);
         }
 
-        public void WriteAllText(string filePath, string content)
+        public void WriteAllText(string path, string content)
         {
-            File.WriteAllText(filePath, content);
+            File.WriteAllText(path, content);
         }
 
-        public void WriteAllText(string filePath, string content, Encoding encoding)
+        public void WriteAllText(string path, string content, Encoding encoding)
         {
-            File.WriteAllText(filePath, content, encoding);
+            File.WriteAllText(path, content, encoding);
         }
 
-        public void WriteAllBytes(string filePath, byte[] bytes)
+        public void WriteAllBytes(string path, byte[] bytes)
         {
-            File.WriteAllBytes(filePath, bytes);
+            File.WriteAllBytes(path, bytes);
         }
 
-        public DateTime LastFileWriteTime(string filepath)
+        public DateTime LastFileWriteTime(string path)
         {
-            return File.GetLastWriteTime(filepath);
+            return File.GetLastWriteTime(path);
         }
 
-        public DateTime LastFileWriteTimeUtc(string filepath)
+        public DateTime LastFileWriteTimeUtc(string path)
         {
-            return File.GetLastWriteTimeUtc(filepath);
+            return File.GetLastWriteTimeUtc(path);
         }
 
-        public long FileLength(string filename)
+        public long FileLength(string path)
         {
-            return new FileInfo(filename).Length;
+            return new FileInfo(path).Length;
         }
 
         public bool DirectoryExists(string dirPath)
@@ -83,14 +83,14 @@ namespace Microsoft.VisualStudio.IO
             Directory.CreateDirectory(dirPath);
         }
 
-        public void RemoveDirectory(string directoryPath, bool recursive)
+        public void RemoveDirectory(string path, bool recursive)
         {
-            Directory.Delete(directoryPath, recursive);
+            Directory.Delete(path, recursive);
         }
 
-        public void SetDirectoryAttribute(string directoryPath, FileAttributes newAttribute)
+        public void SetDirectoryAttribute(string path, FileAttributes newAttribute)
         {
-            var di = new DirectoryInfo(directoryPath);
+            var di = new DirectoryInfo(path);
             if ((di.Attributes & newAttribute) != newAttribute)
             {
                 di.Attributes |= newAttribute;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.IO
     [Export(typeof(IFileSystem))]
     internal class Win32FileSystem : IFileSystem
     {
-        public FileStream Create(string path)
+        public Stream Create(string path)
         {
             return File.Create(path);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.IO
     ///     and <see cref="File"/> classes, and ultimately through Win32 APIs.
     /// </summary>
     [Export(typeof(IFileSystem))]
-    internal class FileSystem : IFileSystem
+    internal class Win32FileSystem : IFileSystem
     {
         public FileStream Create(string filePath)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -133,9 +133,9 @@
     <Compile Include="ProjectSystem\Utilities\DataFlowExtensions\DataFlowExtensionMethodCaller.cs" />
     <Compile Include="ProjectSystem\Utilities\DataFlowExtensions\DataFlowExtensionMethodWrapper.cs" />
     <Compile Include="ProjectSystem\Utilities\DataFlowExtensions\IDataFlowExtensionWrapper.cs" />
-    <Compile Include="ProjectSystem\Utilities\FileSystem.cs" />
+    <Compile Include="IO\FileSystem.cs" />
     <Compile Include="ProjectSystem\Utilities\IEnvironmentHelper.cs" />
-    <Compile Include="ProjectSystem\Utilities\IFileSystem.cs" />
+    <Compile Include="IO\IFileSystem.cs" />
     <Compile Include="ProjectSystem\Imaging\IProjectImageProvider.cs" />
     <Compile Include="ProjectSystem\Imaging\ProjectImageKey.cs" />
     <Compile Include="ProjectSystem\Imaging\ProjectImageProviderAggregator.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -133,7 +133,7 @@
     <Compile Include="ProjectSystem\Utilities\DataFlowExtensions\DataFlowExtensionMethodCaller.cs" />
     <Compile Include="ProjectSystem\Utilities\DataFlowExtensions\DataFlowExtensionMethodWrapper.cs" />
     <Compile Include="ProjectSystem\Utilities\DataFlowExtensions\IDataFlowExtensionWrapper.cs" />
-    <Compile Include="IO\FileSystem.cs" />
+    <Compile Include="IO\Win32FileSystem.cs" />
     <Compile Include="ProjectSystem\Utilities\IEnvironmentHelper.cs" />
     <Compile Include="IO\IFileSystem.cs" />
     <Compile Include="ProjectSystem\Imaging\IProjectImageProvider.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Microsoft.VisualStudio.Threading.Tasks;
+using Microsoft.VisualStudio.IO;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
@@ -7,8 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
-using Diagnostics = System.Diagnostics;
+using Microsoft.VisualStudio.IO;
 
 namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppConfigFileSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppConfigFileSpecialFileProvider.cs
@@ -2,8 +2,7 @@
 
 using System;
 using System.ComponentModel.Composition;
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
-using static System.Diagnostics.Debug;
+using Microsoft.VisualStudio.IO;
 
 namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/ResourcesFileSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/ResourcesFileSpecialFileProvider.cs
@@ -2,8 +2,7 @@
 
 using System;
 using System.ComponentModel.Composition;
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
-using static System.Diagnostics.Debug;
+using Microsoft.VisualStudio.IO;
 
 namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/SettingsFileSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/SettingsFileSpecialFileProvider.cs
@@ -2,8 +2,7 @@
 
 using System;
 using System.ComponentModel.Composition;
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
-using static System.Diagnostics.Debug;
+using Microsoft.VisualStudio.IO;
 
 namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic/ProjectSystem/SpecialFileProviders/BasicAssemblyInfoSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic/ProjectSystem/SpecialFileProviders/BasicAssemblyInfoSpecialFileProvider.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.ComponentModel.Composition;
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
+using Microsoft.VisualStudio.IO;
 
 namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
 {


### PR DESCRIPTION
- Move IFileSystem/FileSystem -> Microsoft.VisualStudio.IO namespace  …
  - Utilities has become a grab bag of everything - it's not a great namespace name, and something we avoided using on the BCL.

- Updated doc comments for FileSystem/IFileSystem

- Rename "FileSystem" -> "Win32FileSystem"  …
  - This better describes it's implementation.