### PR TITLE
Update xlf files with new and modified strings

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/xlf/PropPageDesignerView.xlf
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/xlf/PropPageDesignerView.xlf
@@ -5,23 +5,23 @@
       <group id="src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.resx" />
       <trans-unit id="PlatformLabel.Text">
         <source>Platfor&amp;m:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ConfigurationLabel.Text">
         <source>&amp;Configuration:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PropertyPagePanel.AccessibleName">
         <source>Property Page Panel</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PropertyPagePanel.Text">
         <source>PropertyPagePanel</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="$this.AccessibleName">
         <source>Property Designer Panel</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/xlf/PropPageHostDialog.xlf
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/xlf/PropPageHostDialog.xlf
@@ -5,15 +5,15 @@
       <group id="src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageHostDialog.resx" />
       <trans-unit id="OK.Text">
         <source>OK</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Cancel.Text">
         <source>Cancel</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="$this.Text">
         <source>PropPageHostDialog</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/xlf/PropPageUserControlBase.xlf
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/xlf/PropPageUserControlBase.xlf
@@ -5,7 +5,7 @@
       <group id="src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.resx" />
       <trans-unit id="$this.Name">
         <source>PropPageUserControlBase</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.AppDesigner/Resources/xlf/Microsoft.VisualStudio.AppDesigner.Designer.xlf
+++ b/src/Microsoft.VisualStudio.AppDesigner/Resources/xlf/Microsoft.VisualStudio.AppDesigner.Designer.xlf
@@ -5,44 +5,44 @@
       <group id="src/Microsoft.VisualStudio.AppDesigner/Resources/Microsoft.VisualStudio.AppDesigner.Designer.resx" />
       <trans-unit id="APPDES_ClickHereCreateResx">
         <source>This project does not contain a default resources file.  Click here to create one.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_ClickHereCreateSettings">
         <source>This project does not contain a default settings file.  Click here to create one.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_DesignerLoader_NotDeferred">
         <source>The designer cannot be shown because the document for it was never loaded.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_EditorAlreadyOpen_1Arg">
         <source>The file '{0}' is already open in an editor.  Please close the file and try again.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_ErrorLoadingPropPage">
         <source>An error occurred trying to load the page.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_ErrorLoading_Msg">
         <source>An error occurred trying to load the project properties window.  Close the window and try again.
 {0}</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_FileNotFound_1Arg">
         <source>Could not find the file '{0}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_HostingPanelName">
         <source>Project Designer Page Container</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_OverflowButton_AccessibilityName">
         <source>All Project Designer Pages</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_OverflowButton_Tooltip">
         <source>More Settings</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_PageName">
         <source>{0} page:</source>
@@ -50,35 +50,35 @@
       </trans-unit>
       <trans-unit id="APPDES_ResourceTabTitle">
         <source>Resources</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_SettingsTabTitle">
         <source>Settings</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_SpecialFileNotSupported">
         <source>The requested file type is not supported in projects of this type.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_TabButtonDefaultAction">
         <source>Switch Project Designer Page</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_TabListDescription">
         <source>Allow switching between active pages of the project designer (use Ctrl+PageUp and Ctrl+PageDown)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_Title">
         <source>Project Designer</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="CMN_AllFilesFilter">
         <source>All Files</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DFX_BufferReadOnly">
         <source>Buffer is read only.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DFX_CreateEditorInstanceFailed_Ex">
         <source>Unable to create the designer.  {0}</source>
@@ -106,11 +106,11 @@
       </trans-unit>
       <trans-unit id="DFX_IncompatibleBuffer">
         <source>File is already opened in an incompatible editor.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DFX_InvalidPhysicalViewName">
         <source>Invalid physical view name.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DFX_NoLocalRegistry">
         <source>No LocalRegistry service.</source>
@@ -118,11 +118,11 @@
       </trans-unit>
       <trans-unit id="DFX_NotSupported">
         <source>Unsupported format.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DFX_OneOrMoreFilesReloaded">
         <source>One or more files were reloaded during the checkout. Please retry your operation.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DFX_ReplaceTextStreamFailed">
         <source>Replacing text stream failed:{0}</source>
@@ -138,7 +138,7 @@
       </trans-unit>
       <trans-unit id="DFX_WindowPane_UnknownError">
         <source>Unknown Error.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="General_InvalidArgument_1Arg">
         <source>Invalid argument '{0}'</source>
@@ -150,31 +150,31 @@
       </trans-unit>
       <trans-unit id="PermissionSet_Requires">
         <source>Requires:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_ActiveConfigOrPlatformFormatString_1Arg">
         <source>Active ({0})</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_AllConfigurations">
         <source>All Configurations</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_AllPlatforms">
         <source>All Platforms</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_ApplicationTitle">
         <source>Application</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_ComboBoxSelect_None">
         <source>(None)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_ConfigNotFound_2Args">
         <source>Could not find the configuration '{0}' for platform '{1}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_MyApplication_AuthenMode_ApplicationDefined">
         <source>Application-defined</source>
@@ -186,19 +186,19 @@
       </trans-unit>
       <trans-unit id="PPG_MyApplication_StartupMode_AppExits">
         <source>When last form closes</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_MyApplication_StartupMode_FormCloses">
         <source>When startup form closes</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_NeutralLanguage_None">
         <source>(None)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_NonePermissionSet">
         <source>(None)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_NotApplicable">
         <source>N/A</source>
@@ -208,51 +208,51 @@
         <source>The output path is not trusted.
 The application may throw security exceptions when it attempts to perform actions which require full trust.
 Click OK to ignore and continue. Click CANCEL to choose a different output path.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_PostBuildCommandLineTitle">
         <source>Post-build Event Command Line</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_PreBuildCommandLineTitle">
         <source>Pre-build Event Command Line</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_ProjectReloadedSomePropertiesMayNotHaveBeenSet">
         <source>The project was reloaded, and some changes on this page may have been lost.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_PropertyPageControlName">
         <source>Property Page</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SelectFileTitle">
         <source>Select File</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SelectOutputPathTitle">
         <source>Select Output Path</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SelectReferencePath">
         <source>Select Reference Path</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SelectWorkingDirectoryTitle">
         <source>Select Working Directory</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_StartupObjectNone">
         <source>(None)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_UndoTransaction">
         <source>Change property: {0}</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SingleFileGenerator_FailedToGenerateFile_1Arg">
         <source>Failed to generate file: {0}</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_Err_InternalException">
         <source>Unexpected error.</source>

--- a/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/xlf/AddImports.xlf
+++ b/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/xlf/AddImports.xlf
@@ -38,7 +38,7 @@
       </trans-unit>
       <trans-unit id="AddImportsExtensionMethodsMainFormatString">
         <source>Importing '{0}' would change the meaning of other code in your file, including calls to extension methods. Click OK to correct '{1}' by changing it to '{2}' </source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/xlf/AutoAddImportsCollisionDialog.xlf
+++ b/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/xlf/AutoAddImportsCollisionDialog.xlf
@@ -5,15 +5,15 @@
       <group id="src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AutoAddImportsCollisionDialog.resx" />
       <trans-unit id="m_cancelButton.Text">
         <source>Cancel</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="m_okButton.Text">
         <source>OK</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="$this.Text">
         <source>Add Imports Validation Error</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/xlf/AutoAddImportsExtensionCollisionDialog.xlf
+++ b/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/xlf/AutoAddImportsExtensionCollisionDialog.xlf
@@ -5,15 +5,15 @@
       <group id="src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AutoAddImportsExtensionCollisionDialog.resx" />
       <trans-unit id="btnOk_.Text">
         <source>OK</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="btnCancel_.Text">
         <source>Cancel</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="$this.Text">
         <source>Add Imports Validation Error</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.xlf
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.xlf
@@ -5,31 +5,31 @@
       <group id="src/Microsoft.VisualStudio.Editors/MyExtensibility/AddMyExtensionsDialog.resx" />
       <trans-unit id="buttonOK.Text">
         <source>OK</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="buttonCancel.Text">
         <source>Cancel</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="colHeaderExtensionName.Text">
         <source>Name</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="colHeaderExtensionVersion.Text">
         <source>Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="colHeaderExensionDescription.Text">
         <source>Description</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="listViewExtensions.AccessibleName">
         <source>Available My Namespace Extensions</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="$this.Text">
         <source>Add Visual Basic My Namespace Extension</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AssemblyOptionDialog.xlf
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AssemblyOptionDialog.xlf
@@ -5,11 +5,11 @@
       <group id="src/Microsoft.VisualStudio.Editors/MyExtensibility/AssemblyOptionDialog.resx" />
       <trans-unit id="buttonYes.Text">
         <source>&amp;Yes</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="buttonNo.Text">
         <source>&amp;No</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/MyExtensibilityPropPage.xlf
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/MyExtensibilityPropPage.xlf
@@ -5,31 +5,31 @@
       <group id="src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityPropPage.resx" />
       <trans-unit id="labelDescription.Text">
         <source>My Namespace extensions: </source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="linkLabelHelp.Text">
         <source>Learn more about customizing My Namespace.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="colHeaderExtensionName.Text">
         <source>Name</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="colHeaderExtensionVersion.Text">
         <source>Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="colHeaderExtensionDescription.Text">
         <source>Description</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="buttonRemove.Text">
         <source>Remo&amp;ve extension</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="buttonAdd.Text">
         <source>&amp;Add extension...</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.xlf
@@ -5,55 +5,55 @@
       <group id="src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.resx" />
       <trans-unit id="AssemblyNameLabel.Text">
         <source>Assembly &amp;name:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RootNamespaceLabel.Text">
         <source>&amp;Root namespace:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="TargetFrameworkLabel.Text">
         <source>&amp;Target framework:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StartupObjectOrUriLabel.Text">
         <source>#</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ApplicationTypeLabel.Text">
         <source>&amp;Application type:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="UseApplicationFrameworkCheckBox.Text">
         <source>Enable application framewor&amp;k</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="IconLabel.Text">
         <source>&amp;Icon:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="AssemblyInfoButton.Text">
         <source>Assembl&amp;y Information...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ViewUACSettingsButton.Text">
         <source>View Windows Settin&amp;gs</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="WindowsAppGroupBox.Text">
         <source>Windows application framework properties</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EditXamlButton.Text">
         <source>Edit &amp;XAML</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ViewCodeButton.Text">
         <source>&amp;View Application Events</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ShutdownModeLabel.Text">
         <source>Shutdown m&amp;ode:</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AdvBuildSettingsPropPage.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AdvBuildSettingsPropPage.xlf
@@ -5,55 +5,55 @@
       <group id="src/Microsoft.VisualStudio.Editors/PropPages/AdvBuildSettingsPropPage.resx" />
       <trans-unit id="lblLanguageVersion.Text">
         <source>&amp;Language version:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="lblReportCompilerErrors.Text">
         <source>&amp;Internal compiler error reporting:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="lblDebugInfo.Text">
         <source>D&amp;ebugging information:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="lblFileAlignment.Text">
         <source>&amp;File alignment:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="cboFileAlignment.Items">
         <source>512</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="cboFileAlignment.Items1">
         <source>1024</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="cboFileAlignment.Items2">
         <source>2048</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="cboFileAlignment.Items3">
         <source>4096</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="cboFileAlignment.Items4">
         <source>8192</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="lblDLLBase.Text">
         <source>Library &amp;base address:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="generalLabel.Text">
         <source>General</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="chkOverflow.Text">
         <source>Chec&amp;k for arithmetic overflow/underflow</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AdvCompilerSettingsPropPage.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AdvCompilerSettingsPropPage.xlf
@@ -5,55 +5,55 @@
       <group id="src/Microsoft.VisualStudio.Editors/PropPages/AdvCompilerSettingsPropPage.resx" />
       <trans-unit id="OptimizationsLabel.Text">
         <source>Optimizations</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RemoveIntegerChecks.Text">
         <source>&amp;Remove integer overflow checks</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Optimize.Text">
         <source>&amp;Enable optimizations</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DllBaseLabel.Text">
         <source>DLL &amp;base address:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DefineDebug.Text">
         <source>Define &amp;DEBUG constant</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DefineTrace.Text">
         <source>Define &amp;TRACE constant</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="GenerateSerializationAssembliesLabel.Text">
         <source>Generate &amp;serialization assemblies:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="CustomConstantsLabel.Text">
         <source>&amp;Custom constants:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="GenerateDebugInfoLabel.Text">
         <source>&amp;Generate debug info:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="CustomConstantsExampleLabel.Text">
         <source>Example: Name1="Value1",Name2="Value2",Name3="Value3"</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="CompilationConstantsLabel.Text">
         <source>Compilation Constants</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="CompileWithDotNetNative.Text">
         <source>Compile with .NET Native toolchain</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnableGatekeeperAudit.Text">
         <source>Enable static analysis for .NET Native</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AdvancedServicesDialog.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AdvancedServicesDialog.xlf
@@ -5,19 +5,19 @@
       <group id="src/Microsoft.VisualStudio.Editors/PropPages/AdvancedServicesDialog.resx" />
       <trans-unit id="RoleServiceCacheTimeoutLabel.Text">
         <source>Role service cache &amp;timeout:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SavePasswordHashLocallyCheckbox.Text">
         <source>&amp;Save password hash locally to enable offline login</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="HonorServerCookieExpirationCheckbox.Text">
         <source>&amp;Require users to log on again whenever the server cookie expires</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="UseCustomConnectionStringCheckBox.Text">
         <source>&amp;Use custom connection string:</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.xlf
@@ -5,63 +5,63 @@
       <group id="src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.resx" />
       <trans-unit id="AssemblyNameLabel.Text">
         <source>Assembly &amp;name:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RootNamespaceLabel.Text">
         <source>Defau&amp;lt namespace:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="OutputTypeLabel.Text">
         <source>O&amp;utput type:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StartupObjectLabel.Text">
         <source>Startup &amp;object:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="AssemblyInfoButton.Text">
         <source>Assembly &amp;Information...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="TargetFrameworkLabel.Text">
         <source>Tar&amp;get framework:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ResourcesLabel.Text">
         <source>Specify how application resources will be managed:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="IconRadioButton.Text">
         <source>I&amp;con and manifest</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ManifestExplanationLabel.Text">
         <source>A manifest determines specific settings for an application. To embed a custom manifest, first add it to your project and then select it from the list below.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ApplicationIconLabel.Text">
         <source>Icon:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="AppIconBrowse.Text">
         <source>...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ApplicationManifestLabel.Text">
         <source>Manifest:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Win32ResourceRadioButton.Text">
         <source>Re&amp;source file:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Win32ResourceFileBrowse.Text">
         <source>...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ResourcesGroupBox.Text">
         <source>Resources</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.xlf
@@ -5,71 +5,71 @@
       <group id="src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.resx" />
       <trans-unit id="AssemblyNameLabel.Text">
         <source>Assembly &amp;name:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RootNamespaceLabel.Text">
         <source>&amp;Root namespace:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="TargetFrameworkLabel.Text">
         <source>&amp;Target framework:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StartupObjectLabel.Text">
         <source>Startup &amp;object:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ApplicationTypeLabel.Text">
         <source>&amp;Application type:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="IconLabel.Text">
         <source>&amp;Icon:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="UseApplicationFrameworkCheckBox.Text">
         <source>Enable application framewor&amp;k</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="AssemblyInfoButton.Text">
         <source>Assembl&amp;y Information...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ViewUACSettingsButton.Text">
         <source>View Windows Settin&amp;gs</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnableXPThemesCheckBox.Text">
         <source>Enable &amp;XP visual styles</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SingleInstanceCheckBox.Text">
         <source>Make &amp;single instance application</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SaveMySettingsCheckbox.Text">
         <source>Save My.Settin&amp;gs on Shutdown</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="AuthenticationModeLabel.Text">
         <source>Aut&amp;hentication mode:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ShutdownModeLabel.Text">
         <source>Sh&amp;utdown mode:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SplashScreenLabel.Text">
         <source>Sp&amp;lash screen:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ViewCodeButton.Text">
         <source>&amp;View Application Events</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="WindowsAppGroupBox.Text">
         <source>Windows application framework properties</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.xlf
@@ -5,79 +5,79 @@
       <group id="src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.resx" />
       <trans-unit id="TitleLabel.Text">
         <source>&amp;Title:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="TrademarkLabel.Text">
         <source>T&amp;rademark:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="CopyrightLabel.Text">
         <source>C&amp;opyright:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ProductLabel.Text">
         <source>&amp;Product:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="CompanyLabel.Text">
         <source>&amp;Company:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DescriptionLabel.Text">
         <source>&amp;Description:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ComVisibleCheckBox.Text">
         <source>&amp;Make assembly COM-Visible</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NeutralLanguageLabel.Text">
         <source>&amp;Neutral language:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionLabel.Text">
         <source>&amp;Assembly version:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="FileVersionLabel.Text">
         <source>&amp;File version:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
         <source>Major</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
         <source>Minor</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
         <source>Build</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
         <source>Revision</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="GuidLabel.Text">
         <source>&amp;GUID:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
         <source>Major</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
         <source>Minor</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
         <source>Build</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
         <source>Revision</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildEventCommandLineDialog.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildEventCommandLineDialog.xlf
@@ -5,39 +5,39 @@
       <group id="src/Microsoft.VisualStudio.Editors/PropPages/BuildEventCommandLineDialog.resx" />
       <trans-unit id="InsertButton.Text">
         <source>I&amp;nsert</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="OKButton.Text">
         <source>OK</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Cancel_Button.Text">
         <source>Cancel</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="CommandLine.AccessibleName">
         <source>Build Command Line</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ShowMacrosButton.Text">
         <source>&amp;Macros &gt;&gt;</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="HideMacrosButton.Text">
         <source>&lt;&lt; &amp;Macros</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="TokenList.AccessibleName">
         <source>Macro List</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Macro.Text">
         <source>Macro</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Value.Text">
         <source>Value</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildEventsPropPage.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildEventsPropPage.xlf
@@ -5,35 +5,35 @@
       <group id="src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.resx" />
       <trans-unit id="lblPreBuildEventCommandLine.Text">
         <source>P&amp;re-build event command line:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="btnPreBuildBuilder.Text">
         <source>Ed&amp;it Pre-build ...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="lblPostBuildEventCommandLine.Text">
         <source>P&amp;ost-build event command line:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="btnPostBuildBuilder.Text">
         <source>Edit Post-b&amp;uild ...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="lblRunPostBuildEvent.Text">
         <source>Ru&amp;n the post-build event:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="cboRunPostBuildEvent.Items">
         <source>Always</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="cboRunPostBuildEvent.Items1">
         <source>On successful build</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="cboRunPostBuildEvent.Items2">
         <source>When the build updates the project output</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.xlf
@@ -5,111 +5,111 @@
       <group id="src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.resx" />
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="generalLabel.Text">
         <source>General</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="treatWarningsAsErrorsLabel.Text">
         <source>Treat warnings as errors</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="errorsAndWarningsLabel.Text">
         <source>Errors and warnings</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
         <source>Register for &amp;COM interop</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="chkXMLDocumentationFile.Text">
         <source>&amp;XML documentation file:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="btnOutputPathBrowse.Text">
         <source>B&amp;rowse...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="lblOutputPath.Text">
         <source>&amp;Output path:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="rbWarningSpecific.Text">
         <source>Specif&amp;ic warnings:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="rbWarningAll.Text">
         <source>A&amp;ll</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="rbWarningNone.Text">
         <source>&amp;None</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="lblSupressWarnings.Text">
         <source>&amp;Suppress warnings:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="cboWarningLevel.Items">
         <source>0</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="cboWarningLevel.Items1">
         <source>1</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="cboWarningLevel.Items2">
         <source>2</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="cboWarningLevel.Items3">
         <source>3</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="cboWarningLevel.Items4">
         <source>4</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="lblWarningLevel.Text">
         <source>W&amp;arning level:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="chkOptimizeCode.Text">
         <source>Optimi&amp;ze code</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="chkAllowUnsafeCode.Text">
         <source>Allow unsa&amp;fe code</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="chkPrefer32Bit.Text">
         <source>&amp;Prefer 32-bit</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="chkDefineTrace.Text">
         <source>Define &amp;TRACE constant</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="lblPlatformTarget.Text">
         <source>Platform tar&amp;get:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="lblSGenOption.Text">
         <source>G&amp;enerate serialization assembly:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="btnAdvanced.Text">
         <source>A&amp;dvanced...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/DebugPropPage.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/DebugPropPage.xlf
@@ -5,75 +5,75 @@
       <group id="src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.resx" />
       <trans-unit id="StartActionLabel.Text">
         <source>Start action</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="rbStartProject.Text">
         <source>&amp;Start project</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="rbStartProgram.Text">
         <source>Start e&amp;xternal program:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="rbStartURL.Text">
         <source>Start browser with U&amp;RL:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StartProgram.AccessibleName">
         <source>Program to start</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StartURL.AccessibleName">
         <source>URL to start browser with</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StartProgramBrowse.AccessibleName">
         <source>Browse for external program</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StartProgramBrowse.Text">
         <source>&amp;Browse...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StartOptionsLabel.Text">
         <source>Start options</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="CommandLineArgsLabel.Text">
         <source>Comma&amp;nd line arguments:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="WorkingDirLabel.Text">
         <source>Wor&amp;king directory:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RemoteDebugEnabled.Text">
         <source>Use remote m&amp;achine</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RemoteDebugMachine.AccessibleName">
         <source>Remote Machine Name:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StartWorkingDirectoryBrowse.AccessibleName">
         <source>Browse for working directory</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StartWorkingDirectoryBrowse.Text">
         <source>&amp;Bro&amp;wse...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnableDebuggerLabel.Text">
         <source>Debugger engines</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnableSQLServerDebugging.Text">
         <source>Enable SQ&amp;L Server debugging</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnableUnmanagedDebugging.Text">
         <source>Enable na&amp;tive code debugging</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.cs.xlf
@@ -1,0 +1,143 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx">
+    <body>
+      <group id="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx" />
+      <trans-unit id="AssemblyVersionLabel.Text">
+        <source>&amp;Assembly version:</source>
+        <target state="new">&amp;Assembly version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CopyrightLabel.Text">
+        <source>&amp;Copyright:</source>
+        <target state="new">&amp;Copyright:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionLabel.Text">
+        <source>&amp;Description:</source>
+        <target state="new">&amp;Description:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIconUrlLabel.Text">
+        <source>&amp;Icon URL:</source>
+        <target state="new">&amp;Icon URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionLabel.Text">
+        <source>Package &amp;version:</source>
+        <target state="new">Package &amp;version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageLicenseUrlLabel.Text">
+        <source>&amp;License URL:</source>
+        <target state="new">&amp;License URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageTagsLabel.Text">
+        <source>&amp;Tags:</source>
+        <target state="new">&amp;Tags:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryUrlLabel.Text">
+        <source>&amp;Repository URL:</source>
+        <target state="new">&amp;Repository URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageReleaseNotesLabel.Text">
+        <source>Release &amp;notes:</source>
+        <target state="new">Release &amp;notes:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryTypeLabel.Text">
+        <source>&amp;Repository type:</source>
+        <target state="new">&amp;Repository type:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageProjectUrlLabel.Text">
+        <source>&amp;Project URL:</source>
+        <target state="new">&amp;Project URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratePackageOnBuild.Text">
+        <source>&amp;Generate NuGet package on build</source>
+        <target state="new">&amp;Generate NuGet package on build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeutralLanguageLabel.Text">
+        <source>Assembly &amp;neutral language:</source>
+        <target state="new">Assembly &amp;neutral language:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageRequireLicenseAcceptance.Text">
+        <source>Require &amp;license acceptance</source>
+        <target state="new">Require &amp;license acceptance</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdLabel.Text">
+        <source>Package &amp;id:</source>
+        <target state="new">Package &amp;id:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AuthorsLabel.Text">
+        <source>&amp;Authors:</source>
+        <target state="new">&amp;Authors:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyCompanyLabel.Text">
+        <source>Compan&amp;y:</source>
+        <target state="new">Compan&amp;y:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProductLabel.Text">
+        <source>&amp;Product:</source>
+        <target state="new">&amp;Product:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyFileVersionLabel.Text">
+        <source>Assembly &amp;file version:</source>
+        <target state="new">Assembly &amp;file version:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.de.xlf
@@ -1,0 +1,143 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx">
+    <body>
+      <group id="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx" />
+      <trans-unit id="AssemblyVersionLabel.Text">
+        <source>&amp;Assembly version:</source>
+        <target state="new">&amp;Assembly version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CopyrightLabel.Text">
+        <source>&amp;Copyright:</source>
+        <target state="new">&amp;Copyright:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionLabel.Text">
+        <source>&amp;Description:</source>
+        <target state="new">&amp;Description:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIconUrlLabel.Text">
+        <source>&amp;Icon URL:</source>
+        <target state="new">&amp;Icon URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionLabel.Text">
+        <source>Package &amp;version:</source>
+        <target state="new">Package &amp;version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageLicenseUrlLabel.Text">
+        <source>&amp;License URL:</source>
+        <target state="new">&amp;License URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageTagsLabel.Text">
+        <source>&amp;Tags:</source>
+        <target state="new">&amp;Tags:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryUrlLabel.Text">
+        <source>&amp;Repository URL:</source>
+        <target state="new">&amp;Repository URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageReleaseNotesLabel.Text">
+        <source>Release &amp;notes:</source>
+        <target state="new">Release &amp;notes:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryTypeLabel.Text">
+        <source>&amp;Repository type:</source>
+        <target state="new">&amp;Repository type:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageProjectUrlLabel.Text">
+        <source>&amp;Project URL:</source>
+        <target state="new">&amp;Project URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratePackageOnBuild.Text">
+        <source>&amp;Generate NuGet package on build</source>
+        <target state="new">&amp;Generate NuGet package on build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeutralLanguageLabel.Text">
+        <source>Assembly &amp;neutral language:</source>
+        <target state="new">Assembly &amp;neutral language:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageRequireLicenseAcceptance.Text">
+        <source>Require &amp;license acceptance</source>
+        <target state="new">Require &amp;license acceptance</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdLabel.Text">
+        <source>Package &amp;id:</source>
+        <target state="new">Package &amp;id:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AuthorsLabel.Text">
+        <source>&amp;Authors:</source>
+        <target state="new">&amp;Authors:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyCompanyLabel.Text">
+        <source>Compan&amp;y:</source>
+        <target state="new">Compan&amp;y:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProductLabel.Text">
+        <source>&amp;Product:</source>
+        <target state="new">&amp;Product:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyFileVersionLabel.Text">
+        <source>Assembly &amp;file version:</source>
+        <target state="new">Assembly &amp;file version:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.es.xlf
@@ -1,0 +1,143 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx">
+    <body>
+      <group id="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx" />
+      <trans-unit id="AssemblyVersionLabel.Text">
+        <source>&amp;Assembly version:</source>
+        <target state="new">&amp;Assembly version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CopyrightLabel.Text">
+        <source>&amp;Copyright:</source>
+        <target state="new">&amp;Copyright:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionLabel.Text">
+        <source>&amp;Description:</source>
+        <target state="new">&amp;Description:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIconUrlLabel.Text">
+        <source>&amp;Icon URL:</source>
+        <target state="new">&amp;Icon URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionLabel.Text">
+        <source>Package &amp;version:</source>
+        <target state="new">Package &amp;version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageLicenseUrlLabel.Text">
+        <source>&amp;License URL:</source>
+        <target state="new">&amp;License URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageTagsLabel.Text">
+        <source>&amp;Tags:</source>
+        <target state="new">&amp;Tags:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryUrlLabel.Text">
+        <source>&amp;Repository URL:</source>
+        <target state="new">&amp;Repository URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageReleaseNotesLabel.Text">
+        <source>Release &amp;notes:</source>
+        <target state="new">Release &amp;notes:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryTypeLabel.Text">
+        <source>&amp;Repository type:</source>
+        <target state="new">&amp;Repository type:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageProjectUrlLabel.Text">
+        <source>&amp;Project URL:</source>
+        <target state="new">&amp;Project URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratePackageOnBuild.Text">
+        <source>&amp;Generate NuGet package on build</source>
+        <target state="new">&amp;Generate NuGet package on build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeutralLanguageLabel.Text">
+        <source>Assembly &amp;neutral language:</source>
+        <target state="new">Assembly &amp;neutral language:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageRequireLicenseAcceptance.Text">
+        <source>Require &amp;license acceptance</source>
+        <target state="new">Require &amp;license acceptance</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdLabel.Text">
+        <source>Package &amp;id:</source>
+        <target state="new">Package &amp;id:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AuthorsLabel.Text">
+        <source>&amp;Authors:</source>
+        <target state="new">&amp;Authors:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyCompanyLabel.Text">
+        <source>Compan&amp;y:</source>
+        <target state="new">Compan&amp;y:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProductLabel.Text">
+        <source>&amp;Product:</source>
+        <target state="new">&amp;Product:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyFileVersionLabel.Text">
+        <source>Assembly &amp;file version:</source>
+        <target state="new">Assembly &amp;file version:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.fr.xlf
@@ -1,0 +1,143 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx">
+    <body>
+      <group id="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx" />
+      <trans-unit id="AssemblyVersionLabel.Text">
+        <source>&amp;Assembly version:</source>
+        <target state="new">&amp;Assembly version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CopyrightLabel.Text">
+        <source>&amp;Copyright:</source>
+        <target state="new">&amp;Copyright:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionLabel.Text">
+        <source>&amp;Description:</source>
+        <target state="new">&amp;Description:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIconUrlLabel.Text">
+        <source>&amp;Icon URL:</source>
+        <target state="new">&amp;Icon URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionLabel.Text">
+        <source>Package &amp;version:</source>
+        <target state="new">Package &amp;version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageLicenseUrlLabel.Text">
+        <source>&amp;License URL:</source>
+        <target state="new">&amp;License URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageTagsLabel.Text">
+        <source>&amp;Tags:</source>
+        <target state="new">&amp;Tags:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryUrlLabel.Text">
+        <source>&amp;Repository URL:</source>
+        <target state="new">&amp;Repository URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageReleaseNotesLabel.Text">
+        <source>Release &amp;notes:</source>
+        <target state="new">Release &amp;notes:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryTypeLabel.Text">
+        <source>&amp;Repository type:</source>
+        <target state="new">&amp;Repository type:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageProjectUrlLabel.Text">
+        <source>&amp;Project URL:</source>
+        <target state="new">&amp;Project URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratePackageOnBuild.Text">
+        <source>&amp;Generate NuGet package on build</source>
+        <target state="new">&amp;Generate NuGet package on build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeutralLanguageLabel.Text">
+        <source>Assembly &amp;neutral language:</source>
+        <target state="new">Assembly &amp;neutral language:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageRequireLicenseAcceptance.Text">
+        <source>Require &amp;license acceptance</source>
+        <target state="new">Require &amp;license acceptance</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdLabel.Text">
+        <source>Package &amp;id:</source>
+        <target state="new">Package &amp;id:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AuthorsLabel.Text">
+        <source>&amp;Authors:</source>
+        <target state="new">&amp;Authors:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyCompanyLabel.Text">
+        <source>Compan&amp;y:</source>
+        <target state="new">Compan&amp;y:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProductLabel.Text">
+        <source>&amp;Product:</source>
+        <target state="new">&amp;Product:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyFileVersionLabel.Text">
+        <source>Assembly &amp;file version:</source>
+        <target state="new">Assembly &amp;file version:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.it.xlf
@@ -1,0 +1,143 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx">
+    <body>
+      <group id="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx" />
+      <trans-unit id="AssemblyVersionLabel.Text">
+        <source>&amp;Assembly version:</source>
+        <target state="new">&amp;Assembly version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CopyrightLabel.Text">
+        <source>&amp;Copyright:</source>
+        <target state="new">&amp;Copyright:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionLabel.Text">
+        <source>&amp;Description:</source>
+        <target state="new">&amp;Description:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIconUrlLabel.Text">
+        <source>&amp;Icon URL:</source>
+        <target state="new">&amp;Icon URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionLabel.Text">
+        <source>Package &amp;version:</source>
+        <target state="new">Package &amp;version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageLicenseUrlLabel.Text">
+        <source>&amp;License URL:</source>
+        <target state="new">&amp;License URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageTagsLabel.Text">
+        <source>&amp;Tags:</source>
+        <target state="new">&amp;Tags:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryUrlLabel.Text">
+        <source>&amp;Repository URL:</source>
+        <target state="new">&amp;Repository URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageReleaseNotesLabel.Text">
+        <source>Release &amp;notes:</source>
+        <target state="new">Release &amp;notes:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryTypeLabel.Text">
+        <source>&amp;Repository type:</source>
+        <target state="new">&amp;Repository type:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageProjectUrlLabel.Text">
+        <source>&amp;Project URL:</source>
+        <target state="new">&amp;Project URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratePackageOnBuild.Text">
+        <source>&amp;Generate NuGet package on build</source>
+        <target state="new">&amp;Generate NuGet package on build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeutralLanguageLabel.Text">
+        <source>Assembly &amp;neutral language:</source>
+        <target state="new">Assembly &amp;neutral language:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageRequireLicenseAcceptance.Text">
+        <source>Require &amp;license acceptance</source>
+        <target state="new">Require &amp;license acceptance</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdLabel.Text">
+        <source>Package &amp;id:</source>
+        <target state="new">Package &amp;id:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AuthorsLabel.Text">
+        <source>&amp;Authors:</source>
+        <target state="new">&amp;Authors:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyCompanyLabel.Text">
+        <source>Compan&amp;y:</source>
+        <target state="new">Compan&amp;y:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProductLabel.Text">
+        <source>&amp;Product:</source>
+        <target state="new">&amp;Product:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyFileVersionLabel.Text">
+        <source>Assembly &amp;file version:</source>
+        <target state="new">Assembly &amp;file version:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ja.xlf
@@ -1,0 +1,143 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx">
+    <body>
+      <group id="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx" />
+      <trans-unit id="AssemblyVersionLabel.Text">
+        <source>&amp;Assembly version:</source>
+        <target state="new">&amp;Assembly version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CopyrightLabel.Text">
+        <source>&amp;Copyright:</source>
+        <target state="new">&amp;Copyright:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionLabel.Text">
+        <source>&amp;Description:</source>
+        <target state="new">&amp;Description:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIconUrlLabel.Text">
+        <source>&amp;Icon URL:</source>
+        <target state="new">&amp;Icon URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionLabel.Text">
+        <source>Package &amp;version:</source>
+        <target state="new">Package &amp;version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageLicenseUrlLabel.Text">
+        <source>&amp;License URL:</source>
+        <target state="new">&amp;License URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageTagsLabel.Text">
+        <source>&amp;Tags:</source>
+        <target state="new">&amp;Tags:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryUrlLabel.Text">
+        <source>&amp;Repository URL:</source>
+        <target state="new">&amp;Repository URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageReleaseNotesLabel.Text">
+        <source>Release &amp;notes:</source>
+        <target state="new">Release &amp;notes:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryTypeLabel.Text">
+        <source>&amp;Repository type:</source>
+        <target state="new">&amp;Repository type:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageProjectUrlLabel.Text">
+        <source>&amp;Project URL:</source>
+        <target state="new">&amp;Project URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratePackageOnBuild.Text">
+        <source>&amp;Generate NuGet package on build</source>
+        <target state="new">&amp;Generate NuGet package on build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeutralLanguageLabel.Text">
+        <source>Assembly &amp;neutral language:</source>
+        <target state="new">Assembly &amp;neutral language:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageRequireLicenseAcceptance.Text">
+        <source>Require &amp;license acceptance</source>
+        <target state="new">Require &amp;license acceptance</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdLabel.Text">
+        <source>Package &amp;id:</source>
+        <target state="new">Package &amp;id:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AuthorsLabel.Text">
+        <source>&amp;Authors:</source>
+        <target state="new">&amp;Authors:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyCompanyLabel.Text">
+        <source>Compan&amp;y:</source>
+        <target state="new">Compan&amp;y:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProductLabel.Text">
+        <source>&amp;Product:</source>
+        <target state="new">&amp;Product:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyFileVersionLabel.Text">
+        <source>Assembly &amp;file version:</source>
+        <target state="new">Assembly &amp;file version:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ko.xlf
@@ -1,0 +1,143 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx">
+    <body>
+      <group id="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx" />
+      <trans-unit id="AssemblyVersionLabel.Text">
+        <source>&amp;Assembly version:</source>
+        <target state="new">&amp;Assembly version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CopyrightLabel.Text">
+        <source>&amp;Copyright:</source>
+        <target state="new">&amp;Copyright:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionLabel.Text">
+        <source>&amp;Description:</source>
+        <target state="new">&amp;Description:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIconUrlLabel.Text">
+        <source>&amp;Icon URL:</source>
+        <target state="new">&amp;Icon URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionLabel.Text">
+        <source>Package &amp;version:</source>
+        <target state="new">Package &amp;version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageLicenseUrlLabel.Text">
+        <source>&amp;License URL:</source>
+        <target state="new">&amp;License URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageTagsLabel.Text">
+        <source>&amp;Tags:</source>
+        <target state="new">&amp;Tags:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryUrlLabel.Text">
+        <source>&amp;Repository URL:</source>
+        <target state="new">&amp;Repository URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageReleaseNotesLabel.Text">
+        <source>Release &amp;notes:</source>
+        <target state="new">Release &amp;notes:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryTypeLabel.Text">
+        <source>&amp;Repository type:</source>
+        <target state="new">&amp;Repository type:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageProjectUrlLabel.Text">
+        <source>&amp;Project URL:</source>
+        <target state="new">&amp;Project URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratePackageOnBuild.Text">
+        <source>&amp;Generate NuGet package on build</source>
+        <target state="new">&amp;Generate NuGet package on build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeutralLanguageLabel.Text">
+        <source>Assembly &amp;neutral language:</source>
+        <target state="new">Assembly &amp;neutral language:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageRequireLicenseAcceptance.Text">
+        <source>Require &amp;license acceptance</source>
+        <target state="new">Require &amp;license acceptance</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdLabel.Text">
+        <source>Package &amp;id:</source>
+        <target state="new">Package &amp;id:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AuthorsLabel.Text">
+        <source>&amp;Authors:</source>
+        <target state="new">&amp;Authors:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyCompanyLabel.Text">
+        <source>Compan&amp;y:</source>
+        <target state="new">Compan&amp;y:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProductLabel.Text">
+        <source>&amp;Product:</source>
+        <target state="new">&amp;Product:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyFileVersionLabel.Text">
+        <source>Assembly &amp;file version:</source>
+        <target state="new">Assembly &amp;file version:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.pl.xlf
@@ -1,0 +1,143 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx">
+    <body>
+      <group id="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx" />
+      <trans-unit id="AssemblyVersionLabel.Text">
+        <source>&amp;Assembly version:</source>
+        <target state="new">&amp;Assembly version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CopyrightLabel.Text">
+        <source>&amp;Copyright:</source>
+        <target state="new">&amp;Copyright:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionLabel.Text">
+        <source>&amp;Description:</source>
+        <target state="new">&amp;Description:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIconUrlLabel.Text">
+        <source>&amp;Icon URL:</source>
+        <target state="new">&amp;Icon URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionLabel.Text">
+        <source>Package &amp;version:</source>
+        <target state="new">Package &amp;version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageLicenseUrlLabel.Text">
+        <source>&amp;License URL:</source>
+        <target state="new">&amp;License URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageTagsLabel.Text">
+        <source>&amp;Tags:</source>
+        <target state="new">&amp;Tags:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryUrlLabel.Text">
+        <source>&amp;Repository URL:</source>
+        <target state="new">&amp;Repository URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageReleaseNotesLabel.Text">
+        <source>Release &amp;notes:</source>
+        <target state="new">Release &amp;notes:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryTypeLabel.Text">
+        <source>&amp;Repository type:</source>
+        <target state="new">&amp;Repository type:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageProjectUrlLabel.Text">
+        <source>&amp;Project URL:</source>
+        <target state="new">&amp;Project URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratePackageOnBuild.Text">
+        <source>&amp;Generate NuGet package on build</source>
+        <target state="new">&amp;Generate NuGet package on build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeutralLanguageLabel.Text">
+        <source>Assembly &amp;neutral language:</source>
+        <target state="new">Assembly &amp;neutral language:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageRequireLicenseAcceptance.Text">
+        <source>Require &amp;license acceptance</source>
+        <target state="new">Require &amp;license acceptance</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdLabel.Text">
+        <source>Package &amp;id:</source>
+        <target state="new">Package &amp;id:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AuthorsLabel.Text">
+        <source>&amp;Authors:</source>
+        <target state="new">&amp;Authors:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyCompanyLabel.Text">
+        <source>Compan&amp;y:</source>
+        <target state="new">Compan&amp;y:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProductLabel.Text">
+        <source>&amp;Product:</source>
+        <target state="new">&amp;Product:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyFileVersionLabel.Text">
+        <source>Assembly &amp;file version:</source>
+        <target state="new">Assembly &amp;file version:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.pt-BR.xlf
@@ -1,0 +1,143 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx">
+    <body>
+      <group id="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx" />
+      <trans-unit id="AssemblyVersionLabel.Text">
+        <source>&amp;Assembly version:</source>
+        <target state="new">&amp;Assembly version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CopyrightLabel.Text">
+        <source>&amp;Copyright:</source>
+        <target state="new">&amp;Copyright:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionLabel.Text">
+        <source>&amp;Description:</source>
+        <target state="new">&amp;Description:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIconUrlLabel.Text">
+        <source>&amp;Icon URL:</source>
+        <target state="new">&amp;Icon URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionLabel.Text">
+        <source>Package &amp;version:</source>
+        <target state="new">Package &amp;version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageLicenseUrlLabel.Text">
+        <source>&amp;License URL:</source>
+        <target state="new">&amp;License URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageTagsLabel.Text">
+        <source>&amp;Tags:</source>
+        <target state="new">&amp;Tags:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryUrlLabel.Text">
+        <source>&amp;Repository URL:</source>
+        <target state="new">&amp;Repository URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageReleaseNotesLabel.Text">
+        <source>Release &amp;notes:</source>
+        <target state="new">Release &amp;notes:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryTypeLabel.Text">
+        <source>&amp;Repository type:</source>
+        <target state="new">&amp;Repository type:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageProjectUrlLabel.Text">
+        <source>&amp;Project URL:</source>
+        <target state="new">&amp;Project URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratePackageOnBuild.Text">
+        <source>&amp;Generate NuGet package on build</source>
+        <target state="new">&amp;Generate NuGet package on build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeutralLanguageLabel.Text">
+        <source>Assembly &amp;neutral language:</source>
+        <target state="new">Assembly &amp;neutral language:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageRequireLicenseAcceptance.Text">
+        <source>Require &amp;license acceptance</source>
+        <target state="new">Require &amp;license acceptance</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdLabel.Text">
+        <source>Package &amp;id:</source>
+        <target state="new">Package &amp;id:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AuthorsLabel.Text">
+        <source>&amp;Authors:</source>
+        <target state="new">&amp;Authors:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyCompanyLabel.Text">
+        <source>Compan&amp;y:</source>
+        <target state="new">Compan&amp;y:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProductLabel.Text">
+        <source>&amp;Product:</source>
+        <target state="new">&amp;Product:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyFileVersionLabel.Text">
+        <source>Assembly &amp;file version:</source>
+        <target state="new">Assembly &amp;file version:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ru.xlf
@@ -1,0 +1,143 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx">
+    <body>
+      <group id="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx" />
+      <trans-unit id="AssemblyVersionLabel.Text">
+        <source>&amp;Assembly version:</source>
+        <target state="new">&amp;Assembly version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CopyrightLabel.Text">
+        <source>&amp;Copyright:</source>
+        <target state="new">&amp;Copyright:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionLabel.Text">
+        <source>&amp;Description:</source>
+        <target state="new">&amp;Description:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIconUrlLabel.Text">
+        <source>&amp;Icon URL:</source>
+        <target state="new">&amp;Icon URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionLabel.Text">
+        <source>Package &amp;version:</source>
+        <target state="new">Package &amp;version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageLicenseUrlLabel.Text">
+        <source>&amp;License URL:</source>
+        <target state="new">&amp;License URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageTagsLabel.Text">
+        <source>&amp;Tags:</source>
+        <target state="new">&amp;Tags:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryUrlLabel.Text">
+        <source>&amp;Repository URL:</source>
+        <target state="new">&amp;Repository URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageReleaseNotesLabel.Text">
+        <source>Release &amp;notes:</source>
+        <target state="new">Release &amp;notes:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryTypeLabel.Text">
+        <source>&amp;Repository type:</source>
+        <target state="new">&amp;Repository type:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageProjectUrlLabel.Text">
+        <source>&amp;Project URL:</source>
+        <target state="new">&amp;Project URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratePackageOnBuild.Text">
+        <source>&amp;Generate NuGet package on build</source>
+        <target state="new">&amp;Generate NuGet package on build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeutralLanguageLabel.Text">
+        <source>Assembly &amp;neutral language:</source>
+        <target state="new">Assembly &amp;neutral language:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageRequireLicenseAcceptance.Text">
+        <source>Require &amp;license acceptance</source>
+        <target state="new">Require &amp;license acceptance</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdLabel.Text">
+        <source>Package &amp;id:</source>
+        <target state="new">Package &amp;id:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AuthorsLabel.Text">
+        <source>&amp;Authors:</source>
+        <target state="new">&amp;Authors:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyCompanyLabel.Text">
+        <source>Compan&amp;y:</source>
+        <target state="new">Compan&amp;y:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProductLabel.Text">
+        <source>&amp;Product:</source>
+        <target state="new">&amp;Product:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyFileVersionLabel.Text">
+        <source>Assembly &amp;file version:</source>
+        <target state="new">Assembly &amp;file version:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.tr.xlf
@@ -1,0 +1,143 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx">
+    <body>
+      <group id="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx" />
+      <trans-unit id="AssemblyVersionLabel.Text">
+        <source>&amp;Assembly version:</source>
+        <target state="new">&amp;Assembly version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CopyrightLabel.Text">
+        <source>&amp;Copyright:</source>
+        <target state="new">&amp;Copyright:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionLabel.Text">
+        <source>&amp;Description:</source>
+        <target state="new">&amp;Description:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIconUrlLabel.Text">
+        <source>&amp;Icon URL:</source>
+        <target state="new">&amp;Icon URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionLabel.Text">
+        <source>Package &amp;version:</source>
+        <target state="new">Package &amp;version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageLicenseUrlLabel.Text">
+        <source>&amp;License URL:</source>
+        <target state="new">&amp;License URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageTagsLabel.Text">
+        <source>&amp;Tags:</source>
+        <target state="new">&amp;Tags:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryUrlLabel.Text">
+        <source>&amp;Repository URL:</source>
+        <target state="new">&amp;Repository URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageReleaseNotesLabel.Text">
+        <source>Release &amp;notes:</source>
+        <target state="new">Release &amp;notes:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryTypeLabel.Text">
+        <source>&amp;Repository type:</source>
+        <target state="new">&amp;Repository type:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageProjectUrlLabel.Text">
+        <source>&amp;Project URL:</source>
+        <target state="new">&amp;Project URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratePackageOnBuild.Text">
+        <source>&amp;Generate NuGet package on build</source>
+        <target state="new">&amp;Generate NuGet package on build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeutralLanguageLabel.Text">
+        <source>Assembly &amp;neutral language:</source>
+        <target state="new">Assembly &amp;neutral language:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageRequireLicenseAcceptance.Text">
+        <source>Require &amp;license acceptance</source>
+        <target state="new">Require &amp;license acceptance</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdLabel.Text">
+        <source>Package &amp;id:</source>
+        <target state="new">Package &amp;id:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AuthorsLabel.Text">
+        <source>&amp;Authors:</source>
+        <target state="new">&amp;Authors:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyCompanyLabel.Text">
+        <source>Compan&amp;y:</source>
+        <target state="new">Compan&amp;y:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProductLabel.Text">
+        <source>&amp;Product:</source>
+        <target state="new">&amp;Product:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyFileVersionLabel.Text">
+        <source>Assembly &amp;file version:</source>
+        <target state="new">Assembly &amp;file version:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.xlf
@@ -1,0 +1,116 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" original="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx">
+    <body>
+      <group id="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx" />
+      <trans-unit id="AssemblyVersionLabel.Text">
+        <source>&amp;Assembly version:</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="CopyrightLabel.Text">
+        <source>&amp;Copyright:</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionLabel.Text">
+        <source>&amp;Description:</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIconUrlLabel.Text">
+        <source>&amp;Icon URL:</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionLabel.Text">
+        <source>Package &amp;version:</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageLicenseUrlLabel.Text">
+        <source>&amp;License URL:</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageTagsLabel.Text">
+        <source>&amp;Tags:</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryUrlLabel.Text">
+        <source>&amp;Repository URL:</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageReleaseNotesLabel.Text">
+        <source>Release &amp;notes:</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryTypeLabel.Text">
+        <source>&amp;Repository type:</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageProjectUrlLabel.Text">
+        <source>&amp;Project URL:</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratePackageOnBuild.Text">
+        <source>&amp;Generate NuGet package on build</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeutralLanguageLabel.Text">
+        <source>Assembly &amp;neutral language:</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageRequireLicenseAcceptance.Text">
+        <source>Require &amp;license acceptance</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdLabel.Text">
+        <source>Package &amp;id:</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="AuthorsLabel.Text">
+        <source>&amp;Authors:</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyCompanyLabel.Text">
+        <source>Compan&amp;y:</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProductLabel.Text">
+        <source>&amp;Product:</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyFileVersionLabel.Text">
+        <source>Assembly &amp;file version:</source>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.zh-Hans.xlf
@@ -1,0 +1,143 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx">
+    <body>
+      <group id="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx" />
+      <trans-unit id="AssemblyVersionLabel.Text">
+        <source>&amp;Assembly version:</source>
+        <target state="new">&amp;Assembly version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CopyrightLabel.Text">
+        <source>&amp;Copyright:</source>
+        <target state="new">&amp;Copyright:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionLabel.Text">
+        <source>&amp;Description:</source>
+        <target state="new">&amp;Description:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIconUrlLabel.Text">
+        <source>&amp;Icon URL:</source>
+        <target state="new">&amp;Icon URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionLabel.Text">
+        <source>Package &amp;version:</source>
+        <target state="new">Package &amp;version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageLicenseUrlLabel.Text">
+        <source>&amp;License URL:</source>
+        <target state="new">&amp;License URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageTagsLabel.Text">
+        <source>&amp;Tags:</source>
+        <target state="new">&amp;Tags:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryUrlLabel.Text">
+        <source>&amp;Repository URL:</source>
+        <target state="new">&amp;Repository URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageReleaseNotesLabel.Text">
+        <source>Release &amp;notes:</source>
+        <target state="new">Release &amp;notes:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryTypeLabel.Text">
+        <source>&amp;Repository type:</source>
+        <target state="new">&amp;Repository type:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageProjectUrlLabel.Text">
+        <source>&amp;Project URL:</source>
+        <target state="new">&amp;Project URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratePackageOnBuild.Text">
+        <source>&amp;Generate NuGet package on build</source>
+        <target state="new">&amp;Generate NuGet package on build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeutralLanguageLabel.Text">
+        <source>Assembly &amp;neutral language:</source>
+        <target state="new">Assembly &amp;neutral language:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageRequireLicenseAcceptance.Text">
+        <source>Require &amp;license acceptance</source>
+        <target state="new">Require &amp;license acceptance</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdLabel.Text">
+        <source>Package &amp;id:</source>
+        <target state="new">Package &amp;id:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AuthorsLabel.Text">
+        <source>&amp;Authors:</source>
+        <target state="new">&amp;Authors:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyCompanyLabel.Text">
+        <source>Compan&amp;y:</source>
+        <target state="new">Compan&amp;y:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProductLabel.Text">
+        <source>&amp;Product:</source>
+        <target state="new">&amp;Product:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyFileVersionLabel.Text">
+        <source>Assembly &amp;file version:</source>
+        <target state="new">Assembly &amp;file version:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.zh-Hant.xlf
@@ -1,0 +1,143 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx">
+    <body>
+      <group id="src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx" />
+      <trans-unit id="AssemblyVersionLabel.Text">
+        <source>&amp;Assembly version:</source>
+        <target state="new">&amp;Assembly version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CopyrightLabel.Text">
+        <source>&amp;Copyright:</source>
+        <target state="new">&amp;Copyright:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionLabel.Text">
+        <source>&amp;Description:</source>
+        <target state="new">&amp;Description:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIconUrlLabel.Text">
+        <source>&amp;Icon URL:</source>
+        <target state="new">&amp;Icon URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageVersionLabel.Text">
+        <source>Package &amp;version:</source>
+        <target state="new">Package &amp;version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageLicenseUrlLabel.Text">
+        <source>&amp;License URL:</source>
+        <target state="new">&amp;License URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageTagsLabel.Text">
+        <source>&amp;Tags:</source>
+        <target state="new">&amp;Tags:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryUrlLabel.Text">
+        <source>&amp;Repository URL:</source>
+        <target state="new">&amp;Repository URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageReleaseNotesLabel.Text">
+        <source>Release &amp;notes:</source>
+        <target state="new">Release &amp;notes:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RepositoryTypeLabel.Text">
+        <source>&amp;Repository type:</source>
+        <target state="new">&amp;Repository type:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageProjectUrlLabel.Text">
+        <source>&amp;Project URL:</source>
+        <target state="new">&amp;Project URL:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratePackageOnBuild.Text">
+        <source>&amp;Generate NuGet package on build</source>
+        <target state="new">&amp;Generate NuGet package on build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeutralLanguageLabel.Text">
+        <source>Assembly &amp;neutral language:</source>
+        <target state="new">Assembly &amp;neutral language:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
+        <source>Revision</source>
+        <target state="new">Revision</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionBuildTextBox.AccessibleName">
+        <source>Build</source>
+        <target state="new">Build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMinorTextBox.AccessibleName">
+        <source>Minor</source>
+        <target state="new">Minor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileVersionMajorTextBox.AccessibleName">
+        <source>Major</source>
+        <target state="new">Major</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageRequireLicenseAcceptance.Text">
+        <source>Require &amp;license acceptance</source>
+        <target state="new">Require &amp;license acceptance</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdLabel.Text">
+        <source>Package &amp;id:</source>
+        <target state="new">Package &amp;id:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AuthorsLabel.Text">
+        <source>&amp;Authors:</source>
+        <target state="new">&amp;Authors:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyCompanyLabel.Text">
+        <source>Compan&amp;y:</source>
+        <target state="new">Compan&amp;y:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProductLabel.Text">
+        <source>&amp;Product:</source>
+        <target state="new">&amp;Product:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AssemblyFileVersionLabel.Text">
+        <source>Assembly &amp;file version:</source>
+        <target state="new">Assembly &amp;file version:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ReferencePathsPropPage.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ReferencePathsPropPage.xlf
@@ -5,43 +5,43 @@
       <group id="src/Microsoft.VisualStudio.Editors/PropPages/ReferencePathsPropPage.resx" />
       <trans-unit id="AddFolder.Text">
         <source>&amp;Add Folder</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="UpdateFolder.Text">
         <source>&amp;Update</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ReferencePath.AccessibleName">
         <source>Order of Reference Paths</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ReferencePathLabel.Text">
         <source>Reference &amp;paths:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="FolderBrowse.AccessibleName">
         <source>Browse for Folder</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="FolderBrowse.Text">
         <source>...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="MoveUp.AccessibleName">
         <source>Move up</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="MoveDown.AccessibleName">
         <source>Move down</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RemoveFolder.AccessibleName">
         <source>Delete</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="FolderLabel.Text">
         <source>&amp;Folder:</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ReferencePropPage.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ReferencePropPage.xlf
@@ -5,87 +5,87 @@
       <group id="src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.resx" />
       <trans-unit id="ReferenceListLabel.Text">
         <source>&amp;References:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ColHdr_RefName.Text">
         <source>Reference Name</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ColHdr_Type.Text">
         <source>Type</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ColHdr_Version.Text">
         <source>Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ColHdr_CopyLocal.Text">
         <source>Copy Local</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ColHdr_Path.Text">
         <source>Path</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="UnusedReferences.Text">
         <source>U&amp;nused References...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ReferencePathsButton.Text">
         <source>Reference &amp;Paths...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RemoveReference.Text">
         <source>Remo&amp;ve</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="referenceToolStripMenuItem.Text">
         <source>Reference...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="webReferenceToolStripMenuItem.Text">
         <source>Web Reference...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="serviceReferenceToolStripMenuItem.Text">
         <source>Service Reference...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="addSplitButton.Text">
         <source>&amp;Add...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="UpdateReferences.Text">
         <source>&amp;Update</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="AddUserImportButton.Text">
         <source>Add User Imp&amp;ort</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="UpdateUserImportButton.Text">
         <source>Up&amp;date User Import</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ImportList.AccessibleDescription">
         <source>List of imported namespaces.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ImportList.AccessibleName">
         <source>Imported Namespaces:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="UserImportTextBox.AccessibleName">
         <source>Imported Namespace:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ImportsListLabel.Text">
         <source>&amp;Imported namespaces:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ReferencePageSplitContainer.Text">
         <source>ReferencePageSplitContainer</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ServicesAuthenticationForm.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ServicesAuthenticationForm.xlf
@@ -5,34 +5,34 @@
       <group id="src/Microsoft.VisualStudio.Editors/PropPages/ServicesAuthenticationForm.resx" />
       <trans-unit id="AuthenticationServiceUrlLabel.Text">
         <source>&amp;Authentication service location:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="UserNameLabel.Text">
         <source>&amp;Username:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PasswordLabel.Text">
         <source>&amp;Password:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="OKButton.Text">
         <source>&amp;Log In</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Cancel.Text">
         <source>&amp;Skip Login</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="InfoLabel.Text">
         <source>To retrieve Web settings for a particular user, specify the user credentials and click Log In. To skip authentication and retrieve Web settings for anonymous users, click Skip Login. 
  
 You can modify the location of the authentication and Web settings services on the Services page of the Project Designer. 
 </source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="$this.Text">
         <source>Login</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ServicesPropPage.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ServicesPropPage.xlf
@@ -5,44 +5,44 @@
       <group id="src/Microsoft.VisualStudio.Editors/PropPages/ServicesPropPage.resx" />
       <trans-unit id="HelpLabel.Text">
         <source>Client application services enable your Windows-based applications to use the ASP.NET login (authentication), roles, and profile (settings) services.  Learn more about client application services...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="WindowsBasedAuth.Text">
         <source>Use &amp;Windows authentication</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="FormBasedAuth.Text">
         <source>Use &amp;Forms authentication</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="CustomCredentialProviderTypeLabel.Text">
         <source>Optional: Credentials &amp;provider
 (for example: MyNamespace.MyLoginClass, MyAssembly):</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="AuthenticationServiceUrlLabel.Text">
         <source>&amp;Authentication service location:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="AuthenticationProviderGroupBox.Text">
         <source>Authentication</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RolesServiceUrlLabel.Text">
         <source>&amp;Roles service location:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="WebSettingsUrlLabel.Text">
         <source>We&amp;b settings service location:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="AdvancedSettings.Text">
         <source>A&amp;dvanced...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnableApplicationServices.Text">
         <source>&amp;Enable client application services</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.xlf
@@ -9,11 +9,11 @@
 1. Ensure that any custom permissions defining assemblies referenced by your project have been properly installed to the GAC. If any of these assemblies have been rebuilt or have had their version numbers modified, you must install the new assemblies in the GAC.
  
 2. Restart Visual Studio.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="InstallOtherFrameworks">
         <source>Install other frameworks...</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/UnusedReferencePropPage.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/UnusedReferencePropPage.xlf
@@ -5,31 +5,31 @@
       <group id="src/Microsoft.VisualStudio.Editors/PropPages/UnusedReferencePropPage.resx" />
       <trans-unit id="ColHdr_Type.Text">
         <source>Type</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ColHdr_Path.Text">
         <source>Path</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="UnusedReferenceList.AccessibleName">
         <source>Unused references</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ColHdr_RefName.Text">
         <source>Reference Name</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ColHdr_Version.Text">
         <source>Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ColHdr_CopyLocal.Text">
         <source>Copy Local</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="UnusedReferencesListLabel.Text">
         <source>Clicking "Remove" will remove all checked references.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/compileproppage2.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/compileproppage2.xlf
@@ -5,79 +5,79 @@
       <group id="src/Microsoft.VisualStudio.Editors/PropPages/compileproppage2.resx" />
       <trans-unit id="BuildOutputPathButton.AccessibleName">
         <source>Browse...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BuildOutputPathButton.Text">
         <source>B&amp;rowse...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="OptionExplicitLabel.Text">
         <source>Option e&amp;xplicit:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DisableAllWarningsCheckBox.Text">
         <source>D&amp;isable all warnings</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="WarningsAsErrorCheckBox.Text">
         <source>Treat a&amp;ll warnings as errors</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BuildEventsButton.Text">
         <source>Build Eve&amp;nts...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RegisterForComInteropCheckBox.Text">
         <source>R&amp;egister for COM interop</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="GenerateXMLCheckBox.Text">
         <source>&amp;Generate XML documentation file</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="OptionStrictLabel.Text">
         <source>Option &amp;strict:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="OptionCompareLabel.Text">
         <source>Option c&amp;ompare:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="OptionInferLabel.Text">
         <source>Option in&amp;fer:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="WarningsConfigurationsGridViewLabel.Text">
         <source>Warning configurations:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ConditionColumn.HeaderText">
         <source>Condition</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NotificationColumn.HeaderText">
         <source>Notification</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="AdvancedOptionsButton.Text">
         <source>&amp;Advanced Compile Options...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="CompileOptionsGroupBox.Text">
         <source>Compile Options:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BuildOutputPathLabel.Text">
         <source>B&amp;uild output path:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="TargetCPULabel.Text">
         <source>&amp;Target CPU:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Prefer32BitCheckBox.Text">
         <source>&amp;Prefer 32-bit</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/xlf/DialogQueryName.xlf
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/xlf/DialogQueryName.xlf
@@ -5,19 +5,19 @@
       <group id="src/Microsoft.VisualStudio.Editors/ResourceEditor/DialogQueryName.resx" />
       <trans-unit id="LabelDescription.Text">
         <source>P&amp;lease enter a name for the new resource.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ButtonCancel.Text">
         <source>Cancel</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ButtonAdd.Text">
         <source>&amp;Add</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="$this.Text">
         <source>Add New Resource</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/xlf/OpenFileWarningDialog.xlf
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/xlf/OpenFileWarningDialog.xlf
@@ -5,27 +5,27 @@
       <group id="src/Microsoft.VisualStudio.Editors/ResourceEditor/OpenFileWarningDialog.resx" />
       <trans-unit id="alwaysCheckCheckBox.Text">
         <source>&amp;Always ask before opening this file type.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="messageLabel.Text">
         <source>The Managed Resource Editor does not support the requested file type. Would you like to open the default editor for "{0}"?</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="buttonOK.Text">
         <source>OK</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="buttonCancel.Text">
         <source>Cancel</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="messageLabel2.Text">
         <source>Some files could contain malicious content.  You should only answer Yes if you trust the source of this file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="$this.Text">
         <source>Open File</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.cs.xlf
@@ -2709,6 +2709,16 @@ Chcete aktualizovat hodnotu v souboru .settings?</target>
         <target state="translated">Aktuální importy</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_PackageTitle">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PPG_Property_PackageVersion">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.de.xlf
@@ -2709,6 +2709,16 @@ Möchten Sie den Wert in der SETTINGS-Datei aktualisieren?</target>
         <target state="translated">Aktuelle Importe</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_PackageTitle">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PPG_Property_PackageVersion">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.es.xlf
@@ -2709,6 +2709,16 @@ El nuevo valor del archivo app.config es '{1}'
         <target state="translated">Importaciones actuales</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_PackageTitle">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PPG_Property_PackageVersion">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.fr.xlf
@@ -2709,6 +2709,16 @@ Voulez-vous mettre à jour la valeur dans le fichier .settings ?</target>
         <target state="translated">Importations actuelles</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_PackageTitle">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PPG_Property_PackageVersion">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.it.xlf
@@ -2709,6 +2709,16 @@ Aggiornare il valore nel file .settings?</target>
         <target state="translated">Importazioni correnti</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_PackageTitle">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PPG_Property_PackageVersion">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ja.xlf
@@ -2709,6 +2709,16 @@ app.config ファイルでの新しい値は '{1}' です
         <target state="translated">現在のインポート</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_PackageTitle">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PPG_Property_PackageVersion">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ko.xlf
@@ -2709,6 +2709,16 @@ app.config 파일의 새 값은 '{1}'입니다.
         <target state="translated">현재 가져오기</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_PackageTitle">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PPG_Property_PackageVersion">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pl.xlf
@@ -2709,6 +2709,16 @@ Czy chcesz zaktualizować wartość w pliku settings?</target>
         <target state="translated">Bieżące importy</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_PackageTitle">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PPG_Property_PackageVersion">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pt-BR.xlf
@@ -2709,6 +2709,16 @@ Deseja atualizar o valor no arquivo .settings?</target>
         <target state="translated">Importações Atuais</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_PackageTitle">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PPG_Property_PackageVersion">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ru.xlf
@@ -2709,6 +2709,16 @@ Do you want to update the value in the .settings file?</source>
         <target state="translated">Текущие операции импорта</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_PackageTitle">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PPG_Property_PackageVersion">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.tr.xlf
@@ -2709,6 +2709,16 @@ app.config dosyasındaki yeni değer: '{1}'
         <target state="translated">Geçerli İçeri Aktarmalar</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_PackageTitle">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PPG_Property_PackageVersion">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.xlf
@@ -2164,6 +2164,14 @@ Do you want to update the value in the .settings file?</source>
         <source>Current Imports</source>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_PackageTitle">
+        <source>Package</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PPG_Property_PackageVersion">
+        <source>Package Version</source>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.xlf
@@ -5,105 +5,105 @@
       <group id="src/Microsoft.VisualStudio.Editors/Resources/Microsoft.VisualStudio.Editors.Designer.resx" />
       <trans-unit id="CMN_AllFilesFilter">
         <source>All Files</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_PropertyPageControlName">
         <source>Property Page</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_ReferencesTitle">
         <source>References</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_VersionTitle">
         <source>Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SigningTitle">
         <source>Signing</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_ApplicationTitle">
         <source>Application</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_CompileTitle">
         <source>Compile</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_DebugTitle">
         <source>Debug</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_DeployTitle">
         <source>Deploy</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_VdtGeneralTitle">
         <source>Database</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Security">
         <source>Security</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_BuildTitle">
         <source>Build</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_BuildEventsTitle">
         <source>Build Events</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_ReferencePathsTitle">
         <source>Reference Paths</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_PreBuildCommandLineTitle">
         <source>Pre-build Event Command Line</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_PostBuildCommandLineTitle">
         <source>Post-build Event Command Line</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_OutputPathNotSecure">
         <source>The output path is not trusted.
 The application may throw security exceptions when it attempts to perform actions which require full trust.
 Click OK to ignore and continue. Click CANCEL to choose a different output path.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_BrowseText">
         <source>&lt;Browse...&gt;</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_StartupObjectNone">
         <source>(None)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_KeyFileNewText">
         <source>&lt;New...&gt;</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_KeyFileBrowseText">
         <source>&lt;Browse...&gt;</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_ComboBoxSelect_None">
         <source>(None)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_ActiveConfigOrPlatformFormatString_1Arg">
         <source>Active ({0})</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_AllConfigurations">
         <source>All Configurations</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_AllPlatforms">
         <source>All Platforms</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_NotApplicable">
         <source>N/A</source>
@@ -111,116 +111,116 @@ Click OK to ignore and continue. Click CANCEL to choose a different output path.
       </trans-unit>
       <trans-unit id="PPG_ConfigNotFound_2Args">
         <source>Could not find the configuration '{0}' for platform '{1}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_NeutralLanguage_None">
         <source>(None)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SelectFileTitle">
         <source>Select File</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_AddExistingFilesTitle">
         <source>Add existing file to project</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_AddIconFilesFilter">
         <source>Icon Files</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_ExeFilesFilter">
         <source>Executable Files</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SelectWorkingDirectoryTitle">
         <source>Select Working Directory</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SelectOutputPathTitle">
         <source>Select Output Path</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SelectReferencePath">
         <source>Select Reference Path</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_AddWin32ResourceFilter">
         <source>Win32 Resource Files</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_AddWin32ResourceTitle">
         <source>Add Win32 resource file to project</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_InvalidFolderPath">
         <source>Folder path does not exist.
 Please select a valid folder path.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_AdvancedCompilerSettings_Title">
         <source>Advanced Compiler Settings</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_AdvancedBuildSettings_Title">
         <source>Advanced Build Settings</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_CompilerWarnings_Title">
         <source>Compiler Warnings</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_ReferencePaths_Title">
         <source>Reference Paths</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_CompatibleSettings_Title">
         <source>Compatible Settings</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_AssemblyInfo_Title">
         <source>Assembly Information</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_AssemblyInfo_InvalidVersion">
         <source>Invalid version format, expected "[Major]", "[Major].[Minor]", "[Major].[Minor].[Build]" or "[Major].[Minor].[Build].[Revision]"</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_AssemblyInfo_BadWildcard">
         <source>A wildcard ("*") is not allowed in this field.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_AssemblyInfo_VersionOutOfRange_2Args">
         <source>Each part of the version number for '{0}' must be an integer between 0 and {1}.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_DefaultIconText">
         <source>(Default Icon)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_InvalidSubMainStartup">
         <source>Startup object must be a form when 'Enable application framework' is checked.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_StartupObjectNotSet">
         <source>(Not set)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_CantAddIcon">
         <source>Icon could not be added to the project.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_BadIcon">
         <source>Invalid icon file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_BadIcon_1Arg">
         <source>{0} is not a valid icon file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_BadGuid">
         <source>The GUID should match the format dddddddd-dddd-dddd-dddd-dddddddddddd.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_MyAppCommentLine1">
         <source>NOTE: This file is auto-generated; do not modify it directly.  To make changes,</source>
@@ -228,128 +228,128 @@ Please select a valid folder path.</source>
       </trans-unit>
       <trans-unit id="PPG_Application_MyAppCommentLine2">
         <source> or if you encounter build errors in this file, go to the Project Designer</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_MyAppCommentLine3">
         <source> (go to Project Properties or double-click the My Project node in</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_MyAppCommentLine4">
         <source> Solution Explorer), and make changes on the Application tab.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_InvalidIdentifierStartupForm_1Arg">
         <source>'{0}' is not a valid identifier. Please select a different Startup form.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_InvalidIdentifierSplashScreenForm_1Arg">
         <source>'{0}' is not a valid identifier. Please select a different Splash screen form.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_SplashSameAsStart">
         <source>The splash screen form cannot be the start-up form.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_StartupFormLabelText">
         <source>Startup f&amp;orm:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_AppEventsCommentLine1">
         <source>The following events are available for MyApplication:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_AppEventsCommentLine3">
         <source>Startup: Raised when the application starts, before the startup form is created.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_AppEventsCommentLine4">
         <source>Shutdown: Raised after all application forms are closed.  This event is not raised if the application terminates abnormally.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_AppEventsCommentLine5">
         <source>UnhandledException: Raised if the application encounters an unhandled exception.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_AppEventsCommentLine6">
         <source>StartupNextInstance: Raised when launching a single-instance application and the application is already active. </source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_AppEventsCommentLine7">
         <source>NetworkAvailabilityChanged: Raised when the network connection is connected or disconnected.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_AdvancedBuildSettings_InvalidBaseAddress">
         <source>Base address must be a hexadecimal number with less than or equal to 8 digits, for example, 0x11000000.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Compile_Notification_None">
         <source>None</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Compile_Notification_Warning">
         <source>Warning</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Compile_Notification_Error">
         <source>Error</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Compile_OptionStrict_Custom">
         <source>(custom)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Compile_42016">
         <source>Implicit conversion</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Compile_42017_42018_42019">
         <source>Late binding; call could fail at run time</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Compile_42020">
         <source>Implicit type; object assumed</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Compile_42104">
         <source>Use of variable prior to assignment</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Compile_42105_42106_42107">
         <source>Function returning reference type without return value</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Compile_42353_42354_42355">
         <source>Function returning intrinsic value type without return value</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Compile_42024">
         <source>Unused local variable</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Compile_42025">
         <source>Instance variable accesses shared member</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Compile_42004">
         <source>Recursive operator or property access</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Compile_42029">
         <source>Duplicate or overlapping catch blocks</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Compile_ResetIndeterminateWarningLevels">
         <source>The warning settings for one or more configurations conflict.
 Changing this setting will reset the settings in all configurations.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_MyApplication_StartupMode_FormCloses">
         <source>When startup form closes</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_MyApplication_StartupMode_AppExits">
         <source>When last form closes</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_MyApplication_AuthenMode_Windows">
         <source>Windows</source>
@@ -361,47 +361,47 @@ Changing this setting will reset the settings in all configurations.</source>
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_Cancel">
         <source>Cancel</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_Calculate">
         <source>&amp;Calculate Permissions</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_MgdStatus_Stopped">
         <source>Stopped...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_MgdStatus_Starting">
         <source>Starting...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_MgdStatus_Building">
         <source>Building...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_MgdStatus_Analyzing">
         <source>Analyzing...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_MgdStatus_AnalyzeFailed">
         <source>Analyze Failed</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_MgdStatus_Aborting">
         <source>Aborting...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_MgdStatus_Cancelling">
         <source>Canceling...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_InternetZone">
         <source>Internet</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_LocalIntranetZone">
         <source>Local Intranet</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_CustomZone">
         <source>(Custom)</source>
@@ -409,19 +409,19 @@ Changing this setting will reset the settings in all configurations.</source>
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_ZoneDefault">
         <source>(Zone Default)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_Included">
         <source>Include</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_Excluded">
         <source>Exclude</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_FullTrustToolTip">
         <source>The application will require elevated permissions to run in the selected zone. Click the help link above for more info.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_BadPermissionToolTip">
         <source>This permission could not be loaded. Press the delete key to remove it from your project.</source>
@@ -429,88 +429,88 @@ Changing this setting will reset the settings in all configurations.</source>
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_HeaderIncluded">
         <source>Included</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_HeaderPermission">
         <source>Permission</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_HeaderSetting">
         <source>Setting</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_HelpLabelText">
         <source>Specify the code access security permissions that your ClickOnce application requires in order to run. Learn more about code access security...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_HelpLabelLink">
         <source>Learn more about code access security...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_BadDropDownValue">
         <source>Invalid value</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_SecurityPermissionCannotBeExcluded">
         <source>The SecurityPermission must be included in your application with the Execute flag set or your application will not run. Mark this permission as "Zone Default" or "Include."</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_ExecuteCannotBeExcluded">
         <source>The SecurityPermission must be included in your application with the Execute flag set or your application will not run. The Execute flag has been added to the SecurityPermission in your manifest.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_SwitchToFullTrustDialog">
         <source>This application requires full trust to run correctly. Would you like to set this as a full trust application?</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_SwitchToFullTrustDialogTitle">
         <source>Full Trust Required</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_CouldNotSaveManifest">
         <source>An error occurred and the app.manifest file could not be saved.
 Error:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_CouldNotLoadManifest">
         <source>An error occurred and the app.manifest file could not be loaded. Please remove any changes you have made to the file and reload the Security property page again.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_CheckAccessibilityName">
         <source>Included</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_BlankAccessibilityName">
         <source>Not Included</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_BangAccessibilityName">
         <source>Included with warning</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_PermCalcFailed">
         <source>Calculating permissions failed.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_PermCalcFailedCaption">
         <source>Error</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityAdvancedPage_Title">
         <source>Advanced Security Settings</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_MgdStatus_BuildFailed">
         <source>Build Failed.  Click CANCEL and correct the build failure before analyzing again.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_MgdStatus_BuildComplete">
         <source>Build completed...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_MgdStatus_BuildUnableToStart">
         <source>Unable to start the build.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_MgdStatus_BuildFailedToStart">
         <source>Serious error.  The build must begin in order to analyze permissions.  It has not started.</source>
@@ -522,355 +522,355 @@ Error:</source>
       </trans-unit>
       <trans-unit id="PPG_NonePermissionSet">
         <source>(None)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_KeyFileBrowse_Title">
         <source>Selecting existing key file</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_KeyFileBrowse_Filter">
         <source>Key Files</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_KeyFileNew_Title">
         <source>Create key file</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_OldPassWrong">
         <source>The old password is invalid.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_OldPassEmpty">
         <source>Enter the old password.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_NewPassEmpty">
         <source>Enter a new password.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_NewPassMismatch">
         <source>The new passwords do not match. Enter the password again.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_NewPassTooShort">
         <source>The new password must be at least 6 characters in length. Enter the password again.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_BrowseCertTitle">
         <source>Select a Certificate</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_BrowseCertStorePrompt">
         <source>Select a certificate to sign your ClickOnce manifests</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_BrowseCertFileFilter">
         <source>Certificate Files</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_IssuedTo">
         <source>Issued To</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_IssuedBy">
         <source>Issued By</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_Purpose">
         <source>Intended Purpose</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_ExpirationDate">
         <source>Expiration Date</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_InvalidPassword">
         <source>The password is invalid.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_InvalidPasswordTitle">
         <source>Invalid password</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_NoPrivateKey">
         <source>The selected file does not contain a private key. You must choose a certificate that contains a private key.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_NoPrivateKeyTitle">
         <source>Invalid key</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_CertCreationError">
         <source>Certificate Creation Error</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_AllPurposes">
         <source>&lt;All&gt;</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_PasswordMismatch">
         <source>The passwords do not match.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_NoPassword">
         <source>Enter a password.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_NoConfirm">
         <source>Confirm the password.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_NoData">
         <source>(none)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_OpenExistingKeyPasswordTitle">
         <source>Enter password to open file</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_OpenExistingKeyPasswordPrompt">
         <source>Enter &amp;password to open file {0}</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_CreateNewKeyPasswordPrompt">
         <source>Enter &amp;password for new file {0}</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_ProjectAlreadyContainsFile">
         <source>The project already contains a file with that name. Choose another certificate file or rename the file in your project.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_CouldNotImportFile">
         <source>The file '{0}' could not be imported: {1}</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_KeyFileNameSuffix">
         <source>_TemporaryKey.pfx</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Signing_CertificateNotCodeSigning">
         <source>The selected certificate is not valid for code signing. Choose another certificate file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_UndoTransaction">
         <source>Change property: {0}</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_WindowsApp">
         <source>Windows Application</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_WindowsService">
         <source>Windows Service</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_WindowsClassLib">
         <source>Class Library</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_CommandLineApp">
         <source>Console Application</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_WebControlLib">
         <source>Web Control Library</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Reference_CanNotRemoveReference">
         <source>Cannot remove '{0}'. {1}
 </source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Reference_RemoveImportsFailUnexpected">
         <source>Adding or removing '{0}' as a project import failed because of an unexpected error from the project system.  The error returned was:  '{1}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Reference_AddWebReference">
         <source>Adding web reference failed. {0}
 </source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Reference_FailedToUpdateWebReference">
         <source>Updating web reference '{0}' failed.
 {1}</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_WebReferenceTypeName">
         <source>Web Reference Properties</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_UrlBehavior_Static">
         <source>Static</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_UrlBehavior_Dynamic">
         <source>Dynamic</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_WebReferenceNameDescription">
         <source>Name of the web reference</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_UrlBehaviorName">
         <source>URL Behavior</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_UrlBehaviorDescription">
         <source>Web reference URL behavior</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_WebReferenceUrlName">
         <source>Web Reference URL</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_WebReferenceUrlDescription">
         <source>Web Reference URL</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_ReferenceDetail_Title">
         <source>Reference Properties</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PropPage_ProgramNotExist">
         <source>The external program cannot be found. Please enter a valid executable file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PropPage_NeedExternalProgram">
         <source>The external program property cannot be empty. Please enter a valid executable file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PropPage_NotAnExeError">
         <source>We can only debug an EXE file. Please enter a valid executable file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PropPage_NeedURL">
         <source>The URL property cannot be empty. Please enter a valid URL.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PropPage_InvalidURL">
         <source>The URL is invalid. Please enter a valid URL like "http://www.microsoft.com/"</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PropPage_WorkingDirError">
         <source>The working directory you entered does not exist. Please enter a valid working directory.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PropPage_ReferenceNotFound">
         <source>&lt;The system cannot find the reference specified&gt;</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PropPage_ImportedNamespacesTitle">
         <source>Imported Namespaces</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PropPage_ComputingReferencedNamespacesMessage">
         <source>Computing referenced namespaces...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PropPage_UnusedReferenceTitle">
         <source>Unused References</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PropPage_UnusedReferenceRemoveButton">
         <source>&amp;Remove</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PropPage_UnusedReferenceNoUnusedReferences">
         <source>No unused references</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PropPage_UnusedReferenceCompileFail">
         <source>Project compilation failed. Cannot determine unused references.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PropPage_UnusedReferenceCompileWaiting">
         <source>Gathering list of unused references...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PropPage_UnusedReferenceError">
         <source>Error getting unused references.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_InvalidHexString">
         <source>Base address must be a hexadecimal number with less than or equal to 8 digits, for example, &amp;H11000000.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PropPage_NeedResFile">
         <source>"Resource files must have a .res file extension. Please enter a valid resource file name."</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PropPage_ResourceFileNotExist">
         <source>"The resource file entered does not exist."</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_Title">
         <source>Project Designer</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_SettingsTabTitle">
         <source>Settings</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_ResourceTabTitle">
         <source>Resources</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_ErrorLoading_Msg">
         <source>An error occurred trying to load the project properties window.  Close the window and try again.
 {0}</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_ErrorLoadingPropPage">
         <source>An error occurred trying to load the page.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_DesignerLoader_NotDeferred">
         <source>The designer cannot be shown because the document for it was never loaded.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_ClickHereCreateResx">
         <source>This project does not contain a default resources file.  Click here to create one.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_ClickHereCreateSettings">
         <source>This project does not contain a default settings file.  Click here to create one.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_FileNotFound_1Arg">
         <source>Could not find the file '{0}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_EditorAlreadyOpen_1Arg">
         <source>The file '{0}' is already open in an editor.  Please close the file and try again.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_OverflowButton_AccessibilityName">
         <source>All Project Designer Pages</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_OverflowButton_Tooltip">
         <source>More Settings</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_SpecialFileNotSupported">
         <source>The requested file type is not supported in projects of this type.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Property_AssemblyName">
         <source>Assembly Name</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Property_RootNamespace">
         <source>Root Namespace</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Property_StartupObject">
         <source>Startup Object</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Property_ApplicationIcon">
         <source>Application Icon</source>
@@ -878,47 +878,47 @@ Error:</source>
       </trans-unit>
       <trans-unit id="PPG_Property_AssemblyVersion">
         <source>Assembly Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Property_AssemblyFileVersion">
         <source>Assembly File Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Property_AssemblyGuid">
         <source>Assembly GUID</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Property_CustomSubMain">
         <source>Enable application framework</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Property_StartProgram">
         <source>External Program Path</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Property_StartURL">
         <source>Start Browser With URL</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Property_StartWorkingDirectory">
         <source>Working Directory</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Property_RemoteDebugMachine">
         <source>Remote Machine Name</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_HostingPanelName">
         <source>Project Designer Page Container</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_TabButtonDefaultAction">
         <source>Switch Project Designer Page</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_TabListDescription">
         <source>Allow switching between active pages of the project designer (use Ctrl+PageUp and Ctrl+PageDown)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="APPDES_PageName">
         <source>{0} page:</source>
@@ -942,7 +942,7 @@ Error:</source>
       </trans-unit>
       <trans-unit id="DFX_InvalidPhysicalViewName">
         <source>Invalid physical view name.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DFX_UnableCreateTextBuffer">
         <source>Unable to create text buffer.</source>
@@ -958,19 +958,19 @@ Error:</source>
       </trans-unit>
       <trans-unit id="DFX_BufferReadOnly">
         <source>Buffer is read only.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DFX_IncompatibleBuffer">
         <source>File is already opened in an incompatible editor.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DFX_NotSupported">
         <source>Unsupported format.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DFX_WindowPane_UnknownError">
         <source>Unknown Error.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DFX_CreateEditorInstanceFailed_Ex">
         <source>Unable to create the designer.  {0}</source>
@@ -986,11 +986,11 @@ Error:</source>
       </trans-unit>
       <trans-unit id="OptionPage_Editor_InvalidTabSize">
         <source>Please enter an integer between 1 and 60.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="OptionPage_Editor_InvalidIndentSize">
         <source>Please enter an integer between 1 and 60.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="OptionPage_Environment_StartUpShowEmptyEnvironment">
         <source>Show empty environment</source>
@@ -1010,15 +1010,15 @@ Error:</source>
       </trans-unit>
       <trans-unit id="OptionPage_Environment_ShowHelpOptionRequiresRestartOfIde">
         <source>Changes in Help Options will not take effect until the environment is restarted.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="OptionPage_Project_IllegalDefaultProjectDirectory">
         <source>The location specified is on an invalid or read-only disk, or contains a device name reserved for the system.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PermissionSet_Requires">
         <source>Requires:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_ResourceNameColumn">
         <source>Name</source>
@@ -1038,15 +1038,15 @@ Error:</source>
       </trans-unit>
       <trans-unit id="SingleFileGenerator_FailedToGenerateFile_1Arg">
         <source>Failed to generate file: {0}</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_Err_CantEditEmbeddedResource">
         <source>Editing embedded resources directly is not supported. Do you wish to convert this item to a linked resource in order to edit it?</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_Err_RenameNotSupported">
         <source>The current object is auto-generated and only supports renaming through the Managed Resources Editor.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_Err_CantFindResourceFile_1Arg">
         <source>Cannot find the file '{0}'.  It may have been moved or deleted.</source>
@@ -1058,7 +1058,7 @@ Error:</source>
       </trans-unit>
       <trans-unit id="RSE_Err_NameBlank">
         <source>The resource name cannot be empty.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_Err_DuplicateName_1Arg">
         <source>There is already another resource with the name '{0}'.</source>
@@ -1082,11 +1082,11 @@ Error:</source>
       </trans-unit>
       <trans-unit id="RSE_Err_UserCancel">
         <source>The operation has been canceled by the user.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_Err_BadData">
         <source>The resource value contains invalid data or has an incorrect format.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_Err_BadIdentifier_2Arg">
         <source>The name of the resource '{0}' cannot be used as a valid identifier, because it contains one or more invalid characters: '{1}'.  Please remove or replace those characters and try again.</source>
@@ -1094,7 +1094,7 @@ Error:</source>
       </trans-unit>
       <trans-unit id="RSE_Err_MaxFilesLimitation">
         <source>Too many files specified.  Please select fewer files and try again.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_Err_InternalException">
         <source>Unexpected error.</source>
@@ -1117,17 +1117,17 @@ Error:</source>
       </trans-unit>
       <trans-unit id="RSE_Err_CantBeEmpty">
         <source>One or more of the selected resource values could not be cleared.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_Err_CantEditInDebugMode">
         <source>The resource file cannot be modified at this time.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_Err_UpdateADependentFile">
         <source>You are trying to edit a resource file that is a part of another project item (such as a form or a control).  Editing this item could corrupt the project item, and you will have to recover it by hand.  In addition, changes made to this resource file may be lost if further changes are made to the project item.
 
 Do you really want to edit this file?</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_Err_CantAddUnsupportedResource_1Arg">
         <source>The resource '{0}' cannot be added.</source>
@@ -1323,7 +1323,7 @@ CONSIDER: get this from CodeDom</note>
       </trans-unit>
       <trans-unit id="RSE_Type_BinaryFile">
         <source>Binary File</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_Type_Wave">
         <source>Wave Sound</source>
@@ -1439,11 +1439,11 @@ CONSIDER: get this from CodeDom</note>
       </trans-unit>
       <trans-unit id="RSE_ResourceEditor">
         <source>Managed Resources Editor</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_DlgTitle_AddExisting">
         <source>Add existing file to resources</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_DlgTitle_Import_1Arg">
         <source>Import file into resource '{0}'</source>
@@ -1455,7 +1455,7 @@ CONSIDER: get this from CodeDom</note>
       </trans-unit>
       <trans-unit id="RSE_DlgTitle_AddNew">
         <source>Please specify where to save the new file</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_Dlg_ReplaceExistingFile">
         <source>The file '{0}' already exists.  Do you want to replace it?</source>
@@ -1463,19 +1463,19 @@ CONSIDER: get this from CodeDom</note>
       </trans-unit>
       <trans-unit id="RSE_Dlg_ReplaceExistingFiles">
         <source>The following files already exist.  Do you want to replace them?</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_Dlg_ExportMultiple">
         <source>Select a folder in which to export the resources.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_Dlg_ContinueAnyway">
         <source>Do you want to continue anyway?</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_Dlg_SetCustomTool">
         <source>Do you want to enable strongly-typed resource generation for this file?</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_Task_BadLink_2Args">
         <source>Resource '{0}' could not be loaded because the file to which it is linked could not be found: {1}.</source>
@@ -1495,11 +1495,11 @@ CONSIDER: get this from CodeDom</note>
       </trans-unit>
       <trans-unit id="RSE_Task_WarningCustomToolNotSet">
         <source>Double-click here to enable strongly-typed resources for this file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_Task_InvalidName_1Arg">
         <source>The resource name '{0}' is not a valid identifier.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_EncodingDisplayName">
         <source>{0} - Codepage {1}</source>
@@ -1507,11 +1507,11 @@ CONSIDER: get this from CodeDom</note>
       </trans-unit>
       <trans-unit id="RSE_DefaultEncoding">
         <source>(Default)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_Undo_ChangeName">
         <source>Change resource name</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_Undo_AddResources_1Arg">
         <source>Add {0} new resource(s)</source>
@@ -1531,35 +1531,35 @@ CONSIDER: get this from CodeDom</note>
       </trans-unit>
       <trans-unit id="RSE_PropDesc_Name">
         <source>Name used to identify the resource in code.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_PropDesc_Comment">
         <source>Additional information about the resource.  This property is only meaningful at design time.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_PropDesc_Encoding">
         <source>Character encoding of the file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_PropDesc_Filename">
         <source>The path to the linked resource.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_PropDesc_FileType">
         <source>Specifies whether the file resource is text or binary.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_PropDesc_Persistence">
         <source>Specifies whether the resource is embedded or linked.  Embedded resources are saved in the resource file.  Linked resources reside in an external location on disk.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_PropDesc_Type">
         <source>The resource will be generated as this type in the strongly-typed resource class.  For example, the resource might be generated as a String or Bitmap object.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RSE_PropDesc_Value">
         <source>The value of the resource.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RFS_CantCreateResourcesFolder_Folder_ExMsg">
         <source>Unable to add a '{0}' folder to this project.
@@ -1611,170 +1611,170 @@ CONSIDER: get this from CodeDom</note>
       </trans-unit>
       <trans-unit id="SD_ComboBoxItem_ApplicationScope">
         <source>Application</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_ComboBoxItem_WebApplicationScope">
         <source>Application (Web)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_ComboBoxItem_UserScope">
         <source>User</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_ComboBoxItem_WebUserScope">
         <source>User (Web)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_GridViewNameColumnHeaderText">
         <source>Name</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_GridViewTypeColumnHeaderText">
         <source>Type</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_GridViewScopeColumnHeaderText">
         <source>Scope</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_GridViewValueColumnHeaderText">
         <source>Value</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_UnknownType">
         <source>Type '{0}' is not defined.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_UndoTran_NameChanged">
         <source>Name changed</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_UndoTran_TypeChanged">
         <source>Type changed</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_UndoTran_ScopeChanged">
         <source>Scope changed</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_UndoTran_RoamingChanged">
         <source>Roaming changed</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_UndoTran_DescriptionChanged">
         <source>Description changed</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_UndoTran_ProviderChanged">
         <source>Provider changed</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_UndoTran_SerializedValueChanged">
         <source>Value changed</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_UndoTran_GenerateDefaultValueInCode">
         <source>Generate default value in code changed</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_UndoTran_RemoveMultipleSettings_1Arg">
         <source>Remove {0} setting(s)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_Err_CantLoadSettingsFile">
         <source>Unable to load settings file.  It might be corrupted or contain invalid XML or contain duplicate identifiers.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_NewValuesAdded">
         <source>New values from the app.config file were automatically added</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_ReplaceValueWithAppConfigValueTitle">
         <source>Value of setting '{0}' was changed in the app.config file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_ReplaceValueWithAppConfigValue">
         <source>The current value in the .settings file is '{0}'
 The new value in the app.config file is '{1}'
 
 Do you want to update the value in the .settings file?</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_FailedToLoadAppConfigValues">
         <source>An error occurred while reading the app.config file. The file might be corrupted or contain invalid XML.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_FailedToSaveAppConfigValues">
         <source>An error occurred while saving values to the app.config file. The file might be corrupted or contain invalid XML.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_ERR_DuplicateName_1Arg">
         <source>There is already another setting with the name '{0}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_ERR_InvalidIdentifier_1Arg">
         <source>'{0}' is not a valid identifier.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_ERR_InvalidTypeName_1Arg">
         <source>'{0}' is not a valid type name.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_ERR_NameEmpty">
         <source>The setting name cannot be empty.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_ERR_InvalidValue_2Arg">
         <source>'{0}' cannot be converted to an instance of type '{1}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_ERR_GenericTypesNotSupported_1Arg">
         <source>Generic types are not supported.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_ERR_AbstractTypesNotSupported_1Arg">
         <source>Abstract types are not supported.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_ERR_RenameNotSupported">
         <source>The current object is auto-generated and only supports renaming through the Settings Designer.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_ERR_RenameNotSupportedForWcfGeneratedCode">
         <source>The current object is auto-generated by the Wcf Client Generator and cannot be renamed.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_ERR_ModifyParamsNotSupported">
         <source>The current object is auto-generated and does not support modifying parameters.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_ERR_CantEditInDebugMode">
         <source>The settings file cannot be modified at this time.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_MNU_AddSettingText">
         <source>&amp;Add Setting</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_MNU_RemoveSettingText">
         <source>R&amp;emove Setting</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_FullDescriptionText">
         <source>Application settings allow you to store and retrieve property settings and other information for your application dynamically. For example, the application can save a user's color preferences, then retrieve them the next time it runs.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_LinkPartOfDescriptionText">
         <source>Learn more about application settings...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_IncludeSensitiveInfoInConnectionStringWarning">
         <source>This connection string appears to contain sensitive data (for example, a password), which is required to connect to the database. However, storing sensitive data in the connection string can be a security risk. Do you want to include sensitive data in the connection string?</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_SelectATypeTreeView_AccessibleName">
         <source>Select a Type</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_CODEGENCMT_COMMON1">
         <source>This class allows you to handle specific events on the settings class:</source>
@@ -1782,75 +1782,75 @@ Do you want to update the value in the .settings file?</source>
       </trans-unit>
       <trans-unit id="SD_CODEGENCMT_COMMON2">
         <source> The SettingChanging event is raised before a setting's value is changed.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_CODEGENCMT_COMMON3">
         <source> The PropertyChanged event is raised after a setting's value is changed.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_CODEGENCMT_COMMON4">
         <source> The SettingsLoaded event is raised after the setting values are loaded.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_CODEGENCMT_COMMON5">
         <source> The SettingsSaving event is raised before the setting values are saved.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_CODEGENCMT_HOWTO_ATTACHEVTS">
         <source>To add event handlers for saving and changing settings, uncomment the lines below:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_CODEGENCMT_HANDLE_CHANGING">
         <source>Add code to handle the SettingChangingEvent event here.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_CODEGENCMT_HANDLE_SAVING">
         <source>Add code to handle the SettingsSaving event here.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_CODEGEN_FAILEDOPENCREATEEXTENDINGFILE">
         <source>Failed to create or open file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_DESCR_Description">
         <source>Description of the setting.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_DESCR_GenerateDefaultValueInCode">
         <source>Specifies whether or not the default setting value should be generated in the strongly-typed settings class.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_DESCR_Group">
         <source>Specifies the group to which this Settings file belongs.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_DESCR_GroupDescription">
         <source>Description of the group to which this Settings file belongs.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_DESCR_Roaming">
         <source>Indicates whether the setting should roam when Windows roaming profiles are enabled.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_DESCR_Name">
         <source>Name used to identify the setting.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_DESCR_Provider">
         <source>The provider (System.Configuration.Provider.ProviderBase) used to manage the setting.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_DESCR_Scope">
         <source>Specifies whether the setting is per-application (read-only) or per-user (read-write).</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_DESCR_SerializedSettingType">
         <source>The setting will be generated as this type in the strongly-typed settings class. For example, the setting might be generated as a String or Integer object.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_DESCR_Value">
         <source>The current value for the setting.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_SyncFiles_1Arg">
         <source>The following files will be deleted:
@@ -1862,11 +1862,11 @@ Do you want to update the value in the .settings file?</source>
         <source>No user.config files were found in any of the following locations:
 
 {0}</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_SyncFilesOneOrMoreFailed">
         <source>One or more user.config files was not removed.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_SFG_AutoSaveRegionText">
         <source>My.Settings Auto-Save Functionality</source>
@@ -1890,7 +1890,7 @@ Do you want to update the value in the .settings file?</source>
       </trans-unit>
       <trans-unit id="PPG_WindowsApp_WPF">
         <source>WPF Application</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_WPFApp_InvalidShutdownMode">
         <source>(Invalid value: "{0}")</source>
@@ -1898,43 +1898,43 @@ Do you want to update the value in the .settings file?</source>
       </trans-unit>
       <trans-unit id="PPG_WPFApp_ShutdownMode_OnExplicitShutdown">
         <source>On explicit shutdown</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_WPFApp_ShutdownMode_OnLastWindowClose">
         <source>On last window close</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_WPFApp_ShutdownMode_OnMainWindowClose">
         <source>On main window close</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_WPFApp_Xaml_CouldntFindRootElement">
         <source>Could not find the expected root element "{0}" in the application definition file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_WPFApp_Xaml_UnexpectedFormat_2Args">
         <source>The .xaml file was in an unexpected format, near line {0} column {1}.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_StartupObjectLabelText">
         <source>Startup &amp;object:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_StartupUriLabelText">
         <source>Startup &amp;URI:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_WPFApp_AppXamlOpenInUnsupportedEditor">
         <source>The application definition file is already opened in an incompatible editor.  Please close the other editor and reload the project properties page.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_WPFApp_CantOpenOrCreateAppXaml_1Arg">
         <source>There was an error trying to open or create the application definition file for this project.  {0}</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_WPFApp_ErrorControlMessage_1Arg">
         <source>An error occurred trying to load the application definition file for this project.  The file '{0}' could not be parsed.  Please edit the file in the XAML editor to fix the error.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_WPFApp_CantReadPropertyValue">
         <source>(Error)</source>
@@ -1942,15 +1942,15 @@ Do you want to update the value in the .settings file?</source>
       </trans-unit>
       <trans-unit id="PPG_Unexpected">
         <source>An unspecified error has occurred.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_WPFApp_CantFindAppXaml">
         <source>This project does not contain an application definition file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_WPFApp_CouldntCreateApplicationEventsFile_1Arg">
         <source>An error occurred trying to create the application events file.  {0}</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="General_InvalidArgument_1Arg">
         <source>Invalid argument '{0}'</source>
@@ -1958,99 +1958,99 @@ Do you want to update the value in the .settings file?</source>
       </trans-unit>
       <trans-unit id="PPG_CommandLineApp_WPF">
         <source>WPF Console Application</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_WindowsClassLib_WPF">
         <source>WPF Class Library</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_DefaultManifestText">
         <source>Embed manifest with default settings</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_NoManifestText">
         <source>Create application without a manifest</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Application_BadManifest">
         <source>Invalid manifest file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Services">
         <source>Services</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Services_HelpLabelText">
         <source>Client application services enable your Windows-based applications to use the ASP.NET login (authentication), roles, and profile (settings) services. To enable client application services, you must set the Target Framework for your application to the full version of the .NET Framework 3.5 or later.  </source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Services_HelpLabelLink">
         <source>Learn more about client application services...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_ServicesAdvancedPage_Title">
         <source>Advanced Settings for Services</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Services_ConfirmRemoveServices">
         <source>Disabling application services will clear the default services for Authentication, Roles, and Settings.  Click OK to disable application services.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Services_ConfirmRemoveServices_Caption">
         <source>Disable Application Services</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Services_Seconds">
         <source>seconds</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Services_Minutes">
         <source>minutes</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Services_Hours">
         <source>hours</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Services_Days">
         <source>days</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Services_VersionWarning">
         <source>To enable client application services, you must set the Target Framework for your application to .NET Framework 3.5 or later. In C#, you can do this on the Application property page. In Visual Basic, you can do this on the Compile property page by clicking Advanced Compile Options.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Services_InvalidAppConfigXml">
         <source>An error occurred while reading the Application configuration file.  The file might be corrupted or contain invalid XML.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Services_InvalidUrl">
         <source>The URL is invalid. Please enter a valid URL like http://microsoft.com/services</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Services_InvalidUrls">
         <source>A service URL in the application configuration file is not in the expected format.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Services_ConnectionStringsDontMatch">
         <source>Authentication, Roles and Web Settings providers have been configured via the Application configuration file such that they do not share a common connection string.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_Services_connectionStringValueDefaultDisplayValue">
         <source>Specify a connection string to a SQL Server database, or use the special connection string "Data Source = |SQL/CE|", which causes SQL Server Compact to generate local database files for offline storage.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_ERR_UnreferencedTypeNameList_1Arg">
         <source>The following type names were not understood: '{0}'.  Make sure you have references to these types.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_ERR_DuplicateNameList_1Arg">
         <source>There are already settings with the following names: {0}.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_ERR_CantAuthenticate">
         <source>The username/password combination cannot be authenticated.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_WindowsFormsApp">
         <source>Windows Forms Application</source>
@@ -2058,39 +2058,39 @@ Do you want to update the value in the .settings file?</source>
       </trans-unit>
       <trans-unit id="PPG_ServiceReferenceNamespaceDescription">
         <source>Namespace of the service reference.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_ServiceReferenceTypeName">
         <source>Service Reference Properties</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_ServiceReferenceUrlDescription">
         <source>Metadata Location Url</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_ServiceReferenceUrlName">
         <source>Metadata Location</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_ServiceReferenceProperty_MultipleUrlNotSupported">
         <source>A service reference with multiple source urls is not supported.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_ServiceReferenceProperty_SetReferenceUrlEmpty">
         <source>Cannot change reference Url to empty. The reference url must be a valid URL.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DFX_OneOrMoreFilesReloaded">
         <source>One or more files were reloaded during the checkout. Please retry your operation.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_ProjectReloadedSomePropertiesMayNotHaveBeenSet">
         <source>The project was reloaded, and some changes on this page may have been lost.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_SecurityPage_XBAPOutOfTrustZoneToolTip">
         <source>The application will fail to run in the selected zone because of this requested elevated permission. Click the help link above for more info.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="XmlToSchema_InvalidXMLFormat">
         <source>Invalid XML Format: {0}</source>
@@ -2098,7 +2098,7 @@ Do you want to update the value in the .settings file?</source>
       </trans-unit>
       <trans-unit id="XmlToSchema_XMLSchemaInferenceWizard">
         <source>XML Schema Inference Wizard</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="XmlToSchema_Error">
         <source>Error: {0}</source>
@@ -2114,7 +2114,7 @@ Do you want to update the value in the .settings file?</source>
       </trans-unit>
       <trans-unit id="XmlToSchema_InvalidEmptyItemName">
         <source>Invalid empty project item name.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="XmlToSchema_InvalidProjectPath">
         <source>Invalid project path: {0}</source>
@@ -2122,47 +2122,47 @@ Do you want to update the value in the .settings file?</source>
       </trans-unit>
       <trans-unit id="XmlToSchema_NoProjectSelected">
         <source>No project selected.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ResolveKeySource_InvalidKeyName">
         <source>Invalid key file name "{0}".</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Unable_To_Get_Checksum">
         <source>Unable to get MD5 checksum for the key file "{0}". {1}.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ErrorImportingKey">
         <source>Error importing key</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="CSRDlg_MultipleURL">
         <source>Multiple addresses (editable in .svcmap file)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_WinMDObj">
         <source>Windows Runtime Component</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_AppContainerExe">
         <source>Windows Store App</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PPG_UnknownOutputType">
         <source>Unknown output type: {0}</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SD_DefaultSettingName">
         <source>Setting</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PropPage_ComputingCurrentImportsMessage">
         <source>Computing current imports...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="PropPage_CurrentImportsTitle">
         <source>Current Imports</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hans.xlf
@@ -2709,6 +2709,16 @@ app.config 文件中的新值为“{1}”
         <target state="translated">当前导入</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_PackageTitle">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PPG_Property_PackageVersion">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hant.xlf
@@ -2709,6 +2709,16 @@ app.config 檔的新值是 '{1}'
         <target state="translated">目前的匯入</target>
         <note />
       </trans-unit>
+      <trans-unit id="PPG_PackageTitle">
+        <source>Package</source>
+        <target state="new">Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PPG_Property_PackageVersion">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/xlf/TypeEditorHostControl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/xlf/TypeEditorHostControl.xlf
@@ -5,7 +5,7 @@
       <group id="src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypeEditorHostControl.resx" />
       <trans-unit id="ShowEditorButton.AccessibleName">
         <source>Show type editor</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/xlf/TypePickerDialog.xlf
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/xlf/TypePickerDialog.xlf
@@ -5,19 +5,19 @@
       <group id="src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypePickerDialog.resx" />
       <trans-unit id="m_CancelButton.Text">
         <source>Cancel</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="m_OkButton.Text">
         <source>OK</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SelectedTypeLabel.Text">
         <source>Selected &amp;type:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="$this.Text">
         <source>Select a Type</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/XmlToSchema/xlf/InputXmlForm.xlf
+++ b/src/Microsoft.VisualStudio.Editors/XmlToSchema/xlf/InputXmlForm.xlf
@@ -5,63 +5,63 @@
       <group id="src/Microsoft.VisualStudio.Editors/XmlToSchema/InputXmlForm.resx" />
       <trans-unit id="_cancelButton.Text">
         <source>Cancel</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ColumnHeader1.Text">
         <source>Source Type</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ColumnHeader2.Text">
         <source>XML Document Location</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="_listView.AccessibleName">
         <source>XML Documents</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="_addAsTextButton.AccessibleName">
         <source>Type or paste XML</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="_addAsTextButton.Text">
         <source>Type or paste &amp;XML</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Label1.Text">
         <source>Specify XML documents to infer XML Schema set</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="_addFromFileButton.AccessibleName">
         <source>Add from File</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="_addFromFileButton.Text">
         <source>Add from &amp;File</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="_addFromWebButton.AccessibleName">
         <source>Add from Web</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="_addFromWebButton.Text">
         <source>Add from &amp;Web</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="_okButton.Text">
         <source>OK</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="_xmlFileDialog.Filter">
         <source>XML files (*.xml)|*.xml|All files (*.*)|*.*</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="_xmlFileDialog.Title">
         <source>Add XML Files</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="$this.Text">
         <source>Infer XML Schema set from XML documents</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/XmlToSchema/xlf/PasteXmlDialog.xlf
+++ b/src/Microsoft.VisualStudio.Editors/XmlToSchema/xlf/PasteXmlDialog.xlf
@@ -5,19 +5,19 @@
       <group id="src/Microsoft.VisualStudio.Editors/XmlToSchema/PasteXmlDialog.resx" />
       <trans-unit id="okButton.Text">
         <source>&amp;OK</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="cancelButton.Text">
         <source>Cancel</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Label1.Text">
         <source>&amp;Type or paste an XML document</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="$this.Text">
         <source>Add XML</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/XmlToSchema/xlf/WebUrlDialog.xlf
+++ b/src/Microsoft.VisualStudio.Editors/XmlToSchema/xlf/WebUrlDialog.xlf
@@ -5,19 +5,19 @@
       <group id="src/Microsoft.VisualStudio.Editors/XmlToSchema/WebUrlDialog.resx" />
       <trans-unit id="okButton.Text">
         <source>OK</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="cancelButton.Text">
         <source>Cancel</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Label2.Text">
         <source>&amp;Provide the HTTP address of an XML document:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="$this.Text">
         <source>Add an XML document from the Web</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.Editors/package/xlf/EditorToolsOptionsPanel.xlf
+++ b/src/Microsoft.VisualStudio.Editors/package/xlf/EditorToolsOptionsPanel.xlf
@@ -5,43 +5,43 @@
       <group id="src/Microsoft.VisualStudio.Editors/package/EditorToolsOptionsPanel.resx" />
       <trans-unit id="_indentTypeLabel.Text">
         <source>Indent type:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="_indentTypeNoneRadioButton.Text">
         <source>&amp;None</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="_indentTypeBlockRadioButton.Text">
         <source>&amp;Block</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="_indentTypeSmartRadioButton.Text">
         <source>&amp;Smart</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="_tabSizeLabel.Text">
         <source>&amp;Tab size:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="_indentSizeLabel.Text">
         <source>&amp;Indent size:</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="_wordWrapCheckBox.Text">
         <source>&amp;Word wrap</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="_lineNumbersCheckBox.Text">
         <source>Line n&amp;umbers</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="IndentingGroupBox.Text">
         <source>Indenting</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="InteractionGroupBox.Text">
         <source>Interaction</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.cs.xlf
@@ -43,6 +43,11 @@
         <target state="translated">Soubory projektu .NET Core 2015 (*.xproj);*.xproj</target>
         <note />
       </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="new">Class Library (.NET Core)</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.de.xlf
@@ -43,6 +43,11 @@
         <target state="translated">.NET Core 2015-Projektdateien (*.xproj);*.xproj</target>
         <note />
       </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="new">Class Library (.NET Core)</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.es.xlf
@@ -43,6 +43,11 @@
         <target state="translated">Archivos de proyecto de .NET Core 2015 (*.xproj);*.xproj</target>
         <note />
       </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="new">Class Library (.NET Core)</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.fr.xlf
@@ -43,6 +43,11 @@
         <target state="translated">Fichiers projet .NET Core 2015 (*.xproj);*.xproj</target>
         <note />
       </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="new">Class Library (.NET Core)</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.it.xlf
@@ -43,6 +43,11 @@
         <target state="translated">File di progetto .NET Core 2015 (*.xproj);*.xproj</target>
         <note />
       </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="new">Class Library (.NET Core)</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.ja.xlf
@@ -43,6 +43,11 @@
         <target state="translated">.NET Core 2015 プロジェクト ファイル (*.xproj);*.xproj</target>
         <note />
       </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="new">Class Library (.NET Core)</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.ko.xlf
@@ -43,6 +43,11 @@
         <target state="translated">.NET Core 2015 프로젝트 파일(*.xproj);*.xproj</target>
         <note />
       </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="new">Class Library (.NET Core)</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.pl.xlf
@@ -43,6 +43,11 @@
         <target state="translated">Pliki projektu .NET Core 2015 (*.xproj); *.xproj</target>
         <note />
       </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="new">Class Library (.NET Core)</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.pt-BR.xlf
@@ -43,6 +43,11 @@
         <target state="translated">Arquivos de Projeto do .NET Core 2015 (*.xproj);*.xproj</target>
         <note />
       </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="new">Class Library (.NET Core)</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.ru.xlf
@@ -43,6 +43,11 @@
         <target state="translated">Файлы проектов .NET Core 2015 (*.xproj);*.xproj</target>
         <note />
       </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="new">Class Library (.NET Core)</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.tr.xlf
@@ -43,6 +43,11 @@
         <target state="translated">.NET Core 2015 Proje Dosyaları (*.xproj);*.xproj</target>
         <note />
       </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="new">Class Library (.NET Core)</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.xlf
@@ -5,35 +5,35 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.resx" />
       <trans-unit id="1">
         <source>C#</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="2">
         <source>C# Project Files (*.csproj);*.csproj</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="3">
         <source>Console App (.NET Core)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="4">
         <source>A project for creating a command-line application that can run on .NET Core on Windows, Linux and MacOS.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="5">
         <source>Class Library (.NET Standard)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="6">
         <source>A project for creating a class library that targets .NET Standard.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="7">
         <source>Loaded Project File Editor</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="8">
         <source>.NET Core 2015 Project Files (*.xproj);*.xproj</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.xlf
@@ -35,6 +35,10 @@
         <source>.NET Core 2015 Project Files (*.xproj);*.xproj</source>
         <note />
       </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.zh-Hans.xlf
@@ -43,6 +43,11 @@
         <target state="translated">.NET Core 2015 项目文件(*.xproj);*.xproj</target>
         <note />
       </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="new">Class Library (.NET Core)</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.zh-Hant.xlf
@@ -43,6 +43,11 @@
         <target state="translated">.NET Core 2015 專案檔 (*.xproj);*.xproj</target>
         <note />
       </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="new">Class Library (.NET Core)</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.xlf
@@ -5,119 +5,119 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.resx" />
       <trans-unit id="AdminRequiredForPort">
         <source>You must run Visual Studio in the context of an administrator account to create IIS Express sites with ports less than 1024.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="AllFiles">
         <source>All files</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ApplicationArgumentsWatermark">
         <source>Arguments to be passed to the application</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ApplicationUrlWatermark">
         <source>The URL of the application</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="CopyHyperlinkText">
         <source>Copy</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DebugPropertyPageTitle">
         <source>Debug</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DuplicateKey">
         <source>Duplicate Key</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnvVariableNameWatermark">
         <source>Key</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnvVariableValueWatermark">
         <source>Value</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ExecutableFiles">
         <source>Executable files</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ExecutablePathWatermark">
         <source>Path to the executable to run</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="IISExpressMissingAppUrl">
         <source>The IIS settings are missing the App Url property. This is required to configure IIS to run the site.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="IISMissingAppUrl">
         <source>The IIS settings are missing the App Url property. This is required to configure IIS to run the site.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidAppUrl">
         <source>The Application Url is invalid. {0}</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidIISAppUrl">
         <source>The IIS Application Url is invalid. {0}</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidIISExpressAppUrl">
         <source>The IIS Express Application Url is invalid. {0}</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="LaunchUrlWatermark">
         <source>Absolute or relative URL</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NameCannotBeEmpty">
         <source>Name cannot be empty.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NewProfileCaption">
         <source>New profile</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NewProfileSeedName">
         <source>newProfile</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ProfileKindCommandName">
         <source>Command</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ProfileKindExecutableName">
         <source>Executable</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ProfileKindIISExpressName">
         <source>IIS Express</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ProfileKindNoActionName">
         <source>Start</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ProfileKindProjectName">
         <source>Project</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ProfileNameInvalid">
         <source>That profile name is invalid or there is an existing profile with the same name.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ProfileNameRequired">
         <source>You must specify a profile name.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmpty">
         <source>Value cannot be empty.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="WorkingDirectoryWatermark">
         <source>Absolute path to working directory</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.cs.xlf
@@ -23,6 +23,36 @@
         <target state="translated">EditProjectFile</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ButtonText">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ToolTipText">
+        <source>Generate NuGet Package</source>
+        <target state="new">Generate NuGet Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
+        <source>GenerateNuGetPackageProjectContextMenu</source>
+        <target state="new">GenerateNuGetPackageProjectContextMenu</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
+        <source>&amp;Pack selection</source>
+        <target state="new">&amp;Pack selection</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
+        <source>Generate NuGet Package for selected project</source>
+        <target state="new">Generate NuGet Package for selected project</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
+        <source>GenerateNuGetPackageTopLevelBuild</source>
+        <target state="new">GenerateNuGetPackageTopLevelBuild</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.de.xlf
@@ -23,6 +23,36 @@
         <target state="translated">EditProjectFile</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ButtonText">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ToolTipText">
+        <source>Generate NuGet Package</source>
+        <target state="new">Generate NuGet Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
+        <source>GenerateNuGetPackageProjectContextMenu</source>
+        <target state="new">GenerateNuGetPackageProjectContextMenu</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
+        <source>&amp;Pack selection</source>
+        <target state="new">&amp;Pack selection</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
+        <source>Generate NuGet Package for selected project</source>
+        <target state="new">Generate NuGet Package for selected project</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
+        <source>GenerateNuGetPackageTopLevelBuild</source>
+        <target state="new">GenerateNuGetPackageTopLevelBuild</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.es.xlf
@@ -23,6 +23,36 @@
         <target state="translated">EditProjectFile</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ButtonText">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ToolTipText">
+        <source>Generate NuGet Package</source>
+        <target state="new">Generate NuGet Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
+        <source>GenerateNuGetPackageProjectContextMenu</source>
+        <target state="new">GenerateNuGetPackageProjectContextMenu</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
+        <source>&amp;Pack selection</source>
+        <target state="new">&amp;Pack selection</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
+        <source>Generate NuGet Package for selected project</source>
+        <target state="new">Generate NuGet Package for selected project</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
+        <source>GenerateNuGetPackageTopLevelBuild</source>
+        <target state="new">GenerateNuGetPackageTopLevelBuild</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.fr.xlf
@@ -23,6 +23,36 @@
         <target state="translated">EditProjectFile</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ButtonText">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ToolTipText">
+        <source>Generate NuGet Package</source>
+        <target state="new">Generate NuGet Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
+        <source>GenerateNuGetPackageProjectContextMenu</source>
+        <target state="new">GenerateNuGetPackageProjectContextMenu</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
+        <source>&amp;Pack selection</source>
+        <target state="new">&amp;Pack selection</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
+        <source>Generate NuGet Package for selected project</source>
+        <target state="new">Generate NuGet Package for selected project</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
+        <source>GenerateNuGetPackageTopLevelBuild</source>
+        <target state="new">GenerateNuGetPackageTopLevelBuild</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.it.xlf
@@ -23,6 +23,36 @@
         <target state="translated">EditProjectFile</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ButtonText">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ToolTipText">
+        <source>Generate NuGet Package</source>
+        <target state="new">Generate NuGet Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
+        <source>GenerateNuGetPackageProjectContextMenu</source>
+        <target state="new">GenerateNuGetPackageProjectContextMenu</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
+        <source>&amp;Pack selection</source>
+        <target state="new">&amp;Pack selection</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
+        <source>Generate NuGet Package for selected project</source>
+        <target state="new">Generate NuGet Package for selected project</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
+        <source>GenerateNuGetPackageTopLevelBuild</source>
+        <target state="new">GenerateNuGetPackageTopLevelBuild</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ja.xlf
@@ -23,6 +23,36 @@
         <target state="translated">EditProjectFile</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ButtonText">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ToolTipText">
+        <source>Generate NuGet Package</source>
+        <target state="new">Generate NuGet Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
+        <source>GenerateNuGetPackageProjectContextMenu</source>
+        <target state="new">GenerateNuGetPackageProjectContextMenu</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
+        <source>&amp;Pack selection</source>
+        <target state="new">&amp;Pack selection</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
+        <source>Generate NuGet Package for selected project</source>
+        <target state="new">Generate NuGet Package for selected project</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
+        <source>GenerateNuGetPackageTopLevelBuild</source>
+        <target state="new">GenerateNuGetPackageTopLevelBuild</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ko.xlf
@@ -23,6 +23,36 @@
         <target state="translated">EditProjectFile</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ButtonText">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ToolTipText">
+        <source>Generate NuGet Package</source>
+        <target state="new">Generate NuGet Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
+        <source>GenerateNuGetPackageProjectContextMenu</source>
+        <target state="new">GenerateNuGetPackageProjectContextMenu</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
+        <source>&amp;Pack selection</source>
+        <target state="new">&amp;Pack selection</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
+        <source>Generate NuGet Package for selected project</source>
+        <target state="new">Generate NuGet Package for selected project</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
+        <source>GenerateNuGetPackageTopLevelBuild</source>
+        <target state="new">GenerateNuGetPackageTopLevelBuild</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.pl.xlf
@@ -23,6 +23,36 @@
         <target state="translated">EditProjectFile</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ButtonText">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ToolTipText">
+        <source>Generate NuGet Package</source>
+        <target state="new">Generate NuGet Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
+        <source>GenerateNuGetPackageProjectContextMenu</source>
+        <target state="new">GenerateNuGetPackageProjectContextMenu</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
+        <source>&amp;Pack selection</source>
+        <target state="new">&amp;Pack selection</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
+        <source>Generate NuGet Package for selected project</source>
+        <target state="new">Generate NuGet Package for selected project</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
+        <source>GenerateNuGetPackageTopLevelBuild</source>
+        <target state="new">GenerateNuGetPackageTopLevelBuild</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.pt-BR.xlf
@@ -23,6 +23,36 @@
         <target state="translated">EditProjectFile</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ButtonText">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ToolTipText">
+        <source>Generate NuGet Package</source>
+        <target state="new">Generate NuGet Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
+        <source>GenerateNuGetPackageProjectContextMenu</source>
+        <target state="new">GenerateNuGetPackageProjectContextMenu</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
+        <source>&amp;Pack selection</source>
+        <target state="new">&amp;Pack selection</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
+        <source>Generate NuGet Package for selected project</source>
+        <target state="new">Generate NuGet Package for selected project</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
+        <source>GenerateNuGetPackageTopLevelBuild</source>
+        <target state="new">GenerateNuGetPackageTopLevelBuild</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ru.xlf
@@ -23,6 +23,36 @@
         <target state="translated">EditProjectFile</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ButtonText">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ToolTipText">
+        <source>Generate NuGet Package</source>
+        <target state="new">Generate NuGet Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
+        <source>GenerateNuGetPackageProjectContextMenu</source>
+        <target state="new">GenerateNuGetPackageProjectContextMenu</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
+        <source>&amp;Pack selection</source>
+        <target state="new">&amp;Pack selection</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
+        <source>Generate NuGet Package for selected project</source>
+        <target state="new">Generate NuGet Package for selected project</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
+        <source>GenerateNuGetPackageTopLevelBuild</source>
+        <target state="new">GenerateNuGetPackageTopLevelBuild</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.tr.xlf
@@ -23,6 +23,36 @@
         <target state="translated">EditProjectFile</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ButtonText">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ToolTipText">
+        <source>Generate NuGet Package</source>
+        <target state="new">Generate NuGet Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
+        <source>GenerateNuGetPackageProjectContextMenu</source>
+        <target state="new">GenerateNuGetPackageProjectContextMenu</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
+        <source>&amp;Pack selection</source>
+        <target state="new">&amp;Pack selection</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
+        <source>Generate NuGet Package for selected project</source>
+        <target state="new">Generate NuGet Package for selected project</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
+        <source>GenerateNuGetPackageTopLevelBuild</source>
+        <target state="new">GenerateNuGetPackageTopLevelBuild</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.xlf
@@ -5,19 +5,19 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Menus.vsct" />
       <trans-unit id="cmdidProjectDebugger|ButtonText">
         <source>Web Debugger</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="cmdidEditProjFile|ButtonText">
         <source>Edit Project File</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="cmdidEditProjFile|ToolTipText">
         <source>Edit Project File</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="cmdidEditProjFile|CommandName">
         <source>EditProjectFile</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.xlf
@@ -19,6 +19,30 @@
         <source>EditProjectFile</source>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ButtonText">
+        <source>&amp;Pack</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ToolTipText">
+        <source>Generate NuGet Package</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
+        <source>GenerateNuGetPackageProjectContextMenu</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
+        <source>&amp;Pack selection</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
+        <source>Generate NuGet Package for selected project</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
+        <source>GenerateNuGetPackageTopLevelBuild</source>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.zh-Hans.xlf
@@ -23,6 +23,36 @@
         <target state="translated">EditProjectFile</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ButtonText">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ToolTipText">
+        <source>Generate NuGet Package</source>
+        <target state="new">Generate NuGet Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
+        <source>GenerateNuGetPackageProjectContextMenu</source>
+        <target state="new">GenerateNuGetPackageProjectContextMenu</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
+        <source>&amp;Pack selection</source>
+        <target state="new">&amp;Pack selection</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
+        <source>Generate NuGet Package for selected project</source>
+        <target state="new">Generate NuGet Package for selected project</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
+        <source>GenerateNuGetPackageTopLevelBuild</source>
+        <target state="new">GenerateNuGetPackageTopLevelBuild</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.zh-Hant.xlf
@@ -23,6 +23,36 @@
         <target state="translated">EditProjectFile</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ButtonText">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|ToolTipText">
+        <source>Generate NuGet Package</source>
+        <target state="new">Generate NuGet Package</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
+        <source>GenerateNuGetPackageProjectContextMenu</source>
+        <target state="new">GenerateNuGetPackageProjectContextMenu</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
+        <source>&amp;Pack selection</source>
+        <target state="new">&amp;Pack selection</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
+        <source>Generate NuGet Package for selected project</source>
+        <target state="new">Generate NuGet Package for selected project</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
+        <source>GenerateNuGetPackageTopLevelBuild</source>
+        <target state="new">GenerateNuGetPackageTopLevelBuild</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -239,7 +239,7 @@ Pokud chcete projekt ladit, přidejte do řešení spustitelný projekt, který 
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
         <source>Edit {0}</source>
-        <target state="needs-review-translation">Upravte {0}.{1}</target>
+        <target state="needs-review-translation">Upravte {0}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -238,9 +238,9 @@ Pokud chcete projekt ladit, přidejte do řešení spustitelný projekt, který 
         <note />
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
-        <source>Edit {0}.{1}</source>
-        <target state="translated">Upravte {0}.{1}</target>
-        <note />
+        <source>Edit {0}</source>
+        <target state="needs-review-translation">Upravte {0}.{1}</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">
         <source>Unable to run your project. The "RunCommand" property is not defined.</source>
@@ -251,6 +251,16 @@ Pokud chcete projekt ladit, přidejte do řešení spustitelný projekt, který 
         <source>Editing of multiple target framework is not supported.</source>
         <target state="translated">Úprava více cílových platforem není podporovaná.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="PackCommand">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackSelectedProjectCommand">
+        <source>&amp;Pack {0}</source>
+        <target state="new">&amp;Pack {0}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -238,9 +238,9 @@ Um das Projekt zu debuggen, fügen Sie dieser Projektmappe ein ausführbares Pro
         <note />
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
-        <source>Edit {0}.{1}</source>
-        <target state="translated">"{0}.{1}" bearbeiten</target>
-        <note />
+        <source>Edit {0}</source>
+        <target state="needs-review-translation">"{0}.{1}" bearbeiten</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">
         <source>Unable to run your project. The "RunCommand" property is not defined.</source>
@@ -251,6 +251,16 @@ Um das Projekt zu debuggen, fügen Sie dieser Projektmappe ein ausführbares Pro
         <source>Editing of multiple target framework is not supported.</source>
         <target state="translated">Die Bearbeitung mehrerer Zielframeworks wird nicht unterstützt.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="PackCommand">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackSelectedProjectCommand">
+        <source>&amp;Pack {0}</source>
+        <target state="new">&amp;Pack {0}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -239,7 +239,7 @@ Um das Projekt zu debuggen, fügen Sie dieser Projektmappe ein ausführbares Pro
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
         <source>Edit {0}</source>
-        <target state="needs-review-translation">"{0}.{1}" bearbeiten</target>
+        <target state="needs-review-translation">"{0}" bearbeiten</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -238,9 +238,9 @@ Para depurar este proyecto, agregue un proyecto ejecutable a esta solución con 
         <note />
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
-        <source>Edit {0}.{1}</source>
-        <target state="translated">Edite {0}.{1}</target>
-        <note />
+        <source>Edit {0}</source>
+        <target state="needs-review-translation">Edite {0}.{1}</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">
         <source>Unable to run your project. The "RunCommand" property is not defined.</source>
@@ -251,6 +251,16 @@ Para depurar este proyecto, agregue un proyecto ejecutable a esta solución con 
         <source>Editing of multiple target framework is not supported.</source>
         <target state="translated">No se admite la edición de varias plataformas de destino.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="PackCommand">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackSelectedProjectCommand">
+        <source>&amp;Pack {0}</source>
+        <target state="new">&amp;Pack {0}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -239,7 +239,7 @@ Para depurar este proyecto, agregue un proyecto ejecutable a esta solución con 
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
         <source>Edit {0}</source>
-        <target state="needs-review-translation">Edite {0}.{1}</target>
+        <target state="needs-review-translation">Edite {0}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -238,9 +238,9 @@ Pour déboguer ce projet, ajoutez à cette solution un projet exécutable qui fa
         <note />
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
-        <source>Edit {0}.{1}</source>
-        <target state="translated">Modifiez {0}.{1}</target>
-        <note />
+        <source>Edit {0}</source>
+        <target state="needs-review-translation">Modifiez {0}.{1}</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">
         <source>Unable to run your project. The "RunCommand" property is not defined.</source>
@@ -251,6 +251,16 @@ Pour déboguer ce projet, ajoutez à cette solution un projet exécutable qui fa
         <source>Editing of multiple target framework is not supported.</source>
         <target state="translated">La modification de plusieurs frameworks cibles n'est pas prise en charge.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="PackCommand">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackSelectedProjectCommand">
+        <source>&amp;Pack {0}</source>
+        <target state="new">&amp;Pack {0}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -239,7 +239,7 @@ Pour déboguer ce projet, ajoutez à cette solution un projet exécutable qui fa
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
         <source>Edit {0}</source>
-        <target state="needs-review-translation">Modifiez {0}.{1}</target>
+        <target state="needs-review-translation">Modifiez {0}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -238,9 +238,9 @@ Per eseguire il debug del progetto, aggiungere a questa soluzione un progetto es
         <note />
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
-        <source>Edit {0}.{1}</source>
-        <target state="translated">Modifica {0}.{1}</target>
-        <note />
+        <source>Edit {0}</source>
+        <target state="needs-review-translation">Modifica {0}.{1}</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">
         <source>Unable to run your project. The "RunCommand" property is not defined.</source>
@@ -251,6 +251,16 @@ Per eseguire il debug del progetto, aggiungere a questa soluzione un progetto es
         <source>Editing of multiple target framework is not supported.</source>
         <target state="translated">La modifica di più framework di destinazione non è supportata.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="PackCommand">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackSelectedProjectCommand">
+        <source>&amp;Pack {0}</source>
+        <target state="new">&amp;Pack {0}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -239,7 +239,7 @@ Per eseguire il debug del progetto, aggiungere a questa soluzione un progetto es
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
         <source>Edit {0}</source>
-        <target state="needs-review-translation">Modifica {0}.{1}</target>
+        <target state="needs-review-translation">Modifica {0}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -238,9 +238,9 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
-        <source>Edit {0}.{1}</source>
-        <target state="translated">{0} を編集します。{1}</target>
-        <note />
+        <source>Edit {0}</source>
+        <target state="needs-review-translation">{0} を編集します。{1}</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">
         <source>Unable to run your project. The "RunCommand" property is not defined.</source>
@@ -251,6 +251,16 @@ In order to debug this project, add an executable project to this solution which
         <source>Editing of multiple target framework is not supported.</source>
         <target state="translated">複数のターゲット フレームワークの編集はサポートされていません。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="PackCommand">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackSelectedProjectCommand">
+        <source>&amp;Pack {0}</source>
+        <target state="new">&amp;Pack {0}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -239,7 +239,7 @@ In order to debug this project, add an executable project to this solution which
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
         <source>Edit {0}</source>
-        <target state="needs-review-translation">{0} を編集します。{1}</target>
+        <target state="needs-review-translation">{0} を編集します</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -239,7 +239,7 @@ In order to debug this project, add an executable project to this solution which
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
         <source>Edit {0}</source>
-        <target state="needs-review-translation">{0}을(를) 편집합니다.{1}</target>
+        <target state="needs-review-translation">{0}을(를) 편집합니다</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -238,9 +238,9 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
-        <source>Edit {0}.{1}</source>
-        <target state="translated">{0}을(를) 편집합니다.{1}</target>
-        <note />
+        <source>Edit {0}</source>
+        <target state="needs-review-translation">{0}을(를) 편집합니다.{1}</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">
         <source>Unable to run your project. The "RunCommand" property is not defined.</source>
@@ -251,6 +251,16 @@ In order to debug this project, add an executable project to this solution which
         <source>Editing of multiple target framework is not supported.</source>
         <target state="translated">여러 대상 프레임워크를 편집할 수 없습니다.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="PackCommand">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackSelectedProjectCommand">
+        <source>&amp;Pack {0}</source>
+        <target state="new">&amp;Pack {0}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -239,7 +239,7 @@ Aby debugować ten projekt, dodaj projekt wykonywalny do tego rozwiązania, któ
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
         <source>Edit {0}</source>
-        <target state="needs-review-translation">Edytuj element {0}.{1}</target>
+        <target state="needs-review-translation">Edytuj element {0}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -238,9 +238,9 @@ Aby debugować ten projekt, dodaj projekt wykonywalny do tego rozwiązania, któ
         <note />
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
-        <source>Edit {0}.{1}</source>
-        <target state="translated">Edytuj element {0}.{1}</target>
-        <note />
+        <source>Edit {0}</source>
+        <target state="needs-review-translation">Edytuj element {0}.{1}</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">
         <source>Unable to run your project. The "RunCommand" property is not defined.</source>
@@ -251,6 +251,16 @@ Aby debugować ten projekt, dodaj projekt wykonywalny do tego rozwiązania, któ
         <source>Editing of multiple target framework is not supported.</source>
         <target state="translated">Edytowanie wielu platform docelowych nie jest obsługiwane.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="PackCommand">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackSelectedProjectCommand">
+        <source>&amp;Pack {0}</source>
+        <target state="new">&amp;Pack {0}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -239,7 +239,7 @@ Para depurar esse projeto, adicione um projeto executável a essa solução que 
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
         <source>Edit {0}</source>
-        <target state="needs-review-translation">Editar {0}.{1}</target>
+        <target state="needs-review-translation">Editar {0}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -238,9 +238,9 @@ Para depurar esse projeto, adicione um projeto executável a essa solução que 
         <note />
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
-        <source>Edit {0}.{1}</source>
-        <target state="translated">Editar {0}.{1}</target>
-        <note />
+        <source>Edit {0}</source>
+        <target state="needs-review-translation">Editar {0}.{1}</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">
         <source>Unable to run your project. The "RunCommand" property is not defined.</source>
@@ -251,6 +251,16 @@ Para depurar esse projeto, adicione um projeto executável a essa solução que 
         <source>Editing of multiple target framework is not supported.</source>
         <target state="translated">Não há suporte para a edição da estrutura de vários destinos.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="PackCommand">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackSelectedProjectCommand">
+        <source>&amp;Pack {0}</source>
+        <target state="new">&amp;Pack {0}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -239,7 +239,7 @@ In order to debug this project, add an executable project to this solution which
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
         <source>Edit {0}</source>
-        <target state="needs-review-translation">Изменение {0}.{1}</target>
+        <target state="needs-review-translation">Изменение {0}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -238,9 +238,9 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
-        <source>Edit {0}.{1}</source>
-        <target state="translated">Изменение {0}.{1}</target>
-        <note />
+        <source>Edit {0}</source>
+        <target state="needs-review-translation">Изменение {0}.{1}</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">
         <source>Unable to run your project. The "RunCommand" property is not defined.</source>
@@ -251,6 +251,16 @@ In order to debug this project, add an executable project to this solution which
         <source>Editing of multiple target framework is not supported.</source>
         <target state="translated">Изменение нескольких целевых платформ не поддерживается.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="PackCommand">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackSelectedProjectCommand">
+        <source>&amp;Pack {0}</source>
+        <target state="new">&amp;Pack {0}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -239,7 +239,7 @@ Bu projede hata ayıklamak için bu çözüme, kitaplık projesine başvuran bir
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
         <source>Edit {0}</source>
-        <target state="needs-review-translation">{0} öğesini düzenleyin.{1}</target>
+        <target state="needs-review-translation">{0} öğesini düzenleyin</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -238,9 +238,9 @@ Bu projede hata ayıklamak için bu çözüme, kitaplık projesine başvuran bir
         <note />
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
-        <source>Edit {0}.{1}</source>
-        <target state="translated">{0} öğesini düzenleyin.{1}</target>
-        <note />
+        <source>Edit {0}</source>
+        <target state="needs-review-translation">{0} öğesini düzenleyin.{1}</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">
         <source>Unable to run your project. The "RunCommand" property is not defined.</source>
@@ -251,6 +251,16 @@ Bu projede hata ayıklamak için bu çözüme, kitaplık projesine başvuran bir
         <source>Editing of multiple target framework is not supported.</source>
         <target state="translated">Birden fazla hedef çerçevenin düzenlenmesi desteklenmiyor.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="PackCommand">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackSelectedProjectCommand">
+        <source>&amp;Pack {0}</source>
+        <target state="new">&amp;Pack {0}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.xlf
@@ -5,7 +5,7 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx" />
       <trans-unit id="ClassTemplateName">
         <source>Class</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ProjectModificationsPrompt">
         <source>The project '{0}' has been modified outside the environment.
@@ -13,7 +13,7 @@
 Press Reload to load the updated project from disk.
 Press Ignore to ignore the external changes. The changes will be used the next time you open the project.
     </source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ConflictingModificationsPrompt">
         <source>The project '{0}' has been modified outside the environment, and there are unsaved changes to the project.
@@ -23,177 +23,177 @@ Press Discard to discard the unsaved changes and load the updated project from d
 Press Overwrite to overwrite the external changes with your changes.
 Press Ignore to ignore the external changes. Your changes may be lost if you close and reopen the project.
     </source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ConflictingProjectModificationTitle">
         <source>Conflicting Project Modification Detected</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Discard">
         <source>_Discard</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Ignore">
         <source>_Ignore</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="IgnoreAll">
         <source>Ignore A_ll</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Overwrite">
         <source>_Overwrite</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ProjectModificationDlgTitle">
         <source>Project Modification Detected</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Reload">
         <source>_Reload</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ReloadAll">
         <source>Reload A_ll</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="RenameSymbolPrompt">
         <source>You are renaming a file. Would you also like to perform a rename in this project of all references to the code element '{0}'?</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SaveAs">
         <source>_Save As</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="FailedToWatchProject">
         <source>An unexpected error occurred attempting to watch project file '{0}'</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="FrameworkAssembliesNodeName">
         <source>Framework Assemblies</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ComNodeName">
         <source>COM</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="SdkNodeName">
         <source>SDK</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="AssembliesNodeName">
         <source>Assemblies</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DependenciesLoadingPostfix">
         <source> (Loading...)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DependenciesNodeErrorsSuffix">
         <source>(Errors - see Error List)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DependenciesNodeName">
         <source>Dependencies</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="GraphNodeCategoryDependency">
         <source>Dependency</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NoItemTypeForRule">
         <source>Expected to find item type for rule {0}. The rule file is either missing or malformed.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NuGetPackagesNodeName">
         <source>NuGet</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ProjectsNodeName">
         <source>Projects</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="AnalyzersNodeName">
         <source>Analyzers</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DotNetCoreProjectsNotSupported">
         <source>.NET Core projects are not supported in this release of Visual Studio. Support will be available in a later update.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ActiveLaunchProfileNotFound">
         <source>There aren't any active launch profiles configured for this project.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DontKnowHowToRunProfile">
         <source>The project doesn't know how to run the profile {0}.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ErrorInProfilesFile">
         <source>An error in the launch settings file needs to be corrected before you can run the '{0}' project . Please see the error list for details.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ErrorInProfilesFile2">
         <source>An error in the launch settings file needs to be corrected before you can run the '{0}' project. {1}. Please see the error list for details.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ProjectNotRunnableDirectly">
         <source>A project with an Output Type of Class Library cannot be started directly.
 
 In order to debug this project, add an executable project to this solution which references the library project. Set the executable project as the startup project.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NoUrlSpecified">
         <source>The debug profile '{0}' has requested a web browser be launched, but a URL was not specified.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidAbsoluteUrlSpecified">
         <source>The debug profile '{0}' has requested a web browser be launched, but the URL specified is not a valid absolute URL.  {1}</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NoDebugExecutableSpecified">
         <source>The debug profile '{0}' is missing the path to the executable to debug.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DebugExecutableNotFound">
         <source>The debug executable '{0}' specified in the '{1}' debug profile does not exist.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NoMigratedCSProjFound">
         <source>Expected to find migrated cpsroj in {0}, but did not find any.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="XprojMigrationFailed">
         <source>Failed to migrate XProj project {0}. 'dotnet migrate --skip-backup -s -p "{1}" -x "{2}"' exited with error code {3}.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="MigrationBackupFile">
         <source>Backing up {0} to {1}.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="XprojMigrationFailedProjectJsonFileNotFound">
         <source>Failed to migrate XProj project {0}. Could not find project.json at {1}.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
         <source>Edit {0}.{1}</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">
         <source>Unable to run your project. The "RunCommand" property is not defined.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="MultiTFEditNotSupported">
         <source>Editing of multiple target framework is not supported.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.xlf
@@ -184,8 +184,8 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
-        <source>Edit {0}.{1}</source>
-        <note />
+        <source>Edit {0}</source>
+        <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">
         <source>Unable to run your project. The "RunCommand" property is not defined.</source>
@@ -194,6 +194,14 @@ In order to debug this project, add an executable project to this solution which
       <trans-unit id="MultiTFEditNotSupported">
         <source>Editing of multiple target framework is not supported.</source>
         <note />
+      </trans-unit>
+      <trans-unit id="PackCommand">
+        <source>&amp;Pack</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackSelectedProjectCommand">
+        <source>&amp;Pack {0}</source>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -239,7 +239,7 @@ In order to debug this project, add an executable project to this solution which
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
         <source>Edit {0}</source>
-        <target state="needs-review-translation">编辑{0}。{1}</target>
+        <target state="needs-review-translation">编辑{0}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -238,9 +238,9 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
-        <source>Edit {0}.{1}</source>
-        <target state="translated">编辑{0}。{1}</target>
-        <note />
+        <source>Edit {0}</source>
+        <target state="needs-review-translation">编辑{0}。{1}</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">
         <source>Unable to run your project. The "RunCommand" property is not defined.</source>
@@ -251,6 +251,16 @@ In order to debug this project, add an executable project to this solution which
         <source>Editing of multiple target framework is not supported.</source>
         <target state="translated">不支持编辑多个目标框架。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="PackCommand">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackSelectedProjectCommand">
+        <source>&amp;Pack {0}</source>
+        <target state="new">&amp;Pack {0}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -239,7 +239,7 @@ In order to debug this project, add an executable project to this solution which
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
         <source>Edit {0}</source>
-        <target state="needs-review-translation">編輯 {0}。{1}</target>
+        <target state="needs-review-translation">編輯 {0}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -238,9 +238,9 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="EditProjectFileCommand">
-        <source>Edit {0}.{1}</source>
-        <target state="translated">編輯 {0}。{1}</target>
-        <note />
+        <source>Edit {0}</source>
+        <target state="needs-review-translation">編輯 {0}。{1}</target>
+        <note></note>
       </trans-unit>
       <trans-unit id="NoRunCommandSpecifiedInProject">
         <source>Unable to run your project. The "RunCommand" property is not defined.</source>
@@ -251,6 +251,16 @@ In order to debug this project, add an executable project to this solution which
         <source>Editing of multiple target framework is not supported.</source>
         <target state="translated">不支援編輯多個目標 Framework。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="PackCommand">
+        <source>&amp;Pack</source>
+        <target state="new">&amp;Pack</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PackSelectedProjectCommand">
+        <source>&amp;Pack {0}</source>
+        <target state="new">&amp;Pack {0}</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/AdditionalFiles.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/AdditionalFiles.xaml.xlf
@@ -5,99 +5,99 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AdditionalFiles.xaml" />
       <trans-unit id="Rule|AdditionalFiles|DisplayName">
         <source>Additional File</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|AdditionalFiles|Description">
         <source>Additional file items</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Category|Advanced|DisplayName">
         <source>Advanced</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Category|Misc|DisplayName">
         <source>Misc</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|{}{ItemType}|DisplayName">
         <source>Build Action</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|{}{ItemType}|Description">
         <source>How the file relates to the build and deployment processes.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|CopyToOutputDirectory|DisplayName">
         <source>Copy to Output Directory</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|CopyToOutputDirectory|Description">
         <source>Specifies the source file will be copied to the output directory.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Always|DisplayName">
         <source>Copy always</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.PreserveNewest|DisplayName">
         <source>Copy if newer</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Generator|DisplayName">
         <source>Custom Tool</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Generator|Description">
         <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
         <source>Custom Tool Namespace</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|CustomToolNamespace|Description">
         <source>The namespace into which the output of the custom tool is placed.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Identity|Description">
         <source>The item specified in the Include attribute.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
         <source>Full Path</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|Description">
         <source>Location of the file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileNameAndExtension|DisplayName">
         <source>File Name</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileNameAndExtension|Description">
         <source>Name of the file or folder.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|LastGenOutput|Description">
         <source>The filename of the last file generated as a result of the SFG.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DesignTime|Description">
         <source>A value indicating whether this file has a designer.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|AutoGen|Description">
         <source>A value indicating whether this is a generated file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|CustomTool|Description">
         <source>DTE Property for accessing the Generator property.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/AnalyzerReference.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/AnalyzerReference.xaml.xlf
@@ -5,11 +5,11 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AnalyzerReference.xaml" />
       <trans-unit id="Rule|AnalyzerReference|DisplayName">
         <source>Analyzer Reference</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|AnalyzerReference|Description">
         <source>Analyzer reference properties</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/AppDesigner.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/AppDesigner.xaml.xlf
@@ -5,11 +5,11 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AppDesigner.xaml" />
       <trans-unit id="Rule|AppDesigner|DisplayName">
         <source>AppDesigner</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|AppDesigner|Description">
         <source>General</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/AssemblyReference.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/AssemblyReference.xaml.xlf
@@ -5,55 +5,55 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AssemblyReference.xaml" />
       <trans-unit id="Rule|AssemblyReference|DisplayName">
         <source>Assembly Reference</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|AssemblyReference|Description">
         <source>Assembly reference properties</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">
         <source>Aliases</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">
         <source>A comma-delimited list of aliases to this reference.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|CopyLocal|DisplayName">
         <source>Copy Local</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|CopyLocal|Description">
         <source>Indicates whether the reference will be copied to the output directory.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|EmbedInteropTypes|DisplayName">
         <source>Embed Interop Types</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|EmbedInteropTypes|Description">
         <source>Indicates whether types defined in this assembly will be embedded into the target assembly.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SpecificVersion|DisplayName">
         <source>Specific Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SpecificVersion|Description">
         <source>Indicates whether this assembly can be resolved without regard to multi-targeting rules for assembly resolution.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|RequiredTargetFramework|DisplayName">
         <source>Required Target Framework</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|ImageRuntime|DisplayName">
         <source>Runtime Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|ImageRuntime|Description">
         <source>The CLR runtime version targeted by this assembly.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.xlf
@@ -5,67 +5,67 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CSharp.BrowseObject.xaml" />
       <trans-unit id="Rule|CSharp|DisplayName">
         <source>File Properties</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|CSharp|Description">
         <source>File Properties</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Category|Advanced|DisplayName">
         <source>Advanced</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Category|Misc|DisplayName">
         <source>Misc</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|{}{ItemType}|DisplayName">
         <source>Build Action</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|{}{ItemType}|Description">
         <source>How the file relates to the build and deployment processes.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|CopyToOutputDirectory|DisplayName">
         <source>Copy to Output Directory</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|CopyToOutputDirectory|Description">
         <source>Specifies the source file will be copied to the output directory.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Always|DisplayName">
         <source>Copy always</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.PreserveNewest|DisplayName">
         <source>Copy if newer</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Identity|Description">
         <source>The item specified in the Include attribute.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
         <source>Full Path</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|Description">
         <source>Location of the file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileNameAndExtension|DisplayName">
         <source>File Name</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileNameAndExtension|Description">
         <source>Name of the file or folder.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.ProjectItemsSchema.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.ProjectItemsSchema.xaml.xlf
@@ -5,11 +5,11 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CSharp.ProjectItemsSchema.xaml" />
       <trans-unit id="ContentType|CSharpFile|DisplayName">
         <source>C# file</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ItemType|Compile|DisplayName">
         <source>C# compiler</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.xaml.xlf
@@ -5,79 +5,79 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CSharp.xaml" />
       <trans-unit id="Rule|CSharp|DisplayName">
         <source>C#</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|CSharp|Description">
         <source>C# source file</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Category|Advanced|DisplayName">
         <source>Advanced</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Category|Misc|DisplayName">
         <source>Misc</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|{}{ItemType}|DisplayName">
         <source>Build Action</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|{}{ItemType}|Description">
         <source>How the file relates to the build and deployment processes.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|CopyToOutputDirectory|DisplayName">
         <source>Copy to Output Directory</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|CopyToOutputDirectory|Description">
         <source>Specifies the source file will be copied to the output directory.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Always|DisplayName">
         <source>Copy always</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.PreserveNewest|DisplayName">
         <source>Copy if newer</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Generator|DisplayName">
         <source>Custom Tool</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Generator|Description">
         <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
         <source>Custom Tool Namespace</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|CustomToolNamespace|Description">
         <source>The namespace into which the output of the custom tool is placed.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ExcludedFromBuild|DisplayName">
         <source>Excluded From Build</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|LastGenOutput|Description">
         <source>The filename of the last file generated as a result of the SFG.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DesignTime|Description">
         <source>A value indicating whether this file has a designer.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|AutoGen|Description">
         <source>A value indicating whether this is a generated file.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.xlf
@@ -5,27 +5,27 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ComReference.xaml" />
       <trans-unit id="Rule|ComReference|DisplayName">
         <source>COM Reference</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|ComReference|Description">
         <source>COM reference properties</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Guid|DisplayName">
         <source>CLSID</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Guid|Description">
         <source>The GUID of the COM server.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Lcid|DisplayName">
         <source>Locale</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Lcid|Description">
         <source>The LCID of the COM server.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.cs.xlf
@@ -138,6 +138,11 @@
         <target state="translated">Představuje jazyk, který přetrvává v položkách a šablonách projektu</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|SaveAssemblyInfoInSource|DisplayName">
+        <source>Save assembly info attribute values in source</source>
+        <target state="new">Save assembly info attribute values in source</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.de.xlf
@@ -138,6 +138,11 @@
         <target state="translated">Stellen die Sprache dar, die in Elementen und Projektvorlagen gespeichert ist.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|SaveAssemblyInfoInSource|DisplayName">
+        <source>Save assembly info attribute values in source</source>
+        <target state="new">Save assembly info attribute values in source</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.es.xlf
@@ -138,6 +138,11 @@
         <target state="translated">Representa el lenguaje que se mantiene en los elementos y las plantillas de proyecto</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|SaveAssemblyInfoInSource|DisplayName">
+        <source>Save assembly info attribute values in source</source>
+        <target state="new">Save assembly info attribute values in source</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.fr.xlf
@@ -138,6 +138,11 @@
         <target state="translated">Représente la langue persistante dans les éléments et les modèles de projet</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|SaveAssemblyInfoInSource|DisplayName">
+        <source>Save assembly info attribute values in source</source>
+        <target state="new">Save assembly info attribute values in source</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.it.xlf
@@ -138,6 +138,11 @@
         <target state="translated">Rappresenta il linguaggio impostato come permanente in elementi e modelli di progetto</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|SaveAssemblyInfoInSource|DisplayName">
+        <source>Save assembly info attribute values in source</source>
+        <target state="new">Save assembly info attribute values in source</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ja.xlf
@@ -138,6 +138,11 @@
         <target state="translated">項目やプロジェクト テンプレート内で保持される言語を表します</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|SaveAssemblyInfoInSource|DisplayName">
+        <source>Save assembly info attribute values in source</source>
+        <target state="new">Save assembly info attribute values in source</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ko.xlf
@@ -138,6 +138,11 @@
         <target state="translated">항목 및 프로젝트 템플릿에 있는 언어를 나타냅니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|SaveAssemblyInfoInSource|DisplayName">
+        <source>Save assembly info attribute values in source</source>
+        <target state="new">Save assembly info attribute values in source</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.pl.xlf
@@ -138,6 +138,11 @@
         <target state="translated">Reprezentuje język utrwalony w elementach i szablonach projektu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|SaveAssemblyInfoInSource|DisplayName">
+        <source>Save assembly info attribute values in source</source>
+        <target state="new">Save assembly info attribute values in source</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.pt-BR.xlf
@@ -138,6 +138,11 @@
         <target state="translated">Representa o idioma persistido em modelos de projeto e itens</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|SaveAssemblyInfoInSource|DisplayName">
+        <source>Save assembly info attribute values in source</source>
+        <target state="new">Save assembly info attribute values in source</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ru.xlf
@@ -138,6 +138,11 @@
         <target state="translated">Представляет язык, который сохраняется в элементах и шаблонах проектов</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|SaveAssemblyInfoInSource|DisplayName">
+        <source>Save assembly info attribute values in source</source>
+        <target state="new">Save assembly info attribute values in source</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.tr.xlf
@@ -138,6 +138,11 @@
         <target state="translated">Öğelerde ve proje şablonlarında kalıcı olan dili temsil eder</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|SaveAssemblyInfoInSource|DisplayName">
+        <source>Save assembly info attribute values in source</source>
+        <target state="new">Save assembly info attribute values in source</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.xlf
@@ -111,6 +111,10 @@
         <source>Represent the language that is persisted in items and project templates</source>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|SaveAssemblyInfoInSource|DisplayName">
+        <source>Save assembly info attribute values in source</source>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.xlf
@@ -5,111 +5,111 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml" />
       <trans-unit id="Rule|ConfigurationGeneral|DisplayName">
         <source>General</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|ConfigurationGeneral|Description">
         <source>General</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Category|General|DisplayName">
         <source>General</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Category|General|Description">
         <source>General</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|ApplicationIcon|DisplayName">
         <source>Application Icon</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworkIdentifier|DisplayName">
         <source>Target Framework Identifier</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworks|DisplayName">
         <source>Target Frameworks</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetFramework|DisplayName">
         <source>Target Framework</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworkProfile|DisplayName">
         <source>Target Framework Profile</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworkVersion|DisplayName">
         <source>Target Framework Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworkMoniker|DisplayName">
         <source>Target Framework Moniker</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|DocumentationFile|DisplayName">
         <source>XML doc comments file</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|RootNamespace|DisplayName">
         <source>Root namespace</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|OutputType.Library|DisplayName">
         <source>Class Library</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|OutputType.exe|DisplayName">
         <source>Console Application</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|OutputType.winexe|DisplayName">
         <source>Windows Application</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|OutputType.AppContainerExe|DisplayName">
         <source>Windows Store app</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|OutputType.WinMDObj|DisplayName">
         <source>WinMD</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Should compiler optimize output?</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|PackageAction|Description">
         <source>The MSBuild target to use when packaging a project.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|DefaultContentType|Description">
         <source>The default content type name to use when adding files.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|TargetRuntime.AppHost|DisplayName">
         <source>Windows app</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SuppressOutOfDateMessageOnBuild|Description">
         <source>True to just build out-of-date projects without ever prompting the user to confirm.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|SharedProjectAppliesTo|Description">
         <source>Capability match expression that at a minimum tests for the language of the Shared Project; used to filter Add Shared Project Reference choices.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|AlwaysUseNumericalSuffixInItemNames|Description">
         <source>Indicates if names of newly added items should always be suffixed with a number.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|LanguageServiceName|Description">
         <source>Represents the LanguageName that is passed to Roslyn</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|TemplateLanguage|Description">
         <source>Represent the language that is persisted in items and project templates</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.zh-Hans.xlf
@@ -138,6 +138,11 @@
         <target state="translated">表示项和项目模板中保留的语言</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|SaveAssemblyInfoInSource|DisplayName">
+        <source>Save assembly info attribute values in source</source>
+        <target state="new">Save assembly info attribute values in source</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.zh-Hant.xlf
@@ -138,6 +138,11 @@
         <target state="translated">代表保存在項目和專案範本中的語言</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|SaveAssemblyInfoInSource|DisplayName">
+        <source>Save assembly info attribute values in source</source>
+        <target state="new">Save assembly info attribute values in source</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneralFile.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneralFile.xaml.xlf
@@ -5,83 +5,83 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneralFile.xaml" />
       <trans-unit id="Rule|ConfigurationGeneralFile|DisplayName">
         <source>General</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|ConfigurationGeneralFile|Description">
         <source>Project item general properties</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Category|Advanced|DisplayName">
         <source>Advanced</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Category|Misc|DisplayName">
         <source>Misc</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|{}{ItemType}|DisplayName">
         <source>Build Action</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|{}{ItemType}|Description">
         <source>How the file relates to the build and deployment processes.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|CopyToOutputDirectory|DisplayName">
         <source>Copy to Output Directory</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|CopyToOutputDirectory|Description">
         <source>Specifies the source file will be copied to the output directory.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Always|DisplayName">
         <source>Copy always</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.PreserveNewest|DisplayName">
         <source>Copy if newer</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Identity|Description">
         <source>The item specified in the Include attribute.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
         <source>Full Path</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|Description">
         <source>Location of the file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileNameAndExtension|DisplayName">
         <source>File Name</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileNameAndExtension|Description">
         <source>Name of the file or folder.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|DependentUpon|Description">
         <source>The leaf name of the file that this item appears as a child to in the project tree.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|LastGenOutput|Description">
         <source>The filename of the last file generated as a result of the SFG.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DesignTime|Description">
         <source>A value indicating whether this file has a designer.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|AutoGen|Description">
         <source>A value indicating whether this is a generated file.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/Content.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/Content.xaml.xlf
@@ -5,67 +5,67 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Content.xaml" />
       <trans-unit id="Rule|Content|DisplayName">
         <source>File Properties</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|Content|Description">
         <source>File Properties</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Category|Advanced|DisplayName">
         <source>Advanced</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Category|Misc|DisplayName">
         <source>Misc</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|{}{ItemType}|DisplayName">
         <source>Build Action</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|{}{ItemType}|Description">
         <source>How the file relates to the build and deployment processes.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|CopyToOutputDirectory|DisplayName">
         <source>Copy to Output Directory</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|CopyToOutputDirectory|Description">
         <source>Specifies the source file will be copied to the output directory.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Always|DisplayName">
         <source>Copy always</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.PreserveNewest|DisplayName">
         <source>Copy if newer</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Identity|Description">
         <source>The item specified in the Include attribute.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
         <source>Full Path</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|Description">
         <source>Location of the file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileNameAndExtension|DisplayName">
         <source>File Name</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileNameAndExtension|Description">
         <source>Name of the file or folder.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DebuggerGeneral.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DebuggerGeneral.xaml.xlf
@@ -5,51 +5,51 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DebuggerGeneral.xaml" />
       <trans-unit id="Rule|DebuggerGeneralProperties|DisplayName">
         <source>Debugger General Properties</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|DebuggerGeneralProperties|Description">
         <source>General Debugger options</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|SymbolsPath|DisplayName">
         <source>Symbol Search Path</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|SymbolsPath|Description">
         <source>The search path used by the debugger to locate symbols.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebuggerFlavor|Description">
         <source>The debug rule selected as the active debugger.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ImageClrType|Description">
         <source>The 'hidden' property we pass to debuggers to let them know if this is a managed project.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|ImageClrType.Native|DisplayName">
         <source>Native Image</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|ImageClrType.Native|Description">
         <source>The executable image to debug is a fully native application.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|ImageClrType.Mixed|DisplayName">
         <source>Mixed Image</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|ImageClrType.Mixed|Description">
         <source>The executable image to debug is a mixture of native and managed code.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|ImageClrType.Managed|DisplayName">
         <source>Managed Image</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|ImageClrType.Managed|Description">
         <source>The executable image to debug is a fully managed application.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.xlf
@@ -5,55 +5,55 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DotNetCliToolReference.xaml" />
       <trans-unit id="Rule|DotNetCliToolReference|DisplayName">
         <source>Package</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|DotNetCliToolReference|Description">
         <source>Package</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Description|DisplayName">
         <source>Description</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Description|Description">
         <source>Dependency description.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|Description">
         <source>Version of dependency.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
         <source>IncludeAssets</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
         <source>Assets to include from this reference</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
         <source>ExcludeAssets</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
         <source>Assets to exclude from this reference</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
         <source>PrivateAssets</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
         <source>Assets that are private in this reference</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|OriginalItemSpec|Description">
         <source>The evaluated item name of the original reference item whose resolution resulted in this resolved reference item.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/EmbeddedResource.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/EmbeddedResource.xaml.xlf
@@ -5,99 +5,99 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/EmbeddedResource.xaml" />
       <trans-unit id="Rule|EmbeddedResource|DisplayName">
         <source>Embedded Resource</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|EmbeddedResource|Description">
         <source>Embedded resources</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Category|Advanced|DisplayName">
         <source>Advanced</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Category|Misc|DisplayName">
         <source>Misc</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|{}{ItemType}|DisplayName">
         <source>Build Action</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|{}{ItemType}|Description">
         <source>How the file relates to the build and deployment processes.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|CopyToOutputDirectory|DisplayName">
         <source>Copy to Output Directory</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|CopyToOutputDirectory|Description">
         <source>Specifies the source file will be copied to the output directory.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Always|DisplayName">
         <source>Copy always</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.PreserveNewest|DisplayName">
         <source>Copy if newer</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Generator|DisplayName">
         <source>Custom Tool</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Generator|Description">
         <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
         <source>Custom Tool Namespace</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|CustomToolNamespace|Description">
         <source>The namespace into which the output of the custom tool is placed.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Identity|Description">
         <source>The item specified in the Include attribute.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
         <source>Full Path</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|Description">
         <source>Location of the file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileNameAndExtension|DisplayName">
         <source>File Name</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileNameAndExtension|Description">
         <source>Name of the file or folder.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|LastGenOutput|Description">
         <source>The filename of the last file generated as a result of the SFG.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DesignTime|Description">
         <source>A value indicating whether this file has a designer.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|AutoGen|Description">
         <source>A value indicating whether this is a generated file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|CustomTool|Description">
         <source>DTE Property for accessing the Generator property.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/Folder.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/Folder.xaml.xlf
@@ -5,27 +5,27 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Folder.xaml" />
       <trans-unit id="Rule|Folder|DisplayName">
         <source>General</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|Folder|Description">
         <source>Folder Properties</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
         <source>Full Path</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|Description">
         <source>Location of the folder</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FolderName|DisplayName">
         <source>Folder Name</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FolderName|Description">
         <source>Name of this folder</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.cs.xlf
@@ -253,19 +253,9 @@
         <target state="translated">Složka projektu</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Title|DisplayName">
-        <source>Assembly Title</source>
-        <target state="translated">Název sestavení</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Description|DisplayName">
         <source>Assembly Description</source>
         <target state="translated">Popis sestavení</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Company|DisplayName">
-        <source>Company</source>
-        <target state="translated">Společnost</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Product|DisplayName">
@@ -278,34 +268,9 @@
         <target state="translated">Autorská práva</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Trademark|DisplayName">
-        <source>Trademark</source>
-        <target state="translated">Ochranná známka</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|AssemblyVersion|DisplayName">
         <source>Assembly Version</source>
         <target state="translated">Verze sestavení</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyFileVersion|DisplayName">
-        <source>Assembly FileVersion</source>
-        <target state="translated">Verze souboru sestavení</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyGuid|DisplayName">
-        <source>Assembly Guid</source>
-        <target state="translated">Guid sestavení</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|NeutralResourcesLanguage|DisplayName">
-        <source>Neutral Resources Language</source>
-        <target state="translated">Jazyk neutrálních prostředků</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ComVisible|DisplayName">
-        <source>ComVisible</source>
-        <target state="translated">ComVisible</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|SignAssembly|DisplayName">
@@ -322,6 +287,86 @@
         <source>Strong name key file</source>
         <target state="translated">Soubor klíče se silným názvem</target>
         <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TreatSpecificWarningsAsErrors|Description">
+        <source>Treat specific warnings as errors</source>
+        <target state="new">Treat specific warnings as errors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePackageOnBuild|DisplayName">
+        <source>Generate Package On Build</source>
+        <target state="new">Generate Package On Build</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageId|DisplayName">
+        <source>Package Id</source>
+        <target state="new">Package Id</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageVersion|DisplayName">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Authors|DisplayName">
+        <source>Authors</source>
+        <target state="new">Authors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|DisplayName">
+        <source>Package Require License Acceptance</source>
+        <target state="new">Package Require License Acceptance</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageLicenseUrl|DisplayName">
+        <source>Package License Url</source>
+        <target state="new">Package License Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageProjectUrl|DisplayName">
+        <source>Package Project Url</source>
+        <target state="new">Package Project Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageIconUrl|DisplayName">
+        <source>Package Icon Url</source>
+        <target state="new">Package Icon Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageTags|DisplayName">
+        <source>Package Tags</source>
+        <target state="new">Package Tags</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReleaseNotes|DisplayName">
+        <source>Release Notes</source>
+        <target state="new">Release Notes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
+        <source>Repository Url</source>
+        <target state="new">Repository Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryType|DisplayName">
+        <source>Repository Type</source>
+        <target state="new">Repository Type</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyCompany|DisplayName">
+        <source>Assembly Company</source>
+        <target state="new">Assembly Company</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|FileVersion|DisplayName">
+        <source>Assembly File Version</source>
+        <target state="new">Assembly File Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NeutralLanguage|DisplayName">
+        <source>Neutral Resources Language</source>
+        <target state="new">Neutral Resources Language</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.de.xlf
@@ -253,19 +253,9 @@
         <target state="translated">Projektordner</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Title|DisplayName">
-        <source>Assembly Title</source>
-        <target state="translated">Assemblytitel</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Description|DisplayName">
         <source>Assembly Description</source>
         <target state="translated">Assemblybeschreibung</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Company|DisplayName">
-        <source>Company</source>
-        <target state="translated">Unternehmen</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Product|DisplayName">
@@ -278,34 +268,9 @@
         <target state="translated">Copyright</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Trademark|DisplayName">
-        <source>Trademark</source>
-        <target state="translated">Marke</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|AssemblyVersion|DisplayName">
         <source>Assembly Version</source>
         <target state="translated">Assemblyversion</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyFileVersion|DisplayName">
-        <source>Assembly FileVersion</source>
-        <target state="translated">Assemblydateiversion</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyGuid|DisplayName">
-        <source>Assembly Guid</source>
-        <target state="translated">Assembly-GUID</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|NeutralResourcesLanguage|DisplayName">
-        <source>Neutral Resources Language</source>
-        <target state="translated">Neutrale Ressourcensprache</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ComVisible|DisplayName">
-        <source>ComVisible</source>
-        <target state="translated">ComVisible</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|SignAssembly|DisplayName">
@@ -322,6 +287,86 @@
         <source>Strong name key file</source>
         <target state="translated">Schlüsseldatei mit starkem Namen</target>
         <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TreatSpecificWarningsAsErrors|Description">
+        <source>Treat specific warnings as errors</source>
+        <target state="new">Treat specific warnings as errors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePackageOnBuild|DisplayName">
+        <source>Generate Package On Build</source>
+        <target state="new">Generate Package On Build</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageId|DisplayName">
+        <source>Package Id</source>
+        <target state="new">Package Id</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageVersion|DisplayName">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Authors|DisplayName">
+        <source>Authors</source>
+        <target state="new">Authors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|DisplayName">
+        <source>Package Require License Acceptance</source>
+        <target state="new">Package Require License Acceptance</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageLicenseUrl|DisplayName">
+        <source>Package License Url</source>
+        <target state="new">Package License Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageProjectUrl|DisplayName">
+        <source>Package Project Url</source>
+        <target state="new">Package Project Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageIconUrl|DisplayName">
+        <source>Package Icon Url</source>
+        <target state="new">Package Icon Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageTags|DisplayName">
+        <source>Package Tags</source>
+        <target state="new">Package Tags</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReleaseNotes|DisplayName">
+        <source>Release Notes</source>
+        <target state="new">Release Notes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
+        <source>Repository Url</source>
+        <target state="new">Repository Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryType|DisplayName">
+        <source>Repository Type</source>
+        <target state="new">Repository Type</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyCompany|DisplayName">
+        <source>Assembly Company</source>
+        <target state="new">Assembly Company</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|FileVersion|DisplayName">
+        <source>Assembly File Version</source>
+        <target state="new">Assembly File Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NeutralLanguage|DisplayName">
+        <source>Neutral Resources Language</source>
+        <target state="new">Neutral Resources Language</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.es.xlf
@@ -253,19 +253,9 @@
         <target state="translated">Carpeta de proyecto</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Title|DisplayName">
-        <source>Assembly Title</source>
-        <target state="translated">Título del ensamblado</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Description|DisplayName">
         <source>Assembly Description</source>
         <target state="translated">Descripción del ensamblado</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Company|DisplayName">
-        <source>Company</source>
-        <target state="translated">Compañía</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Product|DisplayName">
@@ -278,34 +268,9 @@
         <target state="translated">Copyright</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Trademark|DisplayName">
-        <source>Trademark</source>
-        <target state="translated">Marca comercial</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|AssemblyVersion|DisplayName">
         <source>Assembly Version</source>
         <target state="translated">Versión del ensamblado</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyFileVersion|DisplayName">
-        <source>Assembly FileVersion</source>
-        <target state="translated">Versión del archivo de ensamblado</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyGuid|DisplayName">
-        <source>Assembly Guid</source>
-        <target state="translated">GUID del ensamblado</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|NeutralResourcesLanguage|DisplayName">
-        <source>Neutral Resources Language</source>
-        <target state="translated">Idioma de recursos neutros</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ComVisible|DisplayName">
-        <source>ComVisible</source>
-        <target state="translated">ComVisible</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|SignAssembly|DisplayName">
@@ -322,6 +287,86 @@
         <source>Strong name key file</source>
         <target state="translated">Archivo de clave de nombre seguro</target>
         <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TreatSpecificWarningsAsErrors|Description">
+        <source>Treat specific warnings as errors</source>
+        <target state="new">Treat specific warnings as errors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePackageOnBuild|DisplayName">
+        <source>Generate Package On Build</source>
+        <target state="new">Generate Package On Build</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageId|DisplayName">
+        <source>Package Id</source>
+        <target state="new">Package Id</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageVersion|DisplayName">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Authors|DisplayName">
+        <source>Authors</source>
+        <target state="new">Authors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|DisplayName">
+        <source>Package Require License Acceptance</source>
+        <target state="new">Package Require License Acceptance</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageLicenseUrl|DisplayName">
+        <source>Package License Url</source>
+        <target state="new">Package License Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageProjectUrl|DisplayName">
+        <source>Package Project Url</source>
+        <target state="new">Package Project Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageIconUrl|DisplayName">
+        <source>Package Icon Url</source>
+        <target state="new">Package Icon Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageTags|DisplayName">
+        <source>Package Tags</source>
+        <target state="new">Package Tags</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReleaseNotes|DisplayName">
+        <source>Release Notes</source>
+        <target state="new">Release Notes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
+        <source>Repository Url</source>
+        <target state="new">Repository Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryType|DisplayName">
+        <source>Repository Type</source>
+        <target state="new">Repository Type</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyCompany|DisplayName">
+        <source>Assembly Company</source>
+        <target state="new">Assembly Company</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|FileVersion|DisplayName">
+        <source>Assembly File Version</source>
+        <target state="new">Assembly File Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NeutralLanguage|DisplayName">
+        <source>Neutral Resources Language</source>
+        <target state="new">Neutral Resources Language</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.fr.xlf
@@ -253,19 +253,9 @@
         <target state="translated">Dossier du projet</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Title|DisplayName">
-        <source>Assembly Title</source>
-        <target state="translated">Titre de l'assembly</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Description|DisplayName">
         <source>Assembly Description</source>
         <target state="translated">Description de l'assembly</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Company|DisplayName">
-        <source>Company</source>
-        <target state="translated">Société</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Product|DisplayName">
@@ -278,34 +268,9 @@
         <target state="translated">Copyright</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Trademark|DisplayName">
-        <source>Trademark</source>
-        <target state="translated">Marque</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|AssemblyVersion|DisplayName">
         <source>Assembly Version</source>
         <target state="translated">Version de l'assembly</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyFileVersion|DisplayName">
-        <source>Assembly FileVersion</source>
-        <target state="translated">Version du fichier d'assembly</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyGuid|DisplayName">
-        <source>Assembly Guid</source>
-        <target state="translated">GUID de l'assembly</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|NeutralResourcesLanguage|DisplayName">
-        <source>Neutral Resources Language</source>
-        <target state="translated">Langage de ressources neutre</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ComVisible|DisplayName">
-        <source>ComVisible</source>
-        <target state="translated">ComVisible</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|SignAssembly|DisplayName">
@@ -322,6 +287,86 @@
         <source>Strong name key file</source>
         <target state="translated">Fichier de clé de nom fort</target>
         <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TreatSpecificWarningsAsErrors|Description">
+        <source>Treat specific warnings as errors</source>
+        <target state="new">Treat specific warnings as errors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePackageOnBuild|DisplayName">
+        <source>Generate Package On Build</source>
+        <target state="new">Generate Package On Build</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageId|DisplayName">
+        <source>Package Id</source>
+        <target state="new">Package Id</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageVersion|DisplayName">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Authors|DisplayName">
+        <source>Authors</source>
+        <target state="new">Authors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|DisplayName">
+        <source>Package Require License Acceptance</source>
+        <target state="new">Package Require License Acceptance</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageLicenseUrl|DisplayName">
+        <source>Package License Url</source>
+        <target state="new">Package License Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageProjectUrl|DisplayName">
+        <source>Package Project Url</source>
+        <target state="new">Package Project Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageIconUrl|DisplayName">
+        <source>Package Icon Url</source>
+        <target state="new">Package Icon Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageTags|DisplayName">
+        <source>Package Tags</source>
+        <target state="new">Package Tags</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReleaseNotes|DisplayName">
+        <source>Release Notes</source>
+        <target state="new">Release Notes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
+        <source>Repository Url</source>
+        <target state="new">Repository Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryType|DisplayName">
+        <source>Repository Type</source>
+        <target state="new">Repository Type</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyCompany|DisplayName">
+        <source>Assembly Company</source>
+        <target state="new">Assembly Company</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|FileVersion|DisplayName">
+        <source>Assembly File Version</source>
+        <target state="new">Assembly File Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NeutralLanguage|DisplayName">
+        <source>Neutral Resources Language</source>
+        <target state="new">Neutral Resources Language</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.it.xlf
@@ -253,19 +253,9 @@
         <target state="translated">Cartella di progetto</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Title|DisplayName">
-        <source>Assembly Title</source>
-        <target state="translated">Titolo dell'assembly</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Description|DisplayName">
         <source>Assembly Description</source>
         <target state="translated">Descrizione dell'assembly</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Company|DisplayName">
-        <source>Company</source>
-        <target state="translated">Società</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Product|DisplayName">
@@ -278,34 +268,9 @@
         <target state="translated">Copyright</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Trademark|DisplayName">
-        <source>Trademark</source>
-        <target state="translated">Marchio</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|AssemblyVersion|DisplayName">
         <source>Assembly Version</source>
         <target state="translated">Versione dell'assembly</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyFileVersion|DisplayName">
-        <source>Assembly FileVersion</source>
-        <target state="translated">Versione file dell'assembly</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyGuid|DisplayName">
-        <source>Assembly Guid</source>
-        <target state="translated">GUID dell'assembly</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|NeutralResourcesLanguage|DisplayName">
-        <source>Neutral Resources Language</source>
-        <target state="translated">Lingua risorse di sistema</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ComVisible|DisplayName">
-        <source>ComVisible</source>
-        <target state="translated">ComVisible</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|SignAssembly|DisplayName">
@@ -322,6 +287,86 @@
         <source>Strong name key file</source>
         <target state="translated">File di chiave con nome sicuro</target>
         <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TreatSpecificWarningsAsErrors|Description">
+        <source>Treat specific warnings as errors</source>
+        <target state="new">Treat specific warnings as errors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePackageOnBuild|DisplayName">
+        <source>Generate Package On Build</source>
+        <target state="new">Generate Package On Build</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageId|DisplayName">
+        <source>Package Id</source>
+        <target state="new">Package Id</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageVersion|DisplayName">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Authors|DisplayName">
+        <source>Authors</source>
+        <target state="new">Authors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|DisplayName">
+        <source>Package Require License Acceptance</source>
+        <target state="new">Package Require License Acceptance</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageLicenseUrl|DisplayName">
+        <source>Package License Url</source>
+        <target state="new">Package License Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageProjectUrl|DisplayName">
+        <source>Package Project Url</source>
+        <target state="new">Package Project Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageIconUrl|DisplayName">
+        <source>Package Icon Url</source>
+        <target state="new">Package Icon Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageTags|DisplayName">
+        <source>Package Tags</source>
+        <target state="new">Package Tags</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReleaseNotes|DisplayName">
+        <source>Release Notes</source>
+        <target state="new">Release Notes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
+        <source>Repository Url</source>
+        <target state="new">Repository Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryType|DisplayName">
+        <source>Repository Type</source>
+        <target state="new">Repository Type</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyCompany|DisplayName">
+        <source>Assembly Company</source>
+        <target state="new">Assembly Company</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|FileVersion|DisplayName">
+        <source>Assembly File Version</source>
+        <target state="new">Assembly File Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NeutralLanguage|DisplayName">
+        <source>Neutral Resources Language</source>
+        <target state="new">Neutral Resources Language</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.ja.xlf
@@ -253,19 +253,9 @@
         <target state="translated">プロジェクト フォルダー</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Title|DisplayName">
-        <source>Assembly Title</source>
-        <target state="translated">アセンブリのタイトル</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Description|DisplayName">
         <source>Assembly Description</source>
         <target state="translated">アセンブリの説明</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Company|DisplayName">
-        <source>Company</source>
-        <target state="translated">会社</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Product|DisplayName">
@@ -278,34 +268,9 @@
         <target state="translated">著作権</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Trademark|DisplayName">
-        <source>Trademark</source>
-        <target state="translated">商標</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|AssemblyVersion|DisplayName">
         <source>Assembly Version</source>
         <target state="translated">アセンブリ バージョン</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyFileVersion|DisplayName">
-        <source>Assembly FileVersion</source>
-        <target state="translated">アセンブリ ファイル バージョン</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyGuid|DisplayName">
-        <source>Assembly Guid</source>
-        <target state="translated">アセンブリ GUID</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|NeutralResourcesLanguage|DisplayName">
-        <source>Neutral Resources Language</source>
-        <target state="translated">ニュートラル リソース言語</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ComVisible|DisplayName">
-        <source>ComVisible</source>
-        <target state="translated">ComVisible</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|SignAssembly|DisplayName">
@@ -322,6 +287,86 @@
         <source>Strong name key file</source>
         <target state="translated">厳密な名前キー ファイル</target>
         <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TreatSpecificWarningsAsErrors|Description">
+        <source>Treat specific warnings as errors</source>
+        <target state="new">Treat specific warnings as errors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePackageOnBuild|DisplayName">
+        <source>Generate Package On Build</source>
+        <target state="new">Generate Package On Build</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageId|DisplayName">
+        <source>Package Id</source>
+        <target state="new">Package Id</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageVersion|DisplayName">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Authors|DisplayName">
+        <source>Authors</source>
+        <target state="new">Authors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|DisplayName">
+        <source>Package Require License Acceptance</source>
+        <target state="new">Package Require License Acceptance</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageLicenseUrl|DisplayName">
+        <source>Package License Url</source>
+        <target state="new">Package License Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageProjectUrl|DisplayName">
+        <source>Package Project Url</source>
+        <target state="new">Package Project Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageIconUrl|DisplayName">
+        <source>Package Icon Url</source>
+        <target state="new">Package Icon Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageTags|DisplayName">
+        <source>Package Tags</source>
+        <target state="new">Package Tags</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReleaseNotes|DisplayName">
+        <source>Release Notes</source>
+        <target state="new">Release Notes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
+        <source>Repository Url</source>
+        <target state="new">Repository Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryType|DisplayName">
+        <source>Repository Type</source>
+        <target state="new">Repository Type</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyCompany|DisplayName">
+        <source>Assembly Company</source>
+        <target state="new">Assembly Company</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|FileVersion|DisplayName">
+        <source>Assembly File Version</source>
+        <target state="new">Assembly File Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NeutralLanguage|DisplayName">
+        <source>Neutral Resources Language</source>
+        <target state="new">Neutral Resources Language</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.ko.xlf
@@ -253,19 +253,9 @@
         <target state="translated">프로젝트 폴더</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Title|DisplayName">
-        <source>Assembly Title</source>
-        <target state="translated">어셈블리 제목</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Description|DisplayName">
         <source>Assembly Description</source>
         <target state="translated">어셈블리 설명</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Company|DisplayName">
-        <source>Company</source>
-        <target state="translated">회사</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Product|DisplayName">
@@ -278,34 +268,9 @@
         <target state="translated">저작권</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Trademark|DisplayName">
-        <source>Trademark</source>
-        <target state="translated">상표</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|AssemblyVersion|DisplayName">
         <source>Assembly Version</source>
         <target state="translated">어셈블리 버전</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyFileVersion|DisplayName">
-        <source>Assembly FileVersion</source>
-        <target state="translated">어셈블리 FileVersion</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyGuid|DisplayName">
-        <source>Assembly Guid</source>
-        <target state="translated">어셈블리 GUID</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|NeutralResourcesLanguage|DisplayName">
-        <source>Neutral Resources Language</source>
-        <target state="translated">중립 리소스 언어</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ComVisible|DisplayName">
-        <source>ComVisible</source>
-        <target state="translated">ComVisible</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|SignAssembly|DisplayName">
@@ -322,6 +287,86 @@
         <source>Strong name key file</source>
         <target state="translated">강력한 이름 키 파일</target>
         <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TreatSpecificWarningsAsErrors|Description">
+        <source>Treat specific warnings as errors</source>
+        <target state="new">Treat specific warnings as errors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePackageOnBuild|DisplayName">
+        <source>Generate Package On Build</source>
+        <target state="new">Generate Package On Build</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageId|DisplayName">
+        <source>Package Id</source>
+        <target state="new">Package Id</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageVersion|DisplayName">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Authors|DisplayName">
+        <source>Authors</source>
+        <target state="new">Authors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|DisplayName">
+        <source>Package Require License Acceptance</source>
+        <target state="new">Package Require License Acceptance</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageLicenseUrl|DisplayName">
+        <source>Package License Url</source>
+        <target state="new">Package License Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageProjectUrl|DisplayName">
+        <source>Package Project Url</source>
+        <target state="new">Package Project Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageIconUrl|DisplayName">
+        <source>Package Icon Url</source>
+        <target state="new">Package Icon Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageTags|DisplayName">
+        <source>Package Tags</source>
+        <target state="new">Package Tags</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReleaseNotes|DisplayName">
+        <source>Release Notes</source>
+        <target state="new">Release Notes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
+        <source>Repository Url</source>
+        <target state="new">Repository Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryType|DisplayName">
+        <source>Repository Type</source>
+        <target state="new">Repository Type</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyCompany|DisplayName">
+        <source>Assembly Company</source>
+        <target state="new">Assembly Company</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|FileVersion|DisplayName">
+        <source>Assembly File Version</source>
+        <target state="new">Assembly File Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NeutralLanguage|DisplayName">
+        <source>Neutral Resources Language</source>
+        <target state="new">Neutral Resources Language</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.pl.xlf
@@ -253,19 +253,9 @@
         <target state="translated">Folder projektu</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Title|DisplayName">
-        <source>Assembly Title</source>
-        <target state="translated">Tytuł zestawu</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Description|DisplayName">
         <source>Assembly Description</source>
         <target state="translated">Opis zestawu</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Company|DisplayName">
-        <source>Company</source>
-        <target state="translated">Firma</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Product|DisplayName">
@@ -278,34 +268,9 @@
         <target state="translated">Prawa autorskie</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Trademark|DisplayName">
-        <source>Trademark</source>
-        <target state="translated">Znak towarowy</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|AssemblyVersion|DisplayName">
         <source>Assembly Version</source>
         <target state="translated">Wersja zestawu</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyFileVersion|DisplayName">
-        <source>Assembly FileVersion</source>
-        <target state="translated">Atrybut FileVersion zestawu</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyGuid|DisplayName">
-        <source>Assembly Guid</source>
-        <target state="translated">Identyfikator GUID zestawu</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|NeutralResourcesLanguage|DisplayName">
-        <source>Neutral Resources Language</source>
-        <target state="translated">Neutralny język zasobów</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ComVisible|DisplayName">
-        <source>ComVisible</source>
-        <target state="translated">Atrybut ComVisible</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|SignAssembly|DisplayName">
@@ -322,6 +287,86 @@
         <source>Strong name key file</source>
         <target state="translated">Plik klucza o silnej nazwie</target>
         <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TreatSpecificWarningsAsErrors|Description">
+        <source>Treat specific warnings as errors</source>
+        <target state="new">Treat specific warnings as errors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePackageOnBuild|DisplayName">
+        <source>Generate Package On Build</source>
+        <target state="new">Generate Package On Build</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageId|DisplayName">
+        <source>Package Id</source>
+        <target state="new">Package Id</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageVersion|DisplayName">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Authors|DisplayName">
+        <source>Authors</source>
+        <target state="new">Authors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|DisplayName">
+        <source>Package Require License Acceptance</source>
+        <target state="new">Package Require License Acceptance</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageLicenseUrl|DisplayName">
+        <source>Package License Url</source>
+        <target state="new">Package License Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageProjectUrl|DisplayName">
+        <source>Package Project Url</source>
+        <target state="new">Package Project Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageIconUrl|DisplayName">
+        <source>Package Icon Url</source>
+        <target state="new">Package Icon Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageTags|DisplayName">
+        <source>Package Tags</source>
+        <target state="new">Package Tags</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReleaseNotes|DisplayName">
+        <source>Release Notes</source>
+        <target state="new">Release Notes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
+        <source>Repository Url</source>
+        <target state="new">Repository Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryType|DisplayName">
+        <source>Repository Type</source>
+        <target state="new">Repository Type</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyCompany|DisplayName">
+        <source>Assembly Company</source>
+        <target state="new">Assembly Company</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|FileVersion|DisplayName">
+        <source>Assembly File Version</source>
+        <target state="new">Assembly File Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NeutralLanguage|DisplayName">
+        <source>Neutral Resources Language</source>
+        <target state="new">Neutral Resources Language</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.pt-BR.xlf
@@ -253,19 +253,9 @@
         <target state="translated">Pasta do Projeto</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Title|DisplayName">
-        <source>Assembly Title</source>
-        <target state="translated">Título do Assembly</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Description|DisplayName">
         <source>Assembly Description</source>
         <target state="translated">Descrição do Assembly</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Company|DisplayName">
-        <source>Company</source>
-        <target state="translated">Empresa</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Product|DisplayName">
@@ -278,34 +268,9 @@
         <target state="translated">Copyright</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Trademark|DisplayName">
-        <source>Trademark</source>
-        <target state="translated">Marca registrada</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|AssemblyVersion|DisplayName">
         <source>Assembly Version</source>
         <target state="translated">Versão do Assembly</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyFileVersion|DisplayName">
-        <source>Assembly FileVersion</source>
-        <target state="translated">Versão do Arquivo do Assembly</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyGuid|DisplayName">
-        <source>Assembly Guid</source>
-        <target state="translated">Guid do Assembly</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|NeutralResourcesLanguage|DisplayName">
-        <source>Neutral Resources Language</source>
-        <target state="translated">Idioma de Recursos Neutros</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ComVisible|DisplayName">
-        <source>ComVisible</source>
-        <target state="translated">ComVisible</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|SignAssembly|DisplayName">
@@ -322,6 +287,86 @@
         <source>Strong name key file</source>
         <target state="translated">Arquivo de chave de nome forte</target>
         <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TreatSpecificWarningsAsErrors|Description">
+        <source>Treat specific warnings as errors</source>
+        <target state="new">Treat specific warnings as errors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePackageOnBuild|DisplayName">
+        <source>Generate Package On Build</source>
+        <target state="new">Generate Package On Build</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageId|DisplayName">
+        <source>Package Id</source>
+        <target state="new">Package Id</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageVersion|DisplayName">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Authors|DisplayName">
+        <source>Authors</source>
+        <target state="new">Authors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|DisplayName">
+        <source>Package Require License Acceptance</source>
+        <target state="new">Package Require License Acceptance</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageLicenseUrl|DisplayName">
+        <source>Package License Url</source>
+        <target state="new">Package License Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageProjectUrl|DisplayName">
+        <source>Package Project Url</source>
+        <target state="new">Package Project Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageIconUrl|DisplayName">
+        <source>Package Icon Url</source>
+        <target state="new">Package Icon Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageTags|DisplayName">
+        <source>Package Tags</source>
+        <target state="new">Package Tags</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReleaseNotes|DisplayName">
+        <source>Release Notes</source>
+        <target state="new">Release Notes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
+        <source>Repository Url</source>
+        <target state="new">Repository Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryType|DisplayName">
+        <source>Repository Type</source>
+        <target state="new">Repository Type</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyCompany|DisplayName">
+        <source>Assembly Company</source>
+        <target state="new">Assembly Company</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|FileVersion|DisplayName">
+        <source>Assembly File Version</source>
+        <target state="new">Assembly File Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NeutralLanguage|DisplayName">
+        <source>Neutral Resources Language</source>
+        <target state="new">Neutral Resources Language</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.ru.xlf
@@ -253,19 +253,9 @@
         <target state="translated">Папка проекта</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Title|DisplayName">
-        <source>Assembly Title</source>
-        <target state="translated">Название сборки</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Description|DisplayName">
         <source>Assembly Description</source>
         <target state="translated">Описание сборки</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Company|DisplayName">
-        <source>Company</source>
-        <target state="translated">Организация</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Product|DisplayName">
@@ -278,34 +268,9 @@
         <target state="translated">Авторские права</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Trademark|DisplayName">
-        <source>Trademark</source>
-        <target state="translated">Товарный знак</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|AssemblyVersion|DisplayName">
         <source>Assembly Version</source>
         <target state="translated">Версия сборки</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyFileVersion|DisplayName">
-        <source>Assembly FileVersion</source>
-        <target state="translated">Версия файла сборки</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyGuid|DisplayName">
-        <source>Assembly Guid</source>
-        <target state="translated">GUID сборки</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|NeutralResourcesLanguage|DisplayName">
-        <source>Neutral Resources Language</source>
-        <target state="translated">Нейтральный язык ресурсов</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ComVisible|DisplayName">
-        <source>ComVisible</source>
-        <target state="translated">ComVisible</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|SignAssembly|DisplayName">
@@ -322,6 +287,86 @@
         <source>Strong name key file</source>
         <target state="translated">Файл ключа строгого имени</target>
         <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TreatSpecificWarningsAsErrors|Description">
+        <source>Treat specific warnings as errors</source>
+        <target state="new">Treat specific warnings as errors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePackageOnBuild|DisplayName">
+        <source>Generate Package On Build</source>
+        <target state="new">Generate Package On Build</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageId|DisplayName">
+        <source>Package Id</source>
+        <target state="new">Package Id</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageVersion|DisplayName">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Authors|DisplayName">
+        <source>Authors</source>
+        <target state="new">Authors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|DisplayName">
+        <source>Package Require License Acceptance</source>
+        <target state="new">Package Require License Acceptance</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageLicenseUrl|DisplayName">
+        <source>Package License Url</source>
+        <target state="new">Package License Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageProjectUrl|DisplayName">
+        <source>Package Project Url</source>
+        <target state="new">Package Project Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageIconUrl|DisplayName">
+        <source>Package Icon Url</source>
+        <target state="new">Package Icon Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageTags|DisplayName">
+        <source>Package Tags</source>
+        <target state="new">Package Tags</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReleaseNotes|DisplayName">
+        <source>Release Notes</source>
+        <target state="new">Release Notes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
+        <source>Repository Url</source>
+        <target state="new">Repository Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryType|DisplayName">
+        <source>Repository Type</source>
+        <target state="new">Repository Type</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyCompany|DisplayName">
+        <source>Assembly Company</source>
+        <target state="new">Assembly Company</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|FileVersion|DisplayName">
+        <source>Assembly File Version</source>
+        <target state="new">Assembly File Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NeutralLanguage|DisplayName">
+        <source>Neutral Resources Language</source>
+        <target state="new">Neutral Resources Language</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.tr.xlf
@@ -253,19 +253,9 @@
         <target state="translated">Proje Klasörü</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Title|DisplayName">
-        <source>Assembly Title</source>
-        <target state="translated">Bütünleştirilmiş Kod Başlığı</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Description|DisplayName">
         <source>Assembly Description</source>
         <target state="translated">Bütünleştirilmiş Kod Açıklaması</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Company|DisplayName">
-        <source>Company</source>
-        <target state="translated">Şirket</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Product|DisplayName">
@@ -278,34 +268,9 @@
         <target state="translated">Telif Hakkı</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Trademark|DisplayName">
-        <source>Trademark</source>
-        <target state="translated">Ticari Marka</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|AssemblyVersion|DisplayName">
         <source>Assembly Version</source>
         <target state="translated">Bütünleştirilmiş Kod Sürümü</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyFileVersion|DisplayName">
-        <source>Assembly FileVersion</source>
-        <target state="translated">Bütünleştirilmiş Kod Dosya Sürümü</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyGuid|DisplayName">
-        <source>Assembly Guid</source>
-        <target state="translated">Bütünleştirilmiş Kod Guid’i</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|NeutralResourcesLanguage|DisplayName">
-        <source>Neutral Resources Language</source>
-        <target state="translated">Bağımsız Kaynak Dili</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ComVisible|DisplayName">
-        <source>ComVisible</source>
-        <target state="translated">ComVisible</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|SignAssembly|DisplayName">
@@ -322,6 +287,86 @@
         <source>Strong name key file</source>
         <target state="translated">Tanımlayıcı ad anahtar dosyası</target>
         <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TreatSpecificWarningsAsErrors|Description">
+        <source>Treat specific warnings as errors</source>
+        <target state="new">Treat specific warnings as errors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePackageOnBuild|DisplayName">
+        <source>Generate Package On Build</source>
+        <target state="new">Generate Package On Build</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageId|DisplayName">
+        <source>Package Id</source>
+        <target state="new">Package Id</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageVersion|DisplayName">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Authors|DisplayName">
+        <source>Authors</source>
+        <target state="new">Authors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|DisplayName">
+        <source>Package Require License Acceptance</source>
+        <target state="new">Package Require License Acceptance</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageLicenseUrl|DisplayName">
+        <source>Package License Url</source>
+        <target state="new">Package License Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageProjectUrl|DisplayName">
+        <source>Package Project Url</source>
+        <target state="new">Package Project Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageIconUrl|DisplayName">
+        <source>Package Icon Url</source>
+        <target state="new">Package Icon Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageTags|DisplayName">
+        <source>Package Tags</source>
+        <target state="new">Package Tags</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReleaseNotes|DisplayName">
+        <source>Release Notes</source>
+        <target state="new">Release Notes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
+        <source>Repository Url</source>
+        <target state="new">Repository Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryType|DisplayName">
+        <source>Repository Type</source>
+        <target state="new">Repository Type</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyCompany|DisplayName">
+        <source>Assembly Company</source>
+        <target state="new">Assembly Company</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|FileVersion|DisplayName">
+        <source>Assembly File Version</source>
+        <target state="new">Assembly File Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NeutralLanguage|DisplayName">
+        <source>Neutral Resources Language</source>
+        <target state="new">Neutral Resources Language</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.xlf
@@ -203,16 +203,8 @@
         <source>Project Folder</source>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Title|DisplayName">
-        <source>Assembly Title</source>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Description|DisplayName">
         <source>Assembly Description</source>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Company|DisplayName">
-        <source>Company</source>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Product|DisplayName">
@@ -223,28 +215,8 @@
         <source>Copyright</source>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Trademark|DisplayName">
-        <source>Trademark</source>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|AssemblyVersion|DisplayName">
         <source>Assembly Version</source>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyFileVersion|DisplayName">
-        <source>Assembly FileVersion</source>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyGuid|DisplayName">
-        <source>Assembly Guid</source>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|NeutralResourcesLanguage|DisplayName">
-        <source>Neutral Resources Language</source>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ComVisible|DisplayName">
-        <source>ComVisible</source>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|SignAssembly|DisplayName">
@@ -258,6 +230,70 @@
       <trans-unit id="StringProperty|AssemblyOriginatorKeyFile|DisplayName">
         <source>Strong name key file</source>
         <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TreatSpecificWarningsAsErrors|Description">
+        <source>Treat specific warnings as errors</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePackageOnBuild|DisplayName">
+        <source>Generate Package On Build</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageId|DisplayName">
+        <source>Package Id</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageVersion|DisplayName">
+        <source>Package Version</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Authors|DisplayName">
+        <source>Authors</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|DisplayName">
+        <source>Package Require License Acceptance</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageLicenseUrl|DisplayName">
+        <source>Package License Url</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageProjectUrl|DisplayName">
+        <source>Package Project Url</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageIconUrl|DisplayName">
+        <source>Package Icon Url</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageTags|DisplayName">
+        <source>Package Tags</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReleaseNotes|DisplayName">
+        <source>Release Notes</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
+        <source>Repository Url</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryType|DisplayName">
+        <source>Repository Type</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyCompany|DisplayName">
+        <source>Assembly Company</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|FileVersion|DisplayName">
+        <source>Assembly File Version</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NeutralLanguage|DisplayName">
+        <source>Neutral Resources Language</source>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.xlf
@@ -5,259 +5,259 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml" />
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|DisplayName">
         <source>General</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|Description">
         <source>General</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Category|General|DisplayName">
         <source>General</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Category|General|Description">
         <source>General</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|ApplicationIcon|DisplayName">
         <source>Application Icon</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworkMoniker|DisplayName">
         <source>Target Framework Moniker</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|AssemblyName|DisplayName">
         <source>Assembly Name</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|RootNamespace|DisplayName">
         <source>Root namespace</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|DefaultNamespace|DisplayName">
         <source>Default namespace</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworks|DisplayName">
         <source>Target Frameworks</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|OutputType|DisplayName">
         <source>Output Type</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OutputTypeEx|DisplayName">
         <source>Output Type</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|OutputTypeEx.winexe|DisplayName">
         <source>0</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|OutputTypeEx.exe|DisplayName">
         <source>1</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|OutputTypeEx.library|DisplayName">
         <source>2</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|OutputTypeEx.appcontainerexe|DisplayName">
         <source>3</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|OutputTypeEx.winmdobj|DisplayName">
         <source>4</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|StartupObject|DisplayName">
         <source>Type that contains the entry point</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|ApplicationManifest|DisplayName">
         <source>Application Manifest</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Win32ResourceFile|DisplayName">
         <source>Win32 Resource File</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|DefineConstants|DisplayName">
         <source>Define Constants</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|PlatformTarget|DisplayName">
         <source>Platform Target</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Prefer32Bit|DisplayName">
         <source>Prefer 32Bit</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|AllowUnsafeBlocks|DisplayName">
         <source>Allow unsafe code</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Optimize|DisplayName">
         <source>Optimize</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|WarningLevel|DisplayName">
         <source>Warning Level</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
         <source>Supress Warning</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|TreatWarningsAsErrors|Description">
         <source>Treat warnings as errors</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Output Path</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|DocumentationFile|DisplayName">
         <source>Documentation file</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|GenerateSerializationAssemblies|DisplayName">
         <source>Generate serialization assemblies</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|GenerateSerializationAssemblies.Auto|DisplayName">
         <source>Auto</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|GenerateSerializationAssemblies.On|DisplayName">
         <source>On</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|GenerateSerializationAssemblies.Off|DisplayName">
         <source>Off</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
         <source>Language version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ErrorReport|DisplayName">
         <source>Error report</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|DebugInfo|DisplayName">
         <source>Debug Info</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|CheckForOverflowUnderflow|DisplayName">
         <source>CheckForOverflowUnderflow</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|DebugSymbols|DisplayName">
         <source>Debug symbols</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FileAlignment|DisplayName">
         <source>File Alignment</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|BaseAddress|DisplayName">
         <source>Base address</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
         <source>Pre Build Event</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
         <source>Post Build Event</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
         <source>Run Post Build Event</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|RunPostBuildEvent.Always|DisplayName">
         <source>Always</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|RunPostBuildEvent.OnBuildSuccess|DisplayName">
         <source>On successful build</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|RunPostBuildEvent.OnOutputUpdated|DisplayName">
         <source>When the build updates the project output</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|ReferencePath|DisplayName">
         <source>Reference Path</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileName|DisplayName">
         <source>Project File</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
         <source>Project Folder</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Title|DisplayName">
         <source>Assembly Title</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Description|DisplayName">
         <source>Assembly Description</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Company|DisplayName">
         <source>Company</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Product|DisplayName">
         <source>Product</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Copyright|DisplayName">
         <source>Copyright</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Trademark|DisplayName">
         <source>Trademark</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|AssemblyVersion|DisplayName">
         <source>Assembly Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|AssemblyFileVersion|DisplayName">
         <source>Assembly FileVersion</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|AssemblyGuid|DisplayName">
         <source>Assembly Guid</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|NeutralResourcesLanguage|DisplayName">
         <source>Neutral Resources Language</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|ComVisible|DisplayName">
         <source>ComVisible</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|SignAssembly|DisplayName">
         <source>Sign the assembly</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|DelaySign|DisplayName">
         <source>Delay sign only</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|AssemblyOriginatorKeyFile|DisplayName">
         <source>Strong name key file</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.zh-Hans.xlf
@@ -253,19 +253,9 @@
         <target state="translated">项目文件夹</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Title|DisplayName">
-        <source>Assembly Title</source>
-        <target state="translated">程序及标题</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Description|DisplayName">
         <source>Assembly Description</source>
         <target state="translated">程序集说明</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Company|DisplayName">
-        <source>Company</source>
-        <target state="translated">公司</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Product|DisplayName">
@@ -278,34 +268,9 @@
         <target state="translated">版权</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Trademark|DisplayName">
-        <source>Trademark</source>
-        <target state="translated">商标</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|AssemblyVersion|DisplayName">
         <source>Assembly Version</source>
         <target state="translated">程序集版本</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyFileVersion|DisplayName">
-        <source>Assembly FileVersion</source>
-        <target state="translated">程序集 FileVersion</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyGuid|DisplayName">
-        <source>Assembly Guid</source>
-        <target state="translated">程序集 Guid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|NeutralResourcesLanguage|DisplayName">
-        <source>Neutral Resources Language</source>
-        <target state="translated">非特定区域性语言</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ComVisible|DisplayName">
-        <source>ComVisible</source>
-        <target state="translated">ComVisible</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|SignAssembly|DisplayName">
@@ -322,6 +287,86 @@
         <source>Strong name key file</source>
         <target state="translated">强名称密钥文件</target>
         <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TreatSpecificWarningsAsErrors|Description">
+        <source>Treat specific warnings as errors</source>
+        <target state="new">Treat specific warnings as errors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePackageOnBuild|DisplayName">
+        <source>Generate Package On Build</source>
+        <target state="new">Generate Package On Build</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageId|DisplayName">
+        <source>Package Id</source>
+        <target state="new">Package Id</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageVersion|DisplayName">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Authors|DisplayName">
+        <source>Authors</source>
+        <target state="new">Authors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|DisplayName">
+        <source>Package Require License Acceptance</source>
+        <target state="new">Package Require License Acceptance</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageLicenseUrl|DisplayName">
+        <source>Package License Url</source>
+        <target state="new">Package License Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageProjectUrl|DisplayName">
+        <source>Package Project Url</source>
+        <target state="new">Package Project Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageIconUrl|DisplayName">
+        <source>Package Icon Url</source>
+        <target state="new">Package Icon Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageTags|DisplayName">
+        <source>Package Tags</source>
+        <target state="new">Package Tags</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReleaseNotes|DisplayName">
+        <source>Release Notes</source>
+        <target state="new">Release Notes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
+        <source>Repository Url</source>
+        <target state="new">Repository Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryType|DisplayName">
+        <source>Repository Type</source>
+        <target state="new">Repository Type</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyCompany|DisplayName">
+        <source>Assembly Company</source>
+        <target state="new">Assembly Company</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|FileVersion|DisplayName">
+        <source>Assembly File Version</source>
+        <target state="new">Assembly File Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NeutralLanguage|DisplayName">
+        <source>Neutral Resources Language</source>
+        <target state="new">Neutral Resources Language</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.zh-Hant.xlf
@@ -253,19 +253,9 @@
         <target state="translated">專案資料夾</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Title|DisplayName">
-        <source>Assembly Title</source>
-        <target state="translated">組件標題</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Description|DisplayName">
         <source>Assembly Description</source>
         <target state="translated">組件描述</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Company|DisplayName">
-        <source>Company</source>
-        <target state="translated">公司</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Product|DisplayName">
@@ -278,34 +268,9 @@
         <target state="translated">著作權</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Trademark|DisplayName">
-        <source>Trademark</source>
-        <target state="translated">商標</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|AssemblyVersion|DisplayName">
         <source>Assembly Version</source>
         <target state="translated">組件版本</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyFileVersion|DisplayName">
-        <source>Assembly FileVersion</source>
-        <target state="translated">組件檔版本</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|AssemblyGuid|DisplayName">
-        <source>Assembly Guid</source>
-        <target state="translated">組件 GUID</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|NeutralResourcesLanguage|DisplayName">
-        <source>Neutral Resources Language</source>
-        <target state="translated">中性資源語言</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ComVisible|DisplayName">
-        <source>ComVisible</source>
-        <target state="translated">ComVisible</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|SignAssembly|DisplayName">
@@ -322,6 +287,86 @@
         <source>Strong name key file</source>
         <target state="translated">強式名稱金鑰檔</target>
         <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TreatSpecificWarningsAsErrors|Description">
+        <source>Treat specific warnings as errors</source>
+        <target state="new">Treat specific warnings as errors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|GeneratePackageOnBuild|DisplayName">
+        <source>Generate Package On Build</source>
+        <target state="new">Generate Package On Build</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageId|DisplayName">
+        <source>Package Id</source>
+        <target state="new">Package Id</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageVersion|DisplayName">
+        <source>Package Version</source>
+        <target state="new">Package Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Authors|DisplayName">
+        <source>Authors</source>
+        <target state="new">Authors</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BoolProperty|PackageRequireLicenseAcceptance|DisplayName">
+        <source>Package Require License Acceptance</source>
+        <target state="new">Package Require License Acceptance</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageLicenseUrl|DisplayName">
+        <source>Package License Url</source>
+        <target state="new">Package License Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageProjectUrl|DisplayName">
+        <source>Package Project Url</source>
+        <target state="new">Package Project Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageIconUrl|DisplayName">
+        <source>Package Icon Url</source>
+        <target state="new">Package Icon Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageTags|DisplayName">
+        <source>Package Tags</source>
+        <target state="new">Package Tags</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageReleaseNotes|DisplayName">
+        <source>Release Notes</source>
+        <target state="new">Release Notes</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryUrl|DisplayName">
+        <source>Repository Url</source>
+        <target state="new">Repository Url</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|RepositoryType|DisplayName">
+        <source>Repository Type</source>
+        <target state="new">Repository Type</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyCompany|DisplayName">
+        <source>Assembly Company</source>
+        <target state="new">Assembly Company</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|FileVersion|DisplayName">
+        <source>Assembly File Version</source>
+        <target state="new">Assembly File Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NeutralLanguage|DisplayName">
+        <source>Neutral Resources Language</source>
+        <target state="new">Neutral Resources Language</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/None.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/None.xaml.xlf
@@ -5,99 +5,99 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/None.xaml" />
       <trans-unit id="Rule|None|DisplayName">
         <source>General</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|None|Description">
         <source>Non-build items</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Category|Advanced|DisplayName">
         <source>Advanced</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Category|Misc|DisplayName">
         <source>Misc</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|{}{ItemType}|DisplayName">
         <source>Build Action</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|{}{ItemType}|Description">
         <source>How the file relates to the build and deployment processes.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|CopyToOutputDirectory|DisplayName">
         <source>Copy to Output Directory</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|CopyToOutputDirectory|Description">
         <source>Specifies the source file will be copied to the output directory.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Always|DisplayName">
         <source>Copy always</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.PreserveNewest|DisplayName">
         <source>Copy if newer</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Generator|DisplayName">
         <source>Custom Tool</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Generator|Description">
         <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
         <source>Custom Tool Namespace</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|CustomToolNamespace|Description">
         <source>The namespace into which the output of the custom tool is placed.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Identity|Description">
         <source>The item specified in the Include attribute.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
         <source>Full Path</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|Description">
         <source>Location of the file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileNameAndExtension|DisplayName">
         <source>File Name</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileNameAndExtension|Description">
         <source>Name of the file or folder.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|LastGenOutput|Description">
         <source>The filename of the last file generated as a result of the SFG.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DesignTime|Description">
         <source>A value indicating whether this file has a designer.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|AutoGen|Description">
         <source>A value indicating whether this is a generated file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|CustomTool|Description">
         <source>DTE Property for accessing the Generator property.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/NuGetRestore.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/NuGetRestore.xaml.xlf
@@ -5,35 +5,35 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml" />
       <trans-unit id="Rule|NuGetRestore|DisplayName">
         <source>NuGetRestore</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|NuGetRestore|Description">
         <source>General Configuration Properties used in NuGet Restore</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworkIdentifier|DisplayName">
         <source>Target Framework Identifier</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworks|DisplayName">
         <source>Target Frameworks</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetFramework|DisplayName">
         <source>Target Framework</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworkProfile|DisplayName">
         <source>Target Framework Profile</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworkVersion|DisplayName">
         <source>Target Framework Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetFrameworkMoniker|DisplayName">
         <source>Target Framework Moniker</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.xlf
@@ -5,55 +5,55 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml" />
       <trans-unit id="Rule|PackageReference|DisplayName">
         <source>Package</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|PackageReference|Description">
         <source>Package</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Description|DisplayName">
         <source>Description</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Description|Description">
         <source>Dependency description.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|Description">
         <source>Version of dependency.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
         <source>IncludeAssets</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
         <source>Assets to include from this reference</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
         <source>ExcludeAssets</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
         <source>Assets to exclude from this reference</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
         <source>PrivateAssets</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
         <source>Assets that are private in this reference</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|OriginalItemSpec|Description">
         <source>The evaluated item name of the original reference item whose resolution resulted in this resolved reference item.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.xlf
@@ -5,19 +5,19 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectDebugger.xaml" />
       <trans-unit id="Rule|ProjectDebugger|DisplayName">
         <source>Start</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|ProjectDebugger|Description">
         <source>Web debugging options</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|ActiveDebugProfile|DisplayName">
         <source>Debug Target</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|ActiveDebugProfile|Description">
         <source>Specifies the profile to use for debugging</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.xlf
@@ -5,55 +5,55 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectItemsSchema.xaml" />
       <trans-unit id="ContentType|Text|DisplayName">
         <source>Text file</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ContentType|XML|DisplayName">
         <source>Xml file</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ContentType|HTML|DisplayName">
         <source>Html file</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ContentType|CSS|DisplayName">
         <source>Cascading style sheet</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ContentType|Json|DisplayName">
         <source>Json file</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ContentType|Font|DisplayName">
         <source>Font file</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ContentType|Media|DisplayName">
         <source>Media file</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ContentType|Image|DisplayName">
         <source>Image file</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ContentType|EmbeddedResource|DisplayName">
         <source>Embedded resource</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ItemType|AdditionalFiles|DisplayName">
         <source>AdditionalFiles</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ItemType|None|DisplayName">
         <source>None</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ItemType|Content|DisplayName">
         <source>Content</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ItemType|EmbeddedResource|DisplayName">
         <source>Embedded resource</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.xlf
@@ -5,67 +5,67 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml" />
       <trans-unit id="Rule|ProjectReference|DisplayName">
         <source>Project Reference</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|ProjectReference|Description">
         <source>Project reference properties</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">
         <source>Reference Output Assembly</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|Description">
         <source>A value indicating whether the compiler should include a reference to the target project's primary output assembly.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|CopyLocalSatelliteAssemblies|DisplayName">
         <source>Copy Local Satellite Assemblies</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|CopyLocalSatelliteAssemblies|Description">
         <source>Indicates whether the satellite assemblies of the reference target should be copied into this project's output directory.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Project|Description">
         <source>the Guid the solution tracks an individual project reference target with</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|ReferencedProjectIdentifier|Description">
         <source>The old (VS2010 beta) way to store the Guid the solution tracks an individual project reference target with</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|CopyLocal|DisplayName">
         <source>Copy Local</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|CopyLocal|Description">
         <source>Indicates whether the reference will be copied to the output directory.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
         <source>IncludeAssets</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
         <source>Assets to include from this reference</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
         <source>ExcludeAssets</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
         <source>Assets to exclude from this reference</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
         <source>PrivateAssets</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
         <source>Assets that are private in this reference</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedAnalyzerReference.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedAnalyzerReference.xaml.xlf
@@ -5,15 +5,15 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAnalyzerReference.xaml" />
       <trans-unit id="Rule|ResolvedAnalyzerReference|DisplayName">
         <source>Resolved Analyzer Reference</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAnalyzerReference|Description">
         <source>Resolved Analyzer reference properties</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|OriginalItemSpec|Description">
         <source>The evaluated item name of the original reference item whose resolution resulted in this resolved reference item.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedAssemblyReference.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedAssemblyReference.xaml.xlf
@@ -5,151 +5,151 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAssemblyReference.xaml" />
       <trans-unit id="Rule|ResolvedAssemblyReference|DisplayName">
         <source>Resolved Assembly Reference</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedAssemblyReference|Description">
         <source>Resolved reference</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">
         <source>Aliases</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">
         <source>A comma-delimited list of aliases to this reference.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|CopyLocal|DisplayName">
         <source>Copy Local</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|CopyLocal|Description">
         <source>Indicates whether the reference will be copied to the output directory.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Culture|DisplayName">
         <source>Culture</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Culture|Description">
         <source>The value of the culture field from the assembly metadata.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Description|DisplayName">
         <source>Description</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Description|Description">
         <source>The value of the Title field from the assembly metadata.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|EmbedInteropTypes|DisplayName">
         <source>Embed Interop Types</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|EmbedInteropTypes|Description">
         <source>Indicates whether types defined in this assembly will be embedded into the target assembly.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FileType|DisplayName">
         <source>File Type</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FileType|Description">
         <source>The file type of the reference.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|FileType.Assembly|DisplayName">
         <source>.NET assembly</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|FileType.ActiveX|DisplayName">
         <source>COM type library</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|FileType.Native Assembly|DisplayName">
         <source>Native Assembly</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Identity|DisplayName">
         <source>Identity</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Identity|Description">
         <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">
         <source>Path</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|Description">
         <source>Location of the file being referenced.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|RuntimeVersion|DisplayName">
         <source>Runtime Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|RuntimeVersion|Description">
         <source>Version of the .NET runtime this assembly was compiled against.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SpecificVersion|DisplayName">
         <source>Specific Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SpecificVersion|Description">
         <source>Indicates whether this assembly can be resolved without regard to multi-targeting rules for assembly resolution.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|StrongName|DisplayName">
         <source>Strong Name</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|StrongName|Description">
         <source>True indicates that the reference has been signed with a key-pair.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|Description">
         <source>Version of reference.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|RequiredTargetFramework|DisplayName">
         <source>Required Target Framework</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|IsWinMDFile|Description">
         <source>Indicates whether the project system ascertained that this is a WinMD (as opposed to an assembly)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|WinMDFile|Description">
         <source>Indicates whether the build system ascertained that this is a WinMD (as opposed to an assembly)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|OriginalItemSpec|Description">
         <source>The evaluated item name of the original reference item whose resolution resulted in this resolved reference item.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|ReferenceFromSDK|Description">
         <source>The SDK that this reference came from when using the expand SDK target.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FusionName|Description">
         <source>The full fusion name of the resolved assembly.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedFrom|Description">
         <source>{}What repository held the reference that was used to resolve this.  ("{GAC}" if it was in the GAC).</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FrameworkFile|Description">
         <source>Is this file a framework file. Ie Found in the target framework directory or in the redist list.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedCOMReference.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedCOMReference.xaml.xlf
@@ -5,143 +5,143 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCOMReference.xaml" />
       <trans-unit id="Rule|ResolvedCOMReference|DisplayName">
         <source>Resolved COM Reference</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedCOMReference|Description">
         <source>Resolved reference</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Guid|DisplayName">
         <source>CLSID</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Guid|Description">
         <source>The GUID of the COM server.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">
         <source>Aliases</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">
         <source>A comma-delimited list of aliases to this reference.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|CopyLocal|DisplayName">
         <source>Copy Local</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|CopyLocal|Description">
         <source>Indicates whether the reference will be copied to the output directory.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Culture|DisplayName">
         <source>Culture</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Culture|Description">
         <source>The value of the culture field from the assembly metadata.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Description|DisplayName">
         <source>Description</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Description|Description">
         <source>The value of the Title field from the assembly metadata.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|EmbedInteropTypes|DisplayName">
         <source>Embed Interop Types</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|EmbedInteropTypes|Description">
         <source>Indicates whether types defined in this assembly will be embedded into the target assembly.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FileType|DisplayName">
         <source>File Type</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FileType|Description">
         <source>The file type of the reference.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|FileType.Assembly|DisplayName">
         <source>.NET assembly</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|FileType.ActiveX|DisplayName">
         <source>COM type library</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|FileType.Native Assembly|DisplayName">
         <source>Native Assembly</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Identity|DisplayName">
         <source>Identity</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Identity|Description">
         <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">
         <source>Path</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|Description">
         <source>Location of the file being referenced.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|RuntimeVersion|DisplayName">
         <source>Runtime Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|RuntimeVersion|Description">
         <source>Version of the .NET runtime this assembly was compiled against.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SpecificVersion|DisplayName">
         <source>Specific Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SpecificVersion|Description">
         <source>Indicates whether this assembly can be resolved without regard to multi-targeting rules for assembly resolution.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|StrongName|DisplayName">
         <source>Strong Name</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|StrongName|Description">
         <source>True indicates that the reference has been signed with a key-pair.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|Description">
         <source>Version of reference.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|RequiredTargetFramework|DisplayName">
         <source>Required Target Framework</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|IsWinMDFile|Description">
         <source>Indicates whether the project system ascertained that this is a WinMD (as opposed to an assembly)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|WinMDFile|Description">
         <source>Indicates whether the build system ascertained that this is a WinMD (as opposed to an assembly)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|OriginalItemSpec|Description">
         <source>The evaluated item name of the original reference item whose resolution resulted in this resolved reference item.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.xlf
@@ -5,39 +5,39 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml" />
       <trans-unit id="Rule|ResolvedPackageReference|DisplayName">
         <source>Package</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedPackageReference|Description">
         <source>Package</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Description|DisplayName">
         <source>Description</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Description|Description">
         <source>Dependency description.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|Description">
         <source>Version of dependency.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|OriginalItemSpec|Description">
         <source>The evaluated item name of the original reference item whose resolution resulted in this resolved reference item.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Dependencies|DisplayName">
         <source>Dependencies</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Dependencies|Description">
         <source>A semicolon-delimited list of direct dependencies of current dependency.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.xlf
@@ -5,139 +5,139 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.xaml" />
       <trans-unit id="Rule|ResolvedProjectReference|DisplayName">
         <source>Resolved Project Reference</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedProjectReference|Description">
         <source>Resolved reference</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">
         <source>Aliases</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|Description">
         <source>A comma-delimited list of aliases to this reference.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|CopyLocal|DisplayName">
         <source>Copy Local</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|CopyLocal|Description">
         <source>Indicates whether the reference will be copied to the output directory.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Culture|DisplayName">
         <source>Culture</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Culture|Description">
         <source>The value of the culture field from the assembly metadata.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Description|DisplayName">
         <source>Description</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Description|Description">
         <source>The value of the Title field from the assembly metadata.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|EmbedInteropTypes|DisplayName">
         <source>Embed Interop Types</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|EmbedInteropTypes|Description">
         <source>Indicates whether types defined in this assembly will be embedded into the target assembly.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FileType|DisplayName">
         <source>File Type</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|FileType|Description">
         <source>The file type of the reference.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|FileType.Assembly|DisplayName">
         <source>.NET assembly</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|FileType.ActiveX|DisplayName">
         <source>COM type library</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|FileType.Native Assembly|DisplayName">
         <source>Native Assembly</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Identity|DisplayName">
         <source>Identity</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Identity|Description">
         <source>Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|DisplayName">
         <source>Path</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|ResolvedPath|Description">
         <source>Location of the file being referenced.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|RuntimeVersion|DisplayName">
         <source>Runtime Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|RuntimeVersion|Description">
         <source>Version of the .NET runtime this assembly was compiled against.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SpecificVersion|DisplayName">
         <source>Specific Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SpecificVersion|Description">
         <source>Indicates whether this assembly can be resolved without regard to multi-targeting rules for assembly resolution.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|StrongName|DisplayName">
         <source>Strong Name</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|StrongName|Description">
         <source>True indicates that the reference has been signed with a key-pair.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Version|Description">
         <source>Version of reference.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|RequiredTargetFramework|DisplayName">
         <source>Required Target Framework</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|IsWinMDFile|Description">
         <source>Indicates whether the project system ascertained that this is a WinMD (as opposed to an assembly)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Project|Description">
         <source>the Guid the solution tracks an individual project reference target with</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|WinMDFile|Description">
         <source>Indicates whether the build system ascertained that this is a WinMD (as opposed to an assembly)</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|OriginalItemSpec|Description">
         <source>The evaluated item name of the original reference item whose resolution resulted in this resolved reference item.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.xlf
@@ -5,39 +5,39 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.xaml" />
       <trans-unit id="Rule|ResolvedSdkReference|DisplayName">
         <source>Resolved SDK Reference</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedSdkReference|Description">
         <source>Resolved SDK reference</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|AppXLocation|DisplayName">
         <source>App Package Location</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FrameworkIdentity|DisplayName">
         <source>FrameworkIdentity</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|DisplayName|DisplayName">
         <source>Display Name</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|CopyPayload|DisplayName">
         <source>Copy Payload</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ExpandContent|DisplayName">
         <source>Expand Content</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ExpandReferenceAssemblies|DisplayName">
         <source>Expand Reference Assemblies</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|CopyLocalExpandedReferenceAssemblies|DisplayName">
         <source>Copy Local Expanded Reference Assemblies</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.xlf
@@ -5,43 +5,43 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml" />
       <trans-unit id="Rule|SdkReference|DisplayName">
         <source>SDK Reference</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|SdkReference|Description">
         <source>SDK reference properties</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|SDKRootFolder|DisplayName">
         <source>SDK Root</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|AppXLocation|DisplayName">
         <source>App Package Location</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FrameworkIdentity|DisplayName">
         <source>FrameworkIdentity</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|CopyPayload|DisplayName">
         <source>Copy Payload</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|CopyPayloadToSubDirectory|DisplayName">
         <source>Copy Payload to Subdirectory</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ExpandContent|DisplayName">
         <source>Expand Content</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ExpandReferenceAssemblies|DisplayName">
         <source>Expand Reference Assemblies</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|CopyLocalExpandedReferenceAssemblies|DisplayName">
         <source>Copy Local Expanded Reference Assemblies</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.xlf
@@ -5,11 +5,11 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SourceControl.xaml" />
       <trans-unit id="Rule|SourceControl|DisplayName">
         <source>Source control</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|SourceControl|Description">
         <source>General</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SpecialFolder.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SpecialFolder.xaml.xlf
@@ -5,19 +5,19 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SpecialFolder.xaml" />
       <trans-unit id="Rule|SpecialFolder|DisplayName">
         <source>General</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|SpecialFolder|Description">
         <source>Special folders</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
         <source>Full Path</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileNameAndExtension|DisplayName">
         <source>Folder Name</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SubProject.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SubProject.xaml.xlf
@@ -5,11 +5,11 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SubProject.xaml" />
       <trans-unit id="Rule|SubProject|DisplayName">
         <source>General</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|SubProject|Description">
         <source>Projects that must be built as part of the containing project, but without an actual build dependency</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.xlf
@@ -5,67 +5,67 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/VisualBasic.BrowseObject.xaml" />
       <trans-unit id="Rule|VisualBasic|DisplayName">
         <source>File Properties</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|VisualBasic|Description">
         <source>File Properties</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Category|Advanced|DisplayName">
         <source>Advanced</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Category|Misc|DisplayName">
         <source>Misc</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|{}{ItemType}|DisplayName">
         <source>Build Action</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|{}{ItemType}|Description">
         <source>How the file relates to the build and deployment processes.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|CopyToOutputDirectory|DisplayName">
         <source>Copy to Output Directory</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|CopyToOutputDirectory|Description">
         <source>Specifies the source file will be copied to the output directory.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Always|DisplayName">
         <source>Copy always</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.PreserveNewest|DisplayName">
         <source>Copy if newer</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Identity|Description">
         <source>The item specified in the Include attribute.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
         <source>Full Path</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|Description">
         <source>Location of the file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileNameAndExtension|DisplayName">
         <source>File Name</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileNameAndExtension|Description">
         <source>Name of the file or folder.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.ProjectItemsSchema.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.ProjectItemsSchema.xaml.xlf
@@ -5,11 +5,11 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/VisualBasic.ProjectItemsSchema.xaml" />
       <trans-unit id="ContentType|VisualBasicFile|DisplayName">
         <source>VB file</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ItemType|Compile|DisplayName">
         <source>VB compiler</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.xlf
@@ -5,79 +5,79 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/VisualBasic.xaml" />
       <trans-unit id="Rule|VisualBasic|DisplayName">
         <source>File Properties</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Rule|VisualBasic|Description">
         <source>File Properties</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Category|Advanced|DisplayName">
         <source>Advanced</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="Category|Misc|DisplayName">
         <source>Misc</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|{}{ItemType}|DisplayName">
         <source>Build Action</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|{}{ItemType}|Description">
         <source>How the file relates to the build and deployment processes.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|CopyToOutputDirectory|DisplayName">
         <source>Copy to Output Directory</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumProperty|CopyToOutputDirectory|Description">
         <source>Specifies the source file will be copied to the output directory.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Always|DisplayName">
         <source>Copy always</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.PreserveNewest|DisplayName">
         <source>Copy if newer</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|Identity|Description">
         <source>The item specified in the Include attribute.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
         <source>Full Path</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|Description">
         <source>Location of the file.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileNameAndExtension|DisplayName">
         <source>File Name</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileNameAndExtension|Description">
         <source>Name of the file or folder.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="StringProperty|LastGenOutput|Description">
         <source>The filename of the last file generated as a result of the SFG.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DesignTime|Description">
         <source>A value indicating whether this file has a designer.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="BoolProperty|AutoGen|Description">
         <source>A value indicating whether this is a generated file.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.xlf
@@ -5,27 +5,27 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx" />
       <trans-unit id="JsonErrorReadingLaunchSettings">
         <source>Error reading the launch settings file. This error will need to be corrected in order to debug this project. '{0}' </source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ErrorReadingLaunchSettings">
         <source>The following error occurred when reading the launch settings file '{0}'. {1} </source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ErrorWritingDebugSettings">
         <source>The following error occurred when writing to the launch settings file '{0}'. {1} </source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="ProfileMissingName">
         <source>At least one launch profile is missing the required name attribute. These profiles will be ignored</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="NoActionProfileName">
         <source>Start</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="JsonErrorNeedToBeCorrected">
         <source>Errors in '{0}' need to be corrected before applying changes.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/xlf/VSPackage.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/xlf/VSPackage.xlf
@@ -5,11 +5,11 @@
       <group id="src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/VSPackage.resx" />
       <trans-unit id="#1">
         <source>Visual Basic</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="#2">
         <source>Visual Basic Project Files (*.vbproj);*.vbproj</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
Mostly, just a run of https://github.com/nguerrera/xliff-converter, but:

* I caught an issue with the placeholder count in one string decreasing. This is not a safe change since translations are not instant. We'd have a point in time where String.Format would throw. I just trimmed off the .{1}'s from translation, but left the tooling flagging of "needing review". 

* Another (minor) annoyance is that our tooling emits <note></note> and the loc team's changes it to <note />. I've separated out a commit to make the review easier.

So the three commits are:

1. Convert <note> to <note />
2. Update xlf with script
3. Fix up EditProjectFile placeholder count

