### PR TITLE
Simplify type name across the tree

### DIFF
--- a/src/Common/ManagedCodeMarkers.vb
+++ b/src/Common/ManagedCodeMarkers.vb
@@ -20,45 +20,45 @@ Namespace Microsoft.Internal.Performance
             '///// Code markers test function imports
 #If Codemarkers_IncludeAppEnum Then
             <DllImport(TestDllName, EntryPoint:="InitPerf")> _
-            Public Shared Sub TestDllInitPerf(iApp As System.Int32)
+            Public Shared Sub TestDllInitPerf(iApp As Integer)
             End Sub
 
             <DllImport(TestDllName, EntryPoint:="UnInitPerf")> _
-            Public Shared Sub TestDllUnInitPerf(iApp As System.Int32)
+            Public Shared Sub TestDllUnInitPerf(iApp As Integer)
             End Sub
 #End If 'Codemarkers_IncludeAppEnum           
 
             <DllImport(s_testDllName, EntryPoint:="PerfCodeMarker")>
-            Public Shared Sub TestDllPerfCodeMarker(nTimerID As System.Int32, uiLow As System.UInt32, uiHigh As System.UInt32)
+            Public Shared Sub TestDllPerfCodeMarker(nTimerID As Integer, uiLow As UInteger, uiHigh As UInteger)
             End Sub
 
             '///// Code markers product function imports
 #If Codemarkers_IncludeAppEnum Then
             <DllImport(ProductDllName, EntryPoint:="InitPerf")> _
-            Public Shared Sub ProductDllInitPerf(iApp As System.Int32)
+            Public Shared Sub ProductDllInitPerf(iApp As Integer)
             End Sub
 
             <DllImport(ProductDllName, EntryPoint:="UnInitPerf")> _
-            Public Shared Sub ProductDllUnInitPerf(iApp As System.Int32)
+            Public Shared Sub ProductDllUnInitPerf(iApp As Integer)
             End Sub
 #End If 'Codemarkers_IncludeAppEnum           
 
             <DllImport(s_productDllName, EntryPoint:="PerfCodeMarker")>
-            Public Shared Sub ProductDllPerfCodeMarker(nTimerID As System.Int32, uiLow As System.UInt32, uiHigh As System.UInt32)
+            Public Shared Sub ProductDllPerfCodeMarker(nTimerID As Integer, uiLow As UInteger, uiHigh As UInteger)
             End Sub
 
             '///// global native method imports
             <DllImport("kernel32.dll", CharSet:=CharSet.Unicode)>
-            Public Shared Function FindAtom(lpString As String) As System.UInt16
+            Public Shared Function FindAtom(lpString As String) As UShort
             End Function
 
 #If Codemarkers_IncludeAppEnum Then
             <DllImport("kernel32.dll", CharSet:=CharSet.Unicode)> _
-            Public Shared Function AddAtom(lpString As String) As UInt16
+            Public Shared Function AddAtom(lpString As String) As UShort
             End Function
 
             <DllImport("kernel32.dll")> _
-            Public Shared Function DeleteAtom(atom As UInt16) As UInt16
+            Public Shared Function DeleteAtom(atom As UShort) As UShort
             End Function
 #End If 'Codemarkers_IncludeAppEnum                     
 
@@ -201,7 +201,7 @@ Namespace Microsoft.Internal.Performance
 
             fUseCodeMarkers = False
 
-            Dim atom As UInt16 = NativeMethods.FindAtom(AtomName)
+            Dim atom As UShort = NativeMethods.FindAtom(AtomName)
             If atom <> 0 Then
                 NativeMethods.DeleteAtom(atom)
             End If

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
@@ -59,16 +59,16 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="CmdUIGuid">Returns guid for CMDUI</param>
         ''' <param name="pgrfCDW">[out] Flags to be passed to CreateDocumentWindow</param>
         ''' <remarks></remarks>
-        Private Function InternalCreateEditorInstance(VsCreateEditorFlags As System.UInt32, _
-                FileName As String, _
-                PhysicalView As String, _
-                Hierarchy As IVsHierarchy, _
-                ItemId As System.UInt32, _
-                ExistingDocData As Object, _
-                ByRef DocView As Object, _
-                ByRef DocData As Object, _
-                ByRef Caption As String, _
-                ByRef CmdUIGuid As System.Guid, _
+        Private Function InternalCreateEditorInstance(VsCreateEditorFlags As UInteger,
+                FileName As String,
+                PhysicalView As String,
+                Hierarchy As IVsHierarchy,
+                ItemId As UInteger,
+                ExistingDocData As Object,
+                ByRef DocView As Object,
+                ByRef DocData As Object,
+                ByRef Caption As String,
+                ByRef CmdUIGuid As System.Guid,
                 ByRef pgrfCDW As Integer) As Integer
             pgrfCDW = 0
             CmdUIGuid = System.Guid.Empty

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerLoader.vb
@@ -184,7 +184,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 End If
 
                 If Common.Switches.PDDesignerActivations.TraceVerbose Then
-                    s.AppendLine(New System.Diagnostics.StackTrace().ToString())
+                    s.AppendLine(New StackTrace().ToString())
                     'If e.NewDesigner Is Me.GetService(GetType(IDesignerHost)) Then
                     '    Dim rootComponent As ApplicationDesignerRootComponent = TryCast(e.NewDesigner.RootComponent, ApplicationDesignerRootComponent)
                     '    e.NewDesigner.Activate()

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerRootComponent.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerRootComponent.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
 
         'Private cache for important data
         Private _hierarchy As IVsHierarchy
-        Private _itemId As UInt32
+        Private _itemId As UInteger
         Private _rootDesigner As ApplicationDesignerRootDesigner
 
         ''' <summary>
@@ -59,11 +59,11 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' </summary>
         ''' <value></value>
         ''' <remarks></remarks>
-        Public Property ItemId() As System.UInt32
+        Public Property ItemId() As UInteger
             Get
                 Return _itemId
             End Get
-            Set(Value As System.UInt32)
+            Set(Value As UInteger)
                 _itemId = Value
             End Set
         End Property

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/CmdTargetHelper.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/CmdTargetHelper.vb
@@ -71,14 +71,14 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
 
             If _windowPane Is Nothing Then
                 Debug.Fail("CmdTargetHelper.IOleCommandTarget_Exec(): m_WindowPane shouldn't be Nothing")
-                Return AppDesInterop.NativeMethods.OLECMDERR_E_NOTSUPPORTED 'Not much we can do
+                Return NativeMethods.OLECMDERR_E_NOTSUPPORTED 'Not much we can do
             End If
 
             'Grab certain commands and handle ourselves
-            If pguidCmdGroup.Equals(Microsoft.VisualStudio.Editors.Constants.MenuConstants.guidVSStd97) Then
+            If pguidCmdGroup.Equals(Constants.MenuConstants.guidVSStd97) Then
                 Common.Switches.TracePDCmdTarget(TraceLevel.Info, "CmdTargetHelper.IOleCommandTarget.Exec: Guid=guidVSStd97, nCmdID=" & nCmdID)
                 Select Case nCmdID
-                    Case Microsoft.VisualStudio.Editors.Constants.MenuConstants.cmdidSaveProjectItem
+                    Case Constants.MenuConstants.cmdidSaveProjectItem
                         Common.Switches.TracePDCmdTarget(TraceLevel.Warning, "  Handling: cmdidSaveProjectItem")
                         'Execute a Save for the App Designer (saves all DocData pages)
                         Return HrSaveProjectDesigner()
@@ -97,14 +97,14 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                         End If
 
                         'Now let the shell do its normal processing of this command
-                        Return AppDesInterop.NativeMethods.OLECMDERR_E_NOTSUPPORTED
+                        Return NativeMethods.OLECMDERR_E_NOTSUPPORTED
 
-                    Case Microsoft.VisualStudio.Editors.Constants.MenuConstants.cmdidSaveProjectItemAs
+                    Case Constants.MenuConstants.cmdidSaveProjectItemAs
                         Debug.Fail("Shouldn't get able to get here - we were supposed to have disabled the menu for save as...")
                         Return NativeMethods.S_OK
 
 
-                    Case Microsoft.VisualStudio.Editors.Constants.MenuConstants.cmdidFileClose, s_cmdidCloseDocument
+                    Case Constants.MenuConstants.cmdidFileClose, s_cmdidCloseDocument
                         'cmdidFileClose = File.CLose
                         'cmdidCloseDocument = CTRL+F4 or right-click Close on the MDI tab
 
@@ -128,7 +128,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                         _windowPane.ClosePromptSave()
 
                         'Now let the shell do its normal processing of this command
-                        Return AppDesInterop.NativeMethods.OLECMDERR_E_NOTSUPPORTED
+                        Return NativeMethods.OLECMDERR_E_NOTSUPPORTED
 
                     Case s_cmdidPaneNextTab 'Window.NextTab (CTRL+PGDN by default) - move to the next tab in the project designer
                         Common.Switches.TracePDCmdTarget(TraceLevel.Warning, "  Handling: cmdidPaneNextTab")
@@ -155,7 +155,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 Common.Switches.TracePDCmdTarget(TraceLevel.Info, "CmdTargetHelper.IOleCommandTarget.Exec: Guid=" & pguidCmdGroup.ToString & ", nCmdID=" & nCmdID)
             End If
 
-            Return AppDesInterop.NativeMethods.OLECMDERR_E_NOTSUPPORTED
+            Return NativeMethods.OLECMDERR_E_NOTSUPPORTED
         End Function
 
         ''' <summary>
@@ -202,20 +202,20 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
 
             Debug.Assert(cCmds = 1, "Unsupported: Multiple commands in QueryStatus") 'I don't think VS is ever supposed to give us more than one at a time
 
-            If pguidCmdGroup.Equals(Microsoft.VisualStudio.Editors.Constants.MenuConstants.guidVSStd97) Then
+            If pguidCmdGroup.Equals(Constants.MenuConstants.guidVSStd97) Then
                 Common.Switches.TracePDCmdTarget(TraceLevel.Verbose, "CmdTargetHelper.IOleCommandTarget.QueryStatus: Guid=guidVSStd97, nCmdID=" & prgCmds(0).cmdID)
                 Select Case prgCmds(0).cmdID
-                    Case Microsoft.VisualStudio.Editors.Constants.MenuConstants.cmdidSaveProjectItem
+                    Case Constants.MenuConstants.cmdidSaveProjectItem
                         Common.Switches.TracePDCmdTarget(TraceLevel.Info, "  Query: cmdidSaveProjectItem")
                         prgCmds(0).cmdf = Supported Or Enabled
                         Return NativeMethods.S_OK
 
-                    Case Microsoft.VisualStudio.Editors.Constants.MenuConstants.cmdidSaveProjectItemAs
+                    Case Constants.MenuConstants.cmdidSaveProjectItemAs
                         Common.Switches.TracePDCmdTarget(TraceLevel.Info, "  Query: cmdidSaveProjectItemAs")
                         prgCmds(0).cmdf = Supported Or Invisible 'CONSIDER: Invisible doesn't seem to work, but it does at least get disabled
                         Return NativeMethods.S_OK
 
-                    Case Microsoft.VisualStudio.Editors.Constants.MenuConstants.cmdidFileClose, s_cmdidCloseDocument
+                    Case Constants.MenuConstants.cmdidFileClose, s_cmdidCloseDocument
                         Common.Switches.TracePDCmdTarget(TraceLevel.Info, "  Query: cmdidFileClose, cmdidCloseDocument")
                         prgCmds(0).cmdf = Supported Or Enabled
                         Return NativeMethods.S_OK
@@ -239,7 +239,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 Common.Switches.TracePDCmdTarget(TraceLevel.Verbose, "CmdTargetHelper.IOleCommandTarget.QueryStatus: Guid=" & pguidCmdGroup.ToString & ", nCmdID=" & prgCmds(0).cmdID)
             End If
 
-            Return AppDesInterop.NativeMethods.OLECMDERR_E_NOTSUPPORTED
+            Return NativeMethods.OLECMDERR_E_NOTSUPPORTED
         End Function
 
 

--- a/src/Microsoft.VisualStudio.AppDesigner/Common/ShellUtil.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/ShellUtil.vb
@@ -42,7 +42,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <remarks></remarks>
         Public Shared Function GetColor(VsUIShell2 As IVsUIShell2, VsSysColorIndex As __VSSYSCOLOREX, DefaultColor As Color) As Color
             If VsUIShell2 IsNot Nothing Then
-                Dim abgrValue As System.UInt32
+                Dim abgrValue As UInteger
                 Dim Hr As Integer = VsUIShell2.GetVSSysColorEx(VsSysColorIndex, abgrValue)
                 If VSErrorHandler.Succeeded(Hr) Then
                     Return COLORREFToColor(abgrValue)
@@ -56,11 +56,11 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         Public Shared Function GetDesignerThemeColor(uiShellService As IVsUIShell5, themeCategory As Guid, themeColorName As String, colorType As __THEMEDCOLORTYPE, defaultColor As Color) As Color
 
             If uiShellService IsNot Nothing Then
-                Dim rgbaValue As UInt32
+                Dim rgbaValue As UInteger
 
-                Dim hr As Int32 = VSErrorHandler.CallWithCOMConvention(
+                Dim hr As Integer = VSErrorHandler.CallWithCOMConvention(
                     Sub()
-                        rgbaValue = uiShellService.GetThemedColor(themeCategory, themeColorName, CType(colorType, System.UInt32))
+                        rgbaValue = uiShellService.GetThemedColor(themeCategory, themeColorName, CType(colorType, UInteger))
                     End Sub)
 
                 If VSErrorHandler.Succeeded(hr) Then
@@ -68,11 +68,11 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
                 End If
             End If
 
-            Debug.Fail("Unable to get color from the shell, using a predetermined default color instead." & VB.vbCrLf & "Color Category = " & themeCategory.ToString() & ", Color Name = " & themeColorName & ", Color Type = " & colorType & ", Default Color = &h" & VB.Hex(DefaultColor.ToArgb))
+            Debug.Fail("Unable to get color from the shell, using a predetermined default color instead." & VB.vbCrLf & "Color Category = " & themeCategory.ToString() & ", Color Name = " & themeColorName & ", Color Type = " & colorType & ", Default Color = &h" & VB.Hex(defaultColor.ToArgb))
             Return defaultColor
         End Function
 
-        Private Shared Function RGBAToColor(rgbaValue As UInt32) As Color
+        Private Shared Function RGBAToColor(rgbaValue As UInteger) As Color
             Return Color.FromArgb(CInt((rgbaValue And &HFF000000UI) >> 24), CInt(rgbaValue And &HFFUI), CInt((rgbaValue And &HFF00UI) >> 8), CInt((rgbaValue And &HFF0000UI) >> 16))
         End Function
 
@@ -82,7 +82,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <param name="abgrValue">The UInteger COLORREF value</param>
         ''' <returns>The System.Drawing.Color equivalent.</returns>
         ''' <remarks></remarks>
-        Private Shared Function COLORREFToColor(abgrValue As System.UInt32) As Color
+        Private Shared Function COLORREFToColor(abgrValue As UInteger) As Color
             Return Color.FromArgb(CInt(abgrValue And &HFFUI), CInt((abgrValue And &HFF00UI) >> 8), CInt((abgrValue And &HFF0000UI) >> 16))
         End Function
 
@@ -312,7 +312,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <param name="hierarchy"></param>
         ''' <returns>true if it is a venus project</returns>
         ''' <remarks></remarks>
-        Public Shared Function IsVenusProject(hierarchy As IVsHierarchy) As [Boolean]
+        Public Shared Function IsVenusProject(hierarchy As IVsHierarchy) As Boolean
 
             If hierarchy Is Nothing Then
                 Return False
@@ -341,7 +341,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <param name="hierarchy"></param>
         ''' <returns></returns>
         ''' <remarks></remarks>
-        Public Shared Function IsSilverLightProject(hierarchy As IVsHierarchy) As [Boolean]
+        Public Shared Function IsSilverLightProject(hierarchy As IVsHierarchy) As Boolean
             Const SilverLightProjectGuid As String = "{A1591282-1198-4647-A2B1-27E5FF5F6F3B}"
 
             If hierarchy Is Nothing Then
@@ -394,7 +394,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <param name="hierarchy"></param>
         ''' <returns></returns>
         ''' <remarks></remarks>
-        Public Shared Function IsWebProject(hierarchy As IVsHierarchy) As [Boolean]
+        Public Shared Function IsWebProject(hierarchy As IVsHierarchy) As Boolean
             Const WebAppProjectGuid As String = "{349c5851-65df-11da-9384-00065b846f21}"
 
             If hierarchy Is Nothing Then

--- a/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
@@ -78,14 +78,14 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <returns></returns>
         ''' <remarks></remarks>
         Public Function NoOverflowCUInt(LongValue As Long) As UInteger
-            Return CUInt(LongValue And UInt32.MaxValue)
+            Return CUInt(LongValue And UInteger.MaxValue)
         End Function
 
         Public Function NoOverflowCInt(LongValue As Long) As Integer
-            If LongValue <= UInt32.MaxValue Then
+            If LongValue <= UInteger.MaxValue Then
                 Return CInt(LongValue)
             End If
-            Return CInt(LongValue And UInt32.MaxValue)
+            Return CInt(LongValue And UInteger.MaxValue)
         End Function
 
         ''' <summary>
@@ -352,7 +352,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
             Dim pvParam As IntPtr = Marshal.AllocCoTaskMem(4)
             Try
                 If AppDesInterop.NativeMethods.SystemParametersInfo(AppDesInterop.win.SPI_GETSCREENREADER, 0, pvParam, 0) <> 0 Then
-                    Dim result As Int32 = Marshal.ReadInt32(pvParam)
+                    Dim result As Integer = Marshal.ReadInt32(pvParam)
                     Return result <> 0
                 End If
             Finally

--- a/src/Microsoft.VisualStudio.AppDesigner/Common/switches.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/switches.vb
@@ -394,7 +394,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
 
             'Get the HWND's text
             Dim WindowText As New String(" "c, 30)
-            Dim CharsCopied As Integer = AppDesInterop.NativeMethods.GetWindowText(msg.HWnd, WindowText, WindowText.Length)
+            Dim CharsCopied As Integer = NativeMethods.GetWindowText(msg.HWnd, WindowText, WindowText.Length)
             If CharsCopied > 0 Then
                 WindowText = WindowText.Substring(0, CharsCopied)
                 str.Append(" """ & WindowText & """")
@@ -629,7 +629,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
                 Trace.WriteLine("  AffectedComponent=" & DebugToString(e.AffectedComponent))
                 Trace.WriteLine("  AffectedProperty=" & DebugToString(e.AffectedProperty))
                 If PDPerf.TraceVerbose Then
-                    Trace.WriteLine(New System.Diagnostics.StackTrace().ToString)
+                    Trace.WriteLine(New StackTrace().ToString)
                 End If
             End If
         End Sub

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerDocData.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerDocData.vb
@@ -76,7 +76,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                     localRegistry = DirectCast(_baseProvider.GetService(GetType(ILocalRegistry)), ILocalRegistry)
                 End If
                 If localRegistry Is Nothing Then
-                    Throw New COMException(SR.GetString(SR.DFX_NoLocalRegistry), AppDesInterop.NativeMethods.E_FAIL)
+                    Throw New COMException(SR.GetString(SR.DFX_NoLocalRegistry), NativeMethods.E_FAIL)
                 End If
 
                 'CONSIDER: Need to check with FX team about removing assert in MS.VS.Shell.Design.DesignerWindowPane.RegisterView
@@ -101,7 +101,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                         End If
                     End If
                 Catch ex As Exception
-                    Throw New COMException(SR.GetString(SR.DFX_UnableCreateTextBuffer), AppDesInterop.NativeMethods.E_FAIL)
+                    Throw New COMException(SR.GetString(SR.DFX_UnableCreateTextBuffer), NativeMethods.E_FAIL)
                 End Try
                 Return _vsTextBuffer
             End Get
@@ -315,7 +315,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             Dim hr As Integer
             hr = Marshal.QueryInterface(punk, riid, ppvSite)
             Marshal.Release(punk)
-            If AppDesInterop.NativeMethods.Failed(hr) Then
+            If NativeMethods.Failed(hr) Then
                 Marshal.ThrowExceptionForHR(hr)
             End If
         End Sub

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerEditorFactory.vb
@@ -59,11 +59,11 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <param name="CmdUIGuid">Returns guid for CMDUI</param>
         ''' <param name="Canceled">Returns True if user canceled</param>
         ''' <remarks></remarks>
-        Private Sub InternalCreateEditorInstance(VsCreateEditorFlags As System.UInt32, _
+        Private Sub InternalCreateEditorInstance(VsCreateEditorFlags As UInteger, _
                 FileName As String, _
                 PhysicalView As String, _
                 Hierarchy As IVsHierarchy, _
-                ItemId As System.UInt32, _
+                ItemId As UInteger, _
                 ExistingDocData As Object, _
                 ByRef DocView As Object, _
                 ByRef DocData As Object, _

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerRootComponent.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerRootComponent.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
 
         'Private cache for important data
         Private _hierarchy As IVsHierarchy
-        Private _itemId As UInt32
+        Private _itemId As UInteger
         Private _rootDesigner As PropPageDesignerRootDesigner
         Private _name As String = "PropPageDesignerRootComponent"
 
@@ -68,11 +68,11 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' </summary>
         ''' <value></value>
         ''' <remarks></remarks>
-        Public Property ItemId() As System.UInt32
+        Public Property ItemId() As UInteger
             Get
                 Return _itemId
             End Get
-            Set(Value As System.UInt32)
+            Set(Value As UInteger)
                 _itemId = Value
             End Set
         End Property

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
@@ -416,7 +416,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             SetDialogFont()
 
             Dim menuCommands As New Collections.ArrayList()
-            Dim cutCmd As New AppDesDesignerFramework.DesignerMenuCommand(_rootDesigner, Microsoft.VisualStudio.Editors.Constants.MenuConstants.CommandIDVSStd97cmdidCut, AddressOf DisabledMenuCommandHandler)
+            Dim cutCmd As New AppDesDesignerFramework.DesignerMenuCommand(_rootDesigner, Constants.MenuConstants.CommandIDVSStd97cmdidCut, AddressOf DisabledMenuCommandHandler)
             cutCmd.Enabled = False
             menuCommands.Add(cutCmd)
 
@@ -1623,7 +1623,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 Return IntPtr.Zero
             End If
 
-            Return AppDesInterop.NativeMethods.GetWindow(PropertyPagePanel.Handle, AppDesInterop.win.GW_CHILD)
+            Return NativeMethods.GetWindow(PropertyPagePanel.Handle, AppDesInterop.win.GW_CHILD)
         End Function
 
 

--- a/src/Microsoft.VisualStudio.AppDesigner/interop/NativeMethods.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/interop/NativeMethods.vb
@@ -278,7 +278,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesInterop
 
         <PreserveSig()> Public Declare Auto Function _
             GetKeyState _
-                Lib "user32" (nVirtKey As Keys) As Int16
+                Lib "user32" (nVirtKey As Keys) As Short
 
         ''' <summary>
         ''' The GetNextDlgTabItem function retrieves a handle to the first control that has the WS_TABSTOP style that precedes (or follows) the specified control. 

--- a/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AutoAddImportsExtensionCollisionDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AutoAddImportsExtensionCollisionDialog.vb
@@ -36,7 +36,7 @@ Namespace Microsoft.VisualStudio.Editors.AddImports
             _lastFocus = CType(sender, Control)
         End Sub
 
-        Private Sub LabelGotFocus(sender As Object, e As System.EventArgs) Handles txtMain_.GotFocus
+        Private Sub LabelGotFocus(sender As Object, e As EventArgs) Handles txtMain_.GotFocus
             _lastFocus.Focus()
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/Common/ShellUtil.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/ShellUtil.vb
@@ -42,7 +42,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <remarks></remarks>
         Public Shared Function GetColor(VsUIShell2 As IVsUIShell2, VsSysColorIndex As __VSSYSCOLOREX, DefaultColor As Color) As Color
             If VsUIShell2 IsNot Nothing Then
-                Dim abgrValue As System.UInt32
+                Dim abgrValue As UInteger
                 Dim Hr As Integer = VsUIShell2.GetVSSysColorEx(VsSysColorIndex, abgrValue)
                 If VSErrorHandler.Succeeded(Hr) Then
                     Return COLORREFToColor(abgrValue)
@@ -60,7 +60,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="abgrValue">The UInteger COLORREF value</param>
         ''' <returns>The System.Drawing.Color equivalent.</returns>
         ''' <remarks></remarks>
-        Private Shared Function COLORREFToColor(abgrValue As System.UInt32) As Color
+        Private Shared Function COLORREFToColor(abgrValue As UInteger) As Color
             Return Color.FromArgb(CInt(abgrValue And &HFFUI), CInt((abgrValue And &HFF00UI) >> 8), CInt((abgrValue And &HFF0000UI) >> 16))
         End Function
 
@@ -826,7 +826,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
             Dim VsUIShell2 As IVsUIShell2 = DirectCast(Microsoft.VisualStudio.Shell.Package.GetGlobalService(GetType(SVsUIShell)), IVsUIShell2)
 
             If VsUIShell2 IsNot Nothing Then
-                Dim abgrValue As System.UInt32
+                Dim abgrValue As UInteger
                 Dim Hr As Integer = VsUIShell2.GetVSSysColorEx(VsSysColorIndex, abgrValue)
                 If VSErrorHandler.Succeeded(Hr) Then
                     Return ColorTranslator.FromWin32(CType(abgrValue, Integer))

--- a/src/Microsoft.VisualStudio.Editors/Common/ShellUtil.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/ShellUtil.vb
@@ -659,7 +659,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
             Inherits BroadcastMessageEventsHelper
 
             ' Control that we are going to set the font on (if any)
-            Private _control As System.Windows.Forms.Control
+            Private _control As Control
 
             Private _serviceProvider As IServiceProvider
 
@@ -670,7 +670,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
             ''' <param name="ctrl"></param>
             ''' <param name="SetFontInitially">If true, set the font of the provided control when this FontChangeMonitor is created</param>
             ''' <remarks></remarks>
-            Public Sub New(sp As IServiceProvider, ctrl As System.Windows.Forms.Control, SetFontInitially As Boolean)
+            Public Sub New(sp As IServiceProvider, ctrl As Control, SetFontInitially As Boolean)
                 MyBase.new(sp)
 
                 Debug.Assert(sp IsNot Nothing, "Why did we get a NULL service provider!?")

--- a/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
@@ -101,12 +101,12 @@ Namespace Microsoft.VisualStudio.Editors.Common
             End If
 
             Dim objType As Type = obj.GetType()
-            If objType Is GetType(UInt16) OrElse
-                objType Is GetType(Int16) OrElse
-                objType Is GetType(UInt32) OrElse
-                objType Is GetType(Int32) OrElse
-                objType Is GetType(UInt64) OrElse
-                objType Is GetType(Int64) OrElse
+            If objType Is GetType(UShort) OrElse
+                objType Is GetType(Short) OrElse
+                objType Is GetType(UInteger) OrElse
+                objType Is GetType(Integer) OrElse
+                objType Is GetType(ULong) OrElse
+                objType Is GetType(Long) OrElse
                 objType Is GetType(Byte) OrElse
                 objType Is GetType(SByte) OrElse
                 objType Is GetType(Single) OrElse
@@ -139,14 +139,14 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <returns></returns>
         ''' <remarks></remarks>
         Public Function NoOverflowCUInt(LongValue As Long) As UInteger
-            Return CUInt(LongValue And UInt32.MaxValue)
+            Return CUInt(LongValue And UInteger.MaxValue)
         End Function
 
         Public Function NoOverflowCInt(LongValue As Long) As Integer
-            If LongValue <= UInt32.MaxValue Then
+            If LongValue <= UInteger.MaxValue Then
                 Return CInt(LongValue)
             End If
-            Return CInt(LongValue And UInt32.MaxValue)
+            Return CInt(LongValue And UInteger.MaxValue)
         End Function
 
         ''' <summary>
@@ -1016,7 +1016,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
             Dim pvParam As IntPtr = Marshal.AllocCoTaskMem(4)
             Try
                 If Interop.NativeMethods.SystemParametersInfo(Interop.win.SPI_GETSCREENREADER, 0, pvParam, 0) <> 0 Then
-                    Dim result As Int32 = Marshal.ReadInt32(pvParam)
+                    Dim result As Integer = Marshal.ReadInt32(pvParam)
                     Return result <> 0
                 End If
             Finally

--- a/src/Microsoft.VisualStudio.Editors/Common/switches.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/switches.vb
@@ -455,7 +455,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
             ''' <remarks></remarks>
             Public ReadOnly Property ValueDefined() As Boolean
                 Get
-                    Return MyBase.Value <> "" AndAlso CInt(System.Convert.ChangeType(Me.Value, TypeCode.Int32)) <> 0
+                    Return MyBase.Value <> "" AndAlso CInt(Convert.ChangeType(Me.Value, TypeCode.Int32)) <> 0
                 End Get
             End Property
 
@@ -480,7 +480,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
             ''' </summary>
             ''' <remarks></remarks>
             Protected Overrides Sub OnValueChanged()
-                SwitchSetting = CInt(System.Convert.ChangeType(Value, TypeCode.Int32))
+                SwitchSetting = CInt(Convert.ChangeType(Value, TypeCode.Int32))
             End Sub
 
         End Class
@@ -628,7 +628,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                 Trace.WriteLine("  AffectedComponent=" & DebugToString(e.AffectedComponent))
                 Trace.WriteLine("  AffectedProperty=" & DebugToString(e.AffectedProperty))
                 If PDPerf.TraceVerbose Then
-                    Trace.WriteLine(New System.Diagnostics.StackTrace().ToString)
+                    Trace.WriteLine(New StackTrace().ToString)
                 End If
             End If
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
@@ -595,7 +595,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '     Reloading is deferred until the document is later activated, and reload is contingent 
         '     upon IsReloadNeeded returning true.
         '**************************************************************************
-        Private Sub DocData_DataChanged(sender As Object, e As System.EventArgs) Handles m_DocData.DataChanged
+        Private Sub DocData_DataChanged(sender As Object, e As EventArgs) Handles m_DocData.DataChanged
             'The DocData has been changed externally (either outside of VS or from another editor).
             '  We notify ourselves that we need to reload.  The reload doesn't actually happen until we
             '  have focus again and then hit idle time processing.

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
@@ -292,7 +292,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             End Get
         End Property
 
-        Friend ReadOnly Property ProjectItemid() As System.UInt32
+        Friend ReadOnly Property ProjectItemid() As UInteger
             Get
                 Return _projectItemid
             End Get
@@ -372,7 +372,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
 
         Private Function GetDocDataState(BitFlagToTest As TextManager.Interop.BUFFERSTATEFLAGS) As Boolean
             If m_DocData IsNot Nothing AndAlso m_DocData.Buffer IsNot Nothing Then
-                Dim State As System.UInt32
+                Dim State As UInteger
                 VSErrorHandler.ThrowOnFailure(m_DocData.Buffer.GetStateFlags(State))
                 Return (State And BitFlagToTest) <> 0
             End If

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseEditorFactory.vb
@@ -309,11 +309,11 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="CmdUIGuid"></param>
         ''' <param name="Canceled"></param>
         ''' <remarks></remarks>
-        Protected Overridable Sub CreateEditorInstance(VsCreateEditorFlags As System.UInt32, _
+        Protected Overridable Sub CreateEditorInstance(VsCreateEditorFlags As UInteger, _
                 FileName As String, _
                 PhysicalView As String, _
                 Hierarchy As IVsHierarchy, _
-                ItemId As System.UInt32, _
+                ItemId As UInteger, _
                 ExistingDocData As Object, _
                 ByRef DocView As Object, _
                 ByRef DocData As Object, _
@@ -331,7 +331,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
 
                     ' perform parameter validation and initialization.
                     '
-                    If (VsCreateEditorFlags And CType(__VSCREATEEDITORFLAGS.CEF_OPENFILE Or __VSCREATEEDITORFLAGS.CEF_SILENT, System.UInt32)) = 0 Then
+                    If (VsCreateEditorFlags And CType(__VSCREATEEDITORFLAGS.CEF_OPENFILE Or __VSCREATEEDITORFLAGS.CEF_SILENT, UInteger)) = 0 Then
                         Throw Common.CreateArgumentException("vscreateeditorflags")
                     End If
 

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerToolbarPanel.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerToolbarPanel.vb
@@ -86,7 +86,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Protected Overrides Sub OnHandleCreated(e As System.EventArgs)
+        Protected Overrides Sub OnHandleCreated(e As EventArgs)
             MyBase.OnHandleCreated(e)
             If _associateToolbarOnHandleCreate Then
                 InternalAssociateToolbarWithHandle()
@@ -99,7 +99,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Protected Overrides Sub OnHandleDestroyed(e As System.EventArgs)
+        Protected Overrides Sub OnHandleDestroyed(e As EventArgs)
             MyBase.OnHandleDestroyed(e)
             If _toolbarHost IsNot Nothing Then
                 ' We had a toolbar host (which should be associated with the old handle)
@@ -131,7 +131,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Protected Overrides Sub OnSizeChanged(e As System.EventArgs)
+        Protected Overrides Sub OnSizeChanged(e As EventArgs)
             MyBase.OnSizeChanged(e)
             If _toolbarHost IsNot Nothing Then
                 _toolbarHost.BorderChanged()

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/ErrorControl.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/ErrorControl.vb
@@ -90,7 +90,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub ErrorText_GotFocus(sender As Object, e As System.EventArgs) Handles ErrorText.GotFocus
+        Private Sub ErrorText_GotFocus(sender As Object, e As EventArgs) Handles ErrorText.GotFocus
             If _firstGotFocus Then
                 'The first time a textbox gets focus, WinForms selects all text in it.  That
                 '  doesn't really make sense in this case, so set it back to no selection.

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/WrapCheckBox.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/WrapCheckBox.vb
@@ -22,12 +22,12 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             Me.AutoSize = True
         End Sub
 
-        Protected Overrides Sub OnTextChanged(e As System.EventArgs)
+        Protected Overrides Sub OnTextChanged(e As EventArgs)
             MyBase.OnTextChanged(e)
             CacheTextSize()
         End Sub
 
-        Protected Overrides Sub OnFontChanged(e As System.EventArgs)
+        Protected Overrides Sub OnFontChanged(e As EventArgs)
             MyBase.OnFontChanged(e)
             CacheTextSize()
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AdvBuildSettingsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AdvBuildSettingsPropPage.vb
@@ -224,7 +224,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     Dim LongValue As ULong
                     Try
                         LongValue = CULng(StringValue)
-                        If LongValue < UInt32.MaxValue Then
+                        If LongValue < UInteger.MaxValue Then
                             value = CUInt(LongValue)
                             Return True
                         End If

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AdvBuildSettingsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AdvBuildSettingsPropPage.vb
@@ -271,7 +271,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return True
         End Function
 
-        Private Sub DebugInfo_SelectedIndexChanged(sender As System.Object, e As System.EventArgs) Handles cboDebugInfo.SelectedIndexChanged
+        Private Sub DebugInfo_SelectedIndexChanged(sender As System.Object, e As EventArgs) Handles cboDebugInfo.SelectedIndexChanged
             If Me.cboDebugInfo.SelectedIndex = 0 Then
                 '// user selcted none
                 m_bDebugSymbols = False

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AdvCompilerSettingsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AdvCompilerSettingsPropPage.vb
@@ -225,7 +225,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Validation method for BaseAddress
         ''' no cancellation, just normalizes value if not an error condition
         ''' </summary>
-        Private Sub BaseAddress_Validating(sender As Object, e As System.ComponentModel.CancelEventArgs) Handles DllBaseTextbox.Validating
+        Private Sub BaseAddress_Validating(sender As Object, e As CancelEventArgs) Handles DllBaseTextbox.Validating
             Dim StringValue As String = Trim(Me.DllBaseTextbox.Text)
 
             Const DEFAULT_DLLBASEADDRESS As String = "&H11000000"
@@ -255,7 +255,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Validation properties
         ''' </summary>
-        Protected Overrides Function ValidateProperty(controlData As PropertyControlData, ByRef message As String, ByRef returnControl As System.Windows.Forms.Control) As ValidationResult
+        Protected Overrides Function ValidateProperty(controlData As PropertyControlData, ByRef message As String, ByRef returnControl As Control) As ValidationResult
             If controlData.FormControl Is DllBaseTextbox Then
                 Try
                     GetBaseAddressFromControl(DllBaseTextbox)

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AdvCompilerSettingsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AdvCompilerSettingsPropPage.vb
@@ -95,7 +95,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Format baseaddress value into VB hex notation
         ''' </summary>
         Private Function ToHexAddress(BaseAddress As UInt64) As String
-            Debug.Assert(BaseAddress >= 0 AndAlso BaseAddress <= UInt32.MaxValue, "Invalid baseaddress value")
+            Debug.Assert(BaseAddress >= 0 AndAlso BaseAddress <= UInteger.MaxValue, "Invalid baseaddress value")
 
             Return "&H" & String.Format("{0:X8}", CUInt(BaseAddress))
         End Function
@@ -130,7 +130,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             If String.Compare(VBStrings.Left(StringValue, 2), "&H", StringComparison.OrdinalIgnoreCase) = 0 AndAlso IsNumeric(StringValue) Then
                 Try
                     LongValue = CULng(StringValue)
-                    If LongValue < UInt32.MaxValue Then
+                    If LongValue < UInteger.MaxValue Then
                         Return CUInt(LongValue)
                     End If
                 Catch ex As Exception
@@ -235,7 +235,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
             ElseIf String.Compare(VBStrings.Left(StringValue, 2), "&H", StringComparison.OrdinalIgnoreCase) = 0 AndAlso IsNumeric(StringValue) Then
                 Dim LongValue As ULong = CULng(StringValue)
-                If LongValue < UInt32.MaxValue Then
+                If LongValue < UInteger.MaxValue Then
                     'Reformat into clean
                     DllBaseTextbox.Text = ToHexAddress(LongValue)
                 Else

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AdvancedServicesDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AdvancedServicesDialog.vb
@@ -137,7 +137,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             SetDirtyFlag()
         End Sub
 
-        Private Sub UseCustomConnectionStringCheckBox_CheckStateChanged(sender As Object, e As System.EventArgs) Handles UseCustomConnectionStringCheckBox.CheckStateChanged
+        Private Sub UseCustomConnectionStringCheckBox_CheckStateChanged(sender As Object, e As EventArgs) Handles UseCustomConnectionStringCheckBox.CheckStateChanged
             UpdateCustomConnectionStringControlBasedOnCheckState()
         End Sub
 
@@ -167,18 +167,18 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             SetDirtyFlag()
         End Sub
 
-        Private Sub CustomConnectionString_TextChanged(sender As Object, e As System.EventArgs) Handles CustomConnectionString.TextChanged
+        Private Sub CustomConnectionString_TextChanged(sender As Object, e As EventArgs) Handles CustomConnectionString.TextChanged
             If CustomConnectionString.Enabled Then
                 ServicesPropPageAppConfigHelper.SetConnectionStringText(_appConfigDocument, CustomConnectionString.Text, ProjectHierarchy)
                 SetDirtyFlag()
             End If
         End Sub
 
-        Private Sub TimeUnitComboBox_SelectedIndexChanged(sender As Object, e As System.EventArgs) Handles TimeUnitComboBox.SelectedIndexChanged
+        Private Sub TimeUnitComboBox_SelectedIndexChanged(sender As Object, e As EventArgs) Handles TimeUnitComboBox.SelectedIndexChanged
             SetCacheTimeout()
         End Sub
 
-        Private Sub TimeQuantity_ValueChanged(sender As Object, e As System.EventArgs) Handles TimeQuantity.ValueChanged
+        Private Sub TimeQuantity_ValueChanged(sender As Object, e As EventArgs) Handles TimeQuantity.ValueChanged
             SetCacheTimeout()
         End Sub
 
@@ -204,12 +204,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             SetDirtyFlag()
         End Sub
 
-        Private Sub SavePasswordHashLocallyCheckbox_CheckedChanged(sender As Object, e As System.EventArgs) Handles SavePasswordHashLocallyCheckbox.CheckedChanged
+        Private Sub SavePasswordHashLocallyCheckbox_CheckedChanged(sender As Object, e As EventArgs) Handles SavePasswordHashLocallyCheckbox.CheckedChanged
             ServicesPropPageAppConfigHelper.SetSavePasswordHashLocally(_appConfigDocument, SavePasswordHashLocallyCheckbox.Checked, ProjectHierarchy)
             SetDirtyFlag()
         End Sub
 
-        Private Sub HonorServerCookieExpirySavePasswordHashLocallyCheckbox_CheckedChanged(sender As Object, e As System.EventArgs) Handles HonorServerCookieExpirationCheckbox.CheckedChanged
+        Private Sub HonorServerCookieExpirySavePasswordHashLocallyCheckbox_CheckedChanged(sender As Object, e As EventArgs) Handles HonorServerCookieExpirationCheckbox.CheckedChanged
             ServicesPropPageAppConfigHelper.SetHonorCookieExpiry(_appConfigDocument, HonorServerCookieExpirationCheckbox.Checked, ProjectHierarchy)
             SetDirtyFlag()
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
@@ -61,7 +61,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             MyBase.Dispose(disposing)
         End Sub
 
-        Private Sub AssemblyInfoButton_Click(sender As Object, e As System.EventArgs) Handles AssemblyInfoButton.Click
+        Private Sub AssemblyInfoButton_Click(sender As Object, e As EventArgs) Handles AssemblyInfoButton.Click
             ShowChildPage(SR.GetString(SR.PPG_AssemblyInfo_Title), GetType(AssemblyInfoPropPage), HelpKeywords.VBProjPropAssemblyInfo)
         End Sub
 
@@ -515,7 +515,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub IconResourceFile_CheckedChanged(sender As Object, e As System.EventArgs) Handles IconRadioButton.CheckedChanged, Win32ResourceRadioButton.CheckedChanged
+        Private Sub IconResourceFile_CheckedChanged(sender As Object, e As EventArgs) Handles IconRadioButton.CheckedChanged, Win32ResourceRadioButton.CheckedChanged
             If (Me.IconRadioButton.Checked = True) Then
                 EnableControl(Me.ApplicationIconLabel, ApplicationIconSupported())
                 EnableControl(Me.ApplicationIcon, ApplicationIconSupported())
@@ -744,7 +744,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub OutputType_SelectionChangeCommitted(sender As Object, e As System.EventArgs) Handles OutputType.SelectionChangeCommitted
+        Private Sub OutputType_SelectionChangeCommitted(sender As Object, e As EventArgs) Handles OutputType.SelectionChangeCommitted
             If m_fInsideInit Then
                 Return
             End If
@@ -782,7 +782,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub Win32ResourceFileBrowse_Click(sender As Object, e As System.EventArgs) Handles Win32ResourceFileBrowse.Click
+        Private Sub Win32ResourceFileBrowse_Click(sender As Object, e As EventArgs) Handles Win32ResourceFileBrowse.Click
 
             SkipValidating(Win32ResourceFile)   ' skip this because we will pop up dialog to edit it...
             ProcessDelayValidationQueue(False)
@@ -818,12 +818,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Sub
 
         'Update the list of available items whenever the start-up object combobox is opened.
-        Private Sub StartupObject_DropDown(sender As Object, e As System.EventArgs) Handles StartupObject.DropDown
+        Private Sub StartupObject_DropDown(sender As Object, e As EventArgs) Handles StartupObject.DropDown
             PopulateStartupObject(StartUpObjectSupported(), PopulateDropdown:=True)
             Common.SetComboBoxDropdownWidth(StartupObject)
         End Sub
 
-        Private Sub StartupObject_SelectionChangeCommitted(sender As Object, e As System.EventArgs) Handles StartupObject.SelectionChangeCommitted
+        Private Sub StartupObject_SelectionChangeCommitted(sender As Object, e As EventArgs) Handles StartupObject.SelectionChangeCommitted
             If m_fInsideInit Then
                 Return
             End If
@@ -864,7 +864,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Sub
 
 
-        Private Sub ApplicationIcon_DropDown(sender As Object, e As System.EventArgs) Handles ApplicationIcon.DropDown
+        Private Sub ApplicationIcon_DropDown(sender As Object, e As EventArgs) Handles ApplicationIcon.DropDown
             If GetPropertyControlData(Const_ApplicationIcon).IsDirty() Then
                 UpdateIconImage(True)
                 SetDirty(VsProjPropId.VBPROJPROPID_ApplicationIcon, True)
@@ -881,7 +881,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub ApplicationIcon_LostFocus(sender As Object, e As System.EventArgs) Handles ApplicationIcon.LostFocus
+        Private Sub ApplicationIcon_LostFocus(sender As Object, e As EventArgs) Handles ApplicationIcon.LostFocus
             If m_fInsideInit Then
                 Return
             End If
@@ -892,7 +892,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
-        Private Sub ApplicationIcon_SelectionChangeCommitted(sender As Object, e As System.EventArgs) Handles ApplicationIcon.SelectionChangeCommitted
+        Private Sub ApplicationIcon_SelectionChangeCommitted(sender As Object, e As EventArgs) Handles ApplicationIcon.SelectionChangeCommitted
             If m_fInsideInit Then
                 Return
             End If
@@ -901,7 +901,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             SetDirty(VsProjPropId.VBPROJPROPID_ApplicationIcon, True)
         End Sub
 
-        Private Sub ApplicationIcon_TextChanged(sender As Object, e As System.EventArgs) Handles ApplicationIcon.TextChanged
+        Private Sub ApplicationIcon_TextChanged(sender As Object, e As EventArgs) Handles ApplicationIcon.TextChanged
             If m_fInsideInit Then
                 Return
             End If
@@ -916,7 +916,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub AppIconBrowse_Click(sender As Object, e As System.EventArgs) Handles AppIconBrowse.Click
+        Private Sub AppIconBrowse_Click(sender As Object, e As EventArgs) Handles AppIconBrowse.Click
             BrowseForAppIcon(ApplicationIcon, AppIconImage)
         End Sub
 
@@ -934,7 +934,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             PopulateManifestList(FindManifestInProject, ApplicationManifest, CType(GetControlValueNative(Const_ApplicationManifest), String))
         End Sub
 
-        Private Sub ApplicationManifest_DropDown(sender As Object, e As System.EventArgs) Handles ApplicationManifest.DropDown
+        Private Sub ApplicationManifest_DropDown(sender As Object, e As EventArgs) Handles ApplicationManifest.DropDown
             If GetPropertyControlData(Const_ApplicationManifest).IsDirty() Then
                 SetDirty(VsProjPropId90.VBPROJPROPID_ApplicationManifest, True)
             End If
@@ -950,7 +950,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '@ <param name="sender"></param>
         '@ <param name="e"></param>
         '@ <remarks></remarks>
-        Private Sub ApplicationManifest_LostFocus(sender As Object, e As System.EventArgs) Handles ApplicationManifest.LostFocus
+        Private Sub ApplicationManifest_LostFocus(sender As Object, e As EventArgs) Handles ApplicationManifest.LostFocus
             If m_fInsideInit Then
                 Return
             End If
@@ -960,7 +960,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
-        Private Sub ApplicationManifest_SelectionChangeCommitted(sender As Object, e As System.EventArgs) Handles ApplicationManifest.SelectionChangeCommitted
+        Private Sub ApplicationManifest_SelectionChangeCommitted(sender As Object, e As EventArgs) Handles ApplicationManifest.SelectionChangeCommitted
             If m_fInsideInit Then
                 Return
             End If
@@ -968,7 +968,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             SetDirty(VsProjPropId90.VBPROJPROPID_ApplicationManifest, True)
         End Sub
 
-        Private Sub ApplicationManifest_TextChanged(sender As Object, e As System.EventArgs) Handles ApplicationManifest.TextChanged
+        Private Sub ApplicationManifest_TextChanged(sender As Object, e As EventArgs) Handles ApplicationManifest.TextChanged
             If m_fInsideInit Then
                 Return
             End If

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
@@ -1402,7 +1402,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
-        Private Sub AssemblyInfoButton_Click(sender As Object, e As System.EventArgs) Handles AssemblyInfoButton.Click
+        Private Sub AssemblyInfoButton_Click(sender As Object, e As EventArgs) Handles AssemblyInfoButton.Click
             ShowChildPage(SR.GetString(SR.PPG_AssemblyInfo_Title), GetType(AssemblyInfoPropPage), HelpKeywords.VBProjPropAssemblyInfo)
         End Sub
 
@@ -1449,7 +1449,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Next
         End Sub
 
-        Private Sub ApplicationTypeComboBox_SelectionChangeCommitted(sender As Object, e As System.EventArgs) Handles ApplicationTypeComboBox.SelectionChangeCommitted
+        Private Sub ApplicationTypeComboBox_SelectionChangeCommitted(sender As Object, e As EventArgs) Handles ApplicationTypeComboBox.SelectionChangeCommitted
             If m_fInsideInit Then
                 Return
             End If
@@ -1518,7 +1518,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         End Sub
 
-        Private Sub StartupObjectComboBox_SelectionChangeCommitted(sender As Object, e As System.EventArgs) Handles StartupObjectComboBox.SelectionChangeCommitted
+        Private Sub StartupObjectComboBox_SelectionChangeCommitted(sender As Object, e As EventArgs) Handles StartupObjectComboBox.SelectionChangeCommitted
             If m_fInsideInit Then
                 Return
             End If
@@ -1532,7 +1532,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub ViewCodeButton_Click(sender As Object, e As System.EventArgs) Handles ViewCodeButton.Click
+        Private Sub ViewCodeButton_Click(sender As Object, e As EventArgs) Handles ViewCodeButton.Click
             Static IsInViewCodeButtonClick As Boolean
             If IsInViewCodeButtonClick Then
                 'Avoid recursive call (possible because of DoEvents work-around in CreateNewMyEventsFile
@@ -1565,7 +1565,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub SplashScreenComboBox_DropDown(sender As Object, e As System.EventArgs) Handles SplashScreenComboBox.DropDown
+        Private Sub SplashScreenComboBox_DropDown(sender As Object, e As EventArgs) Handles SplashScreenComboBox.DropDown
             PopulateSplashScreenList(True)
             Common.SetComboBoxDropdownWidth(DirectCast(sender, ComboBox))
         End Sub
@@ -1578,7 +1578,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub StartupObjectComboBox_DropDown(sender As Object, e As System.EventArgs) Handles StartupObjectComboBox.DropDown
+        Private Sub StartupObjectComboBox_DropDown(sender As Object, e As EventArgs) Handles StartupObjectComboBox.DropDown
             PopulateStartupObject(StartUpObjectSupported(), True)
             Common.SetComboBoxDropdownWidth(DirectCast(sender, ComboBox))
         End Sub
@@ -1610,21 +1610,21 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
 #Region "Application icon"
 
-        Private Sub IconCombobox_DropDown(sender As Object, e As System.EventArgs) Handles IconCombobox.DropDown
+        Private Sub IconCombobox_DropDown(sender As Object, e As EventArgs) Handles IconCombobox.DropDown
             MyBase.HandleIconComboboxDropDown(sender)
         End Sub
 
-        Private Sub IconCombobox_DropDownClosed(sender As Object, e As System.EventArgs) Handles IconCombobox.DropDownClosed
+        Private Sub IconCombobox_DropDownClosed(sender As Object, e As EventArgs) Handles IconCombobox.DropDownClosed
             MyBase.HandleIconComboboxDropDown(sender)
         End Sub
 
-        Private Sub IconCombobox_SelectionChangeCommitted(sender As Object, e As System.EventArgs) Handles IconCombobox.SelectionChangeCommitted
+        Private Sub IconCombobox_SelectionChangeCommitted(sender As Object, e As EventArgs) Handles IconCombobox.SelectionChangeCommitted
             MyBase.HandleIconComboboxSelectionChangeCommitted(sender)
         End Sub
 
 #End Region
 
-        Private Sub UseApplicationFrameworkCheckBox_CheckedChanged(sender As Object, e As System.EventArgs) Handles UseApplicationFrameworkCheckBox.CheckedChanged
+        Private Sub UseApplicationFrameworkCheckBox_CheckedChanged(sender As Object, e As EventArgs) Handles UseApplicationFrameworkCheckBox.CheckedChanged
             If m_fInsideInit Then
                 Return
             End If
@@ -1726,7 +1726,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub ViewUACSettingsButton_Click(sender As Object, e As System.EventArgs) Handles ViewUACSettingsButton.Click
+        Private Sub ViewUACSettingsButton_Click(sender As Object, e As EventArgs) Handles ViewUACSettingsButton.Click
             ViewUACSettings()
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.vb
@@ -96,7 +96,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Property get for file or assembly version.
         ''' </summary>
-        Private Function VersionGet(control As System.Windows.Forms.Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
+        Private Function VersionGet(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
             Dim Version As String = Nothing
 
             If (control Is Me.FileVersionLayoutPanel) Then
@@ -114,7 +114,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Property set for either file or assembly version.
         ''' </summary>
-        Private Function VersionSet(control As System.Windows.Forms.Control, prop As PropertyDescriptor, value As Object) As Boolean
+        Private Function VersionSet(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
             Dim Major As String = Nothing, Minor As String = Nothing, Build As String = Nothing, Revision As String = Nothing
             Dim Version As String
             Dim Values As String()
@@ -167,7 +167,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Occurs when the neutral language combobox is dropped down.  Use this to
         '''   populate it with entries.
         ''' </summary>
-        Private Sub NeutralLanguageComboBox_DropDown(sender As Object, e As System.EventArgs) Handles NeutralLanguageComboBox.DropDown
+        Private Sub NeutralLanguageComboBox_DropDown(sender As Object, e As EventArgs) Handles NeutralLanguageComboBox.DropDown
             PopulateNeutralLanguageComboBox(NeutralLanguageComboBox)
             Common.SetComboBoxDropdownWidth(NeutralLanguageComboBox)
         End Sub
@@ -177,18 +177,18 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return HelpKeywords.VBProjPropAssemblyInfo
         End Function
 
-        Private Sub AssemblyVersionLayoutPanel_TextChanged(sender As Object, e As System.EventArgs) Handles AssemblyVersionMajorTextBox.TextChanged, AssemblyVersionMinorTextBox.TextChanged, AssemblyVersionBuildTextBox.TextChanged, AssemblyVersionRevisionTextBox.TextChanged
+        Private Sub AssemblyVersionLayoutPanel_TextChanged(sender As Object, e As EventArgs) Handles AssemblyVersionMajorTextBox.TextChanged, AssemblyVersionMinorTextBox.TextChanged, AssemblyVersionBuildTextBox.TextChanged, AssemblyVersionRevisionTextBox.TextChanged
             SetDirty(Me.AssemblyVersionLayoutPanel, False)
         End Sub
 
-        Private Sub FileVersionLayoutPanel_TextChanged(sender As Object, e As System.EventArgs) Handles FileVersionMajorTextBox.TextChanged, FileVersionMinorTextBox.TextChanged, FileVersionBuildTextBox.TextChanged, FileVersionRevisionTextBox.TextChanged
+        Private Sub FileVersionLayoutPanel_TextChanged(sender As Object, e As EventArgs) Handles FileVersionMajorTextBox.TextChanged, FileVersionMinorTextBox.TextChanged, FileVersionBuildTextBox.TextChanged, FileVersionRevisionTextBox.TextChanged
             SetDirty(Me.FileVersionLayoutPanel, False)
         End Sub
 
         ''' <summary>
         ''' Validation properties
         ''' </summary>
-        Protected Overrides Function ValidateProperty(controlData As PropertyControlData, ByRef message As String, ByRef returnControl As System.Windows.Forms.Control) As ValidationResult
+        Protected Overrides Function ValidateProperty(controlData As PropertyControlData, ByRef message As String, ByRef returnControl As Control) As ValidationResult
             If controlData.FormControl Is GuidTextBox Then
                 Try
                     Dim guid As New Guid(Trim(GuidTextBox.Text))

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventCommandLineDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventCommandLineDialog.vb
@@ -108,14 +108,14 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End Set
         End Property
 
-        Private Sub OKButton_Click(sender As System.Object, e As System.EventArgs) Handles OKButton.Click
+        Private Sub OKButton_Click(sender As System.Object, e As EventArgs) Handles OKButton.Click
             '// Store the command line
             m_CommandLine = Me.CommandLine.Text
 
             Me.Close()
         End Sub
 
-        Private Sub CancelButton_Click(sender As System.Object, e As System.EventArgs) Handles Cancel_Button.Click
+        Private Sub CancelButton_Click(sender As System.Object, e As EventArgs) Handles Cancel_Button.Click
             Me.Close()
         End Sub
 
@@ -139,15 +139,15 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return True
         End Function
 
-        Private Sub HideMacrosButton_Click(sender As System.Object, e As System.EventArgs) Handles HideMacrosButton.Click
+        Private Sub HideMacrosButton_Click(sender As System.Object, e As EventArgs) Handles HideMacrosButton.Click
             ShowCollapsedForm()
         End Sub
 
-        Private Sub ShowMacrosButton_Click(sender As Object, e As System.EventArgs) Handles ShowMacrosButton.Click
+        Private Sub ShowMacrosButton_Click(sender As Object, e As EventArgs) Handles ShowMacrosButton.Click
             ShowExpandedForm()
         End Sub
 
-        Private Sub BuildEventCommandLineDialog_Load(sender As System.Object, e As System.EventArgs) Handles MyBase.Load
+        Private Sub BuildEventCommandLineDialog_Load(sender As System.Object, e As EventArgs) Handles MyBase.Load
             InitializeControlLocations()
 
             '// Never let them resize to something smaller than the default form size
@@ -185,17 +185,17 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return True
         End Function
 
-        Private Sub InsertButton_Click(sender As System.Object, e As System.EventArgs) Handles InsertButton.Click
+        Private Sub InsertButton_Click(sender As System.Object, e As EventArgs) Handles InsertButton.Click
             AddCurrentMacroToCommandLine()
         End Sub
 
-        Private Sub TokenList_SelectedIndexChanged(sender As System.Object, e As System.EventArgs) Handles TokenList.SelectedIndexChanged
+        Private Sub TokenList_SelectedIndexChanged(sender As System.Object, e As EventArgs) Handles TokenList.SelectedIndexChanged
             SetInsertButtonEnableState()
         End Sub
 
 
 
-        Private Sub TokenList_DoubleClick(sender As Object, e As System.EventArgs) Handles TokenList.DoubleClick
+        Private Sub TokenList_DoubleClick(sender As Object, e As EventArgs) Handles TokenList.DoubleClick
             AddCurrentMacroToCommandLine()
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.vb
@@ -88,7 +88,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Function
 
-        Private Sub PostBuildBuilderButton_Click(sender As Object, e As System.EventArgs) Handles btnPostBuildBuilder.Click
+        Private Sub PostBuildBuilderButton_Click(sender As Object, e As EventArgs) Handles btnPostBuildBuilder.Click
             Dim CommandLineText As String
             CommandLineText = Me.txtPostBuildEventCommandLine.Text
 
@@ -100,7 +100,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
-        Private Sub PreBuildBuilderButton_Click(sender As Object, e As System.EventArgs) Handles btnPreBuildBuilder.Click
+        Private Sub PreBuildBuilderButton_Click(sender As Object, e As EventArgs) Handles btnPreBuildBuilder.Click
             Dim CommandLineText As String
             CommandLineText = Me.txtPreBuildEventCommandLine.Text
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
@@ -161,7 +161,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         End Sub
 
-        Private Sub AdvancedButton_Click(sender As Object, e As System.EventArgs) Handles btnAdvanced.Click
+        Private Sub AdvancedButton_Click(sender As Object, e As EventArgs) Handles btnAdvanced.Click
             ShowChildPage(SR.GetString(SR.PPG_AdvancedBuildSettings_Title), GetType(AdvBuildSettingsPropPage), HelpKeywords.CSProjPropAdvancedCompile)
         End Sub
 
@@ -248,7 +248,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Function
 
-        Private Sub OutputPathBrowse_Click(sender As Object, e As System.EventArgs) Handles btnOutputPathBrowse.Click
+        Private Sub OutputPathBrowse_Click(sender As Object, e As EventArgs) Handles btnOutputPathBrowse.Click
             Dim DirName As String = Nothing
             If GetDirectoryViaBrowseRelativeToProject(Me.txtOutputPath.Text, SR.GetString(SR.PPG_SelectOutputPathTitle), DirName) Then
                 txtOutputPath.Text = DirName
@@ -385,7 +385,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return bRetVal
         End Function
 
-        Private Sub rbStartAction_CheckedChanged(sender As Object, e As System.EventArgs) Handles rbWarningAll.CheckedChanged, rbWarningSpecific.CheckedChanged, rbWarningNone.CheckedChanged
+        Private Sub rbStartAction_CheckedChanged(sender As Object, e As EventArgs) Handles rbWarningAll.CheckedChanged, rbWarningSpecific.CheckedChanged, rbWarningNone.CheckedChanged
             If (Not m_bInsideInternalUpdate) Then
                 Dim warnings As TreatWarningsSetting = TreatSpecificWarningsGetValue()
                 Me.rbWarningAll.Checked = (warnings = TreatWarningsSetting.WARNINGS_ALL)
@@ -526,7 +526,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return True
         End Function
 
-        Private Sub XMLDocumentationEnable_CheckStateChanged(sender As Object, e As System.EventArgs) Handles chkXMLDocumentationFile.CheckStateChanged
+        Private Sub XMLDocumentationEnable_CheckStateChanged(sender As Object, e As EventArgs) Handles chkXMLDocumentationFile.CheckStateChanged
             Const XML_FILE_EXTENSION As String = ".xml"
 
             If Me.chkXMLDocumentationFile.Checked Then
@@ -642,7 +642,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Fired when the conditional compilations contants textbox has changed.  We are manually handling
         '''   events associated with this control, so we need to recalculate related values
         ''' </summary>
-        Private Sub DocumentationFile_TextChanged(sender As Object, e As System.EventArgs) Handles txtXMLDocumentationFile.TextChanged
+        Private Sub DocumentationFile_TextChanged(sender As Object, e As EventArgs) Handles txtXMLDocumentationFile.TextChanged
             If Not m_bInsideInternalUpdate Then
                 Debug.Assert(m_stDocumentationFile IsNot Nothing)
                 For i As Integer = 0 To m_stDocumentationFile.Length - 1
@@ -655,7 +655,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
-        Private Sub PlatformTarget_SelectionChangeCommitted(sender As Object, e As System.EventArgs) Handles cboPlatformTarget.SelectionChangeCommitted
+        Private Sub PlatformTarget_SelectionChangeCommitted(sender As Object, e As EventArgs) Handles cboPlatformTarget.SelectionChangeCommitted
             If m_fInsideInit OrElse m_bInsideInternalUpdate Then
                 Return
             End If
@@ -693,7 +693,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Fired when the conditional compilations contants textbox has changed.  We are manually handling
         '''   events associated with this control, so we need to recalculate related values
         ''' </summary>
-        Private Sub DefineConstants_TextChanged(sender As Object, e As System.EventArgs) Handles txtConditionalCompilationSymbols.TextChanged
+        Private Sub DefineConstants_TextChanged(sender As Object, e As EventArgs) Handles txtConditionalCompilationSymbols.TextChanged
             If Not m_bInsideInternalUpdate Then
                 Debug.Assert(m_stCondCompSymbols IsNot Nothing)
                 For i As Integer = 0 To m_stCondCompSymbols.Length - 1
@@ -729,7 +729,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Fired when the "Define DEBUG Constant" check has changed.  We are manually handling
         '''   events associated with this control, so we need to recalculate related values.
         ''' </summary>
-        Private Sub chkDefineDebug_CheckedChanged(sender As Object, e As System.EventArgs) Handles chkDefineDebug.CheckedChanged
+        Private Sub chkDefineDebug_CheckedChanged(sender As Object, e As EventArgs) Handles chkDefineDebug.CheckedChanged
             If Not m_bInsideInternalUpdate Then
                 Dim DebugIndexDoNotChange As Integer 'Index to avoid changing, if in simplified configs mode
                 If IsSimplifiedConfigs() Then
@@ -765,7 +765,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Fired when the "Define DEBUG Constant" check has changed.  We are manually handling
         '''   events associated with this control, so we need to recalculate related values.
         ''' </summary>
-        Private Sub chkDefineTrace_CheckedChanged(sender As Object, e As System.EventArgs) Handles chkDefineTrace.CheckedChanged
+        Private Sub chkDefineTrace_CheckedChanged(sender As Object, e As EventArgs) Handles chkDefineTrace.CheckedChanged
             If Not m_bInsideInternalUpdate Then
                 For i As Integer = 0 To m_stCondCompSymbols.Length - 1
                     Select Case chkDefineTrace.CheckState

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CompilePropPage2.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CompilePropPage2.vb
@@ -733,7 +733,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
 #End Region
 
-        Private Sub DisableAllWarningsCheckBox_Checked(sender As Object, e As System.EventArgs) Handles DisableAllWarningsCheckBox.CheckStateChanged
+        Private Sub DisableAllWarningsCheckBox_Checked(sender As Object, e As EventArgs) Handles DisableAllWarningsCheckBox.CheckStateChanged
             If Not m_fInsideInit AndAlso Not DisableAllWarningsCheckBox.CheckState = CheckState.Indeterminate Then
                 UpdateWarningList()
                 EnableDisableWarningControls(Me.Enabled)
@@ -772,7 +772,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End With
         End Sub
 
-        Private Sub WarningsAsErrorCheckBox_Checked(sender As Object, e As System.EventArgs) Handles WarningsAsErrorCheckBox.CheckStateChanged
+        Private Sub WarningsAsErrorCheckBox_Checked(sender As Object, e As EventArgs) Handles WarningsAsErrorCheckBox.CheckStateChanged
             If Not m_fInsideInit AndAlso Not WarningsAsErrorCheckBox.CheckState = CheckState.Indeterminate Then
                 UpdateWarningList()
                 EnableDisableWarningControls(Me.Enabled)
@@ -784,7 +784,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Make sure we set the Register for COM interop property whenever the
         ''' user checkes the corresponding checkbox on the property page
         ''' </summary>
-        Private Sub RegisterForComInteropCheckBox_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles RegisterForComInteropCheckBox.CheckedChanged
+        Private Sub RegisterForComInteropCheckBox_CheckedChanged(sender As System.Object, e As EventArgs) Handles RegisterForComInteropCheckBox.CheckedChanged
             If Not m_fInsideInit Then
                 If RegisterForComInteropCheckBox.Checked Then
                     ' Whenever the user checks the register for Com interop, we should also set the COM visible property
@@ -1073,15 +1073,15 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Function
 #End Region
 
-        Private Sub AdvancedOptionsButton_Click(sender As Object, e As System.EventArgs) Handles AdvancedOptionsButton.Click
+        Private Sub AdvancedOptionsButton_Click(sender As Object, e As EventArgs) Handles AdvancedOptionsButton.Click
             ShowChildPage(SR.GetString(SR.PPG_AdvancedCompilerSettings_Title), GetType(AdvCompilerSettingsPropPage), HelpKeywords.VBProjPropAdvancedCompile)
         End Sub
 
-        Private Sub BuildEventsButton_Click(sender As Object, e As System.EventArgs) Handles BuildEventsButton.Click
+        Private Sub BuildEventsButton_Click(sender As Object, e As EventArgs) Handles BuildEventsButton.Click
             ShowChildPage(SR.GetString(SR.PPG_BuildEventsTitle), GetType(BuildEventsPropPage))
         End Sub
 
-        Private Sub BuildOutputPathButton_Click(sender As Object, e As System.EventArgs) Handles BuildOutputPathButton.Click
+        Private Sub BuildOutputPathButton_Click(sender As Object, e As EventArgs) Handles BuildOutputPathButton.Click
             Dim value As String = Nothing
             If GetDirectoryViaBrowseRelativeToProject(Me.BuildOutputPathTextBox.Text, SR.GetString(SR.PPG_SelectOutputPathTitle), value) Then
                 Me.BuildOutputPathTextBox.Text = value
@@ -1089,7 +1089,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
-        Private Sub GenerateXMLCheckBox_CheckStateChanged(sender As Object, e As System.EventArgs) Handles GenerateXMLCheckBox.CheckStateChanged
+        Private Sub GenerateXMLCheckBox_CheckStateChanged(sender As Object, e As EventArgs) Handles GenerateXMLCheckBox.CheckStateChanged
             If Not m_fInsideInit AndAlso Not _settingGenerateXmlDocumentation Then
                 Me.SetDirty(VsProjPropId.VBPROJPROPID_DocumentationFile, True)
             End If
@@ -1268,13 +1268,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Whenever the user changes the option strict combobox in the UI, we have to
         ''' update the corresponding project properties
         ''' </summary>
-        Private Sub OptionStrictComboBox_SelectionChangeCommitted(sender As Object, e As System.EventArgs) Handles OptionStrictComboBox.SelectionChangeCommitted
+        Private Sub OptionStrictComboBox_SelectionChangeCommitted(sender As Object, e As EventArgs) Handles OptionStrictComboBox.SelectionChangeCommitted
             If Not m_fInsideInit Then
                 ResetOptionStrictness(TryCast(OptionStrictComboBox.SelectedItem, String))
             End If
         End Sub
 
-        Private Sub TargetCPUComboBox_SelectionChangeCommitted(sender As Object, e As System.EventArgs) Handles TargetCPUComboBox.SelectionChangeCommitted
+        Private Sub TargetCPUComboBox_SelectionChangeCommitted(sender As Object, e As EventArgs) Handles TargetCPUComboBox.SelectionChangeCommitted
             If m_fInsideInit Then
                 Return
             End If
@@ -1545,7 +1545,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Private _configurationObjectCache As ConfigurationObjectCache
 
             ' Create a new instance
-            Public Sub New(ConfigurationObjectCache As ConfigurationObjectCache, id As Integer, name As String, control As Control, setter As SetDelegate, getter As GetDelegate, flags As ControlDataFlags, AssocControls As System.Windows.Forms.Control())
+            Public Sub New(ConfigurationObjectCache As ConfigurationObjectCache, id As Integer, name As String, control As Control, setter As SetDelegate, getter As GetDelegate, flags As ControlDataFlags, AssocControls As Control())
                 MyBase.New(id, name, control, setter, getter, flags, AssocControls)
                 _configurationObjectCache = ConfigurationObjectCache
             End Sub

--- a/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.vb
@@ -230,7 +230,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.Size = Me.GetPreferredSize(System.Drawing.Size.Empty)
         End Sub
 
-        Private Sub rbStartAction_CheckedChanged(sender As Object, e As System.EventArgs) Handles rbStartProgram.CheckedChanged, rbStartProject.CheckedChanged, rbStartURL.CheckedChanged
+        Private Sub rbStartAction_CheckedChanged(sender As Object, e As EventArgs) Handles rbStartProgram.CheckedChanged, rbStartProject.CheckedChanged, rbStartURL.CheckedChanged
             Dim action As VSLangProj.prjStartAction = StartActionGetValue()
             Me.StartProgram.Enabled = (action = VSLangProj.prjStartAction.prjStartActionProgram)
             Me.StartProgramBrowse.Enabled = Me.StartProgram.Enabled
@@ -255,7 +255,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
-        Private Sub StartWorkingDirectoryBrowse_Click(sender As Object, e As System.EventArgs) Handles StartWorkingDirectoryBrowse.Click
+        Private Sub StartWorkingDirectoryBrowse_Click(sender As Object, e As EventArgs) Handles StartWorkingDirectoryBrowse.Click
             Dim sInitialDirectory As String
             Dim DirName As String = ""
 
@@ -283,7 +283,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         End Sub
 
-        Private Sub RemoteDebugEnabled_CheckedChanged(sender As Object, e As System.EventArgs) Handles RemoteDebugEnabled.CheckedChanged
+        Private Sub RemoteDebugEnabled_CheckedChanged(sender As Object, e As EventArgs) Handles RemoteDebugEnabled.CheckedChanged
             RemoteDebugMachine.Enabled = RemoteDebugEnabled.Checked
 
             If Not m_fInsideInit Then
@@ -296,7 +296,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
-        Private Sub StartProgramBrowse_Click(sender As Object, e As System.EventArgs) Handles StartProgramBrowse.Click
+        Private Sub StartProgramBrowse_Click(sender As Object, e As EventArgs) Handles StartProgramBrowse.Click
             Dim FileName As String = Nothing
 
             SkipValidating(StartProgram)

--- a/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.vb
@@ -57,7 +57,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Property get for file or assembly version.
         ''' </summary>
-        Private Function VersionGet(control As System.Windows.Forms.Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
+        Private Function VersionGet(control As Control, prop As PropertyDescriptor, ByRef value As Object) As Boolean
             Dim Version As String = Nothing
 
             If (control Is Me.FileVersionLayoutPanel) Then
@@ -75,7 +75,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <summary>
         ''' Property set for either file or assembly version.
         ''' </summary>
-        Private Function VersionSet(control As System.Windows.Forms.Control, prop As PropertyDescriptor, value As Object) As Boolean
+        Private Function VersionSet(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
             Dim Major As String = Nothing, Minor As String = Nothing, Build As String = Nothing, Revision As String = Nothing
             Dim Version As String
             Dim Values As String()
@@ -131,18 +131,18 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             ValidateVersion(Me._fileVersionTextBoxes, s_maxFileVersionPartValue, SR.GetString(SR.PPG_Property_AssemblyFileVersion), False, Version)
         End Sub
 
-        Private Sub AssemblyVersionLayoutPanel_TextChanged(sender As Object, e As System.EventArgs) Handles AssemblyVersionMajorTextBox.TextChanged, AssemblyVersionMinorTextBox.TextChanged, AssemblyVersionBuildTextBox.TextChanged, AssemblyVersionRevisionTextBox.TextChanged
+        Private Sub AssemblyVersionLayoutPanel_TextChanged(sender As Object, e As EventArgs) Handles AssemblyVersionMajorTextBox.TextChanged, AssemblyVersionMinorTextBox.TextChanged, AssemblyVersionBuildTextBox.TextChanged, AssemblyVersionRevisionTextBox.TextChanged
             SetDirty(Me.AssemblyVersionLayoutPanel, False)
         End Sub
 
-        Private Sub FileVersionLayoutPanel_TextChanged(sender As Object, e As System.EventArgs) Handles FileVersionMajorTextBox.TextChanged, FileVersionMinorTextBox.TextChanged, FileVersionBuildTextBox.TextChanged, FileVersionRevisionTextBox.TextChanged
+        Private Sub FileVersionLayoutPanel_TextChanged(sender As Object, e As EventArgs) Handles FileVersionMajorTextBox.TextChanged, FileVersionMinorTextBox.TextChanged, FileVersionBuildTextBox.TextChanged, FileVersionRevisionTextBox.TextChanged
             SetDirty(Me.FileVersionLayoutPanel, False)
         End Sub
 
         ''' <summary>
         ''' Validation properties
         ''' </summary>
-        Protected Overrides Function ValidateProperty(controlData As PropertyControlData, ByRef message As String, ByRef returnControl As System.Windows.Forms.Control) As ValidationResult
+        Protected Overrides Function ValidateProperty(controlData As PropertyControlData, ByRef message As String, ByRef returnControl As Control) As ValidationResult
             If controlData.FormControl Is AssemblyVersionLayoutPanel Then
                 Try
                     Dim Version As String = Nothing
@@ -231,7 +231,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Occurs when the neutral language combobox is dropped down.  Use this to
         '''   populate it with entries.
         ''' </summary>
-        Private Sub NeutralLanguageComboBox_DropDown(sender As Object, e As System.EventArgs) Handles NeutralLanguageComboBox.DropDown
+        Private Sub NeutralLanguageComboBox_DropDown(sender As Object, e As EventArgs) Handles NeutralLanguageComboBox.DropDown
             PopulateNeutralLanguageComboBox(NeutralLanguageComboBox)
             Common.SetComboBoxDropdownWidth(NeutralLanguageComboBox)
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePathsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePathsPropPage.vb
@@ -135,7 +135,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return System.IO.Directory.Exists(Dir)
         End Function
 
-        Private Sub AddFolder_Click(sender As Object, e As System.EventArgs) Handles AddFolder.Click
+        Private Sub AddFolder_Click(sender As Object, e As EventArgs) Handles AddFolder.Click
             Dim FolderText As String = GetCurrentFolderPathAbsolute()
             If Len(FolderText) > 0 AndAlso ReferencePath.FindStringExact(FolderText) = -1 Then
                 If IsValidFolderPath(FolderText) Then
@@ -147,7 +147,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
-        Private Sub UpdateFolder_Click(sender As Object, e As System.EventArgs) Handles UpdateFolder.Click
+        Private Sub UpdateFolder_Click(sender As Object, e As EventArgs) Handles UpdateFolder.Click
             Dim FolderText As String = GetCurrentFolderPathAbsolute()
             Dim index As Integer = Me.ReferencePath.SelectedIndex
 
@@ -162,7 +162,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
-        Private Sub RemoveFolder_Click(sender As Object, e As System.EventArgs) Handles RemoveFolder.Click
+        Private Sub RemoveFolder_Click(sender As Object, e As EventArgs) Handles RemoveFolder.Click
             '
             RemoveCurrentPath()
         End Sub
@@ -178,7 +178,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
-        Private Sub MoveUp_Click(sender As Object, e As System.EventArgs) Handles MoveUp.Click
+        Private Sub MoveUp_Click(sender As Object, e As EventArgs) Handles MoveUp.Click
             '
             Dim SelectedIndex As Integer = ReferencePath.SelectedIndex
             Dim SelectedItem As Object = ReferencePath.SelectedItem
@@ -197,7 +197,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
-        Private Sub MoveDown_Click(sender As Object, e As System.EventArgs) Handles MoveDown.Click
+        Private Sub MoveDown_Click(sender As Object, e As EventArgs) Handles MoveDown.Click
             '
             Dim SelectedIndex As Integer = ReferencePath.SelectedIndex
             Dim SelectedItem As Object = ReferencePath.SelectedItem
@@ -216,7 +216,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
-        Private Sub ReferencePath_SelectedIndexChanged(sender As Object, e As System.EventArgs) Handles ReferencePath.SelectedIndexChanged
+        Private Sub ReferencePath_SelectedIndexChanged(sender As Object, e As EventArgs) Handles ReferencePath.SelectedIndexChanged
             If Not m_fInsideInit Then
                 Dim FolderText As String
                 Dim SelectedIndex As Integer = Me.ReferencePath.SelectedIndex
@@ -324,7 +324,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return False
         End Function
 
-        Private Sub Folder_TextChanged(sender As Object, e As System.EventArgs) Handles Folder.TextChanged
+        Private Sub Folder_TextChanged(sender As Object, e As EventArgs) Handles Folder.TextChanged
             If Not m_fInsideInit Then
                 EnableReferencePathGroup()
             End If
@@ -350,7 +350,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return FolderText
         End Function
 
-        Private Sub FolderBrowse_Click(sender As Object, e As System.EventArgs) Handles FolderBrowse.Click
+        Private Sub FolderBrowse_Click(sender As Object, e As EventArgs) Handles FolderBrowse.Click
             Dim value As String = Nothing
             If GetDirectoryViaBrowse(GetCurrentFolderPathAbsolute(), SR.GetString(SR.PPG_SelectReferencePath), value) Then
                 Folder.Text = GetProjectRelativeDirectoryPath(value)
@@ -371,7 +371,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''<summary>
         ''' Handle button Enabled property changing event to reset its image
         '''</summary>
-        Private Sub GraphicButton_OnEnabledChanged(sender As Object, e As System.EventArgs) Handles MoveUp.EnabledChanged, MoveDown.EnabledChanged, RemoveFolder.EnabledChanged
+        Private Sub GraphicButton_OnEnabledChanged(sender As Object, e As EventArgs) Handles MoveUp.EnabledChanged, MoveDown.EnabledChanged, RemoveFolder.EnabledChanged
             UpdateButtonImages()
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
@@ -904,7 +904,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return ResultList.ToArray()
         End Function
 
-        Private Sub RemoveReference_Click(sender As Object, e As System.EventArgs) Handles RemoveReference.Click
+        Private Sub RemoveReference_Click(sender As Object, e As EventArgs) Handles RemoveReference.Click
             RemoveSelectedReference()
         End Sub
 
@@ -1027,7 +1027,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         End Sub
 
-        Private Sub addContextMenuStrip_Opening(sender As Object, e As System.ComponentModel.CancelEventArgs) Handles addContextMenuStrip.Opening
+        Private Sub addContextMenuStrip_Opening(sender As Object, e As CancelEventArgs) Handles addContextMenuStrip.Opening
             Dim vsHierarchy As IVsHierarchy = ShellUtil.VsHierarchyFromDTEProject(ServiceProvider, DTEProject)
             If vsHierarchy IsNot Nothing Then
                 webReferenceToolStripMenuItem.Visible = Utils.IsWebReferenceSupportedByDefaultInProject(vsHierarchy)
@@ -1035,7 +1035,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
-        Private Sub referenceToolStripMenuItem_Click(sender As Object, e As System.EventArgs) Handles referenceToolStripMenuItem.Click, addSplitButton.Click
+        Private Sub referenceToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles referenceToolStripMenuItem.Click, addSplitButton.Click
             Dim UIHier As IVsUIHierarchy
             If TypeOf ProjectHierarchy Is IVsUIHierarchy Then
                 Try
@@ -1071,7 +1071,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
-        Private Sub webReferenceToolStripMenuItem_Click(sender As Object, e As System.EventArgs) Handles webReferenceToolStripMenuItem.Click
+        Private Sub webReferenceToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles webReferenceToolStripMenuItem.Click
             Dim AddWebRefDlg As IVsAddWebReferenceDlg2
             Dim DiscoveryResult As IDiscoveryResult = Nothing
 
@@ -1108,7 +1108,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Sub
 
 
-        Private Sub serviceReferenceToolStripMenuItem_Click(sender As Object, e As System.EventArgs) Handles serviceReferenceToolStripMenuItem.Click
+        Private Sub serviceReferenceToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles serviceReferenceToolStripMenuItem.Click
             Dim AddServiceRefDlg As IVsAddWebReferenceDlg3
 
             AddServiceRefDlg = CType(ServiceProvider.GetService(GetType(SVsAddWebReferenceDlg3)), IVsAddWebReferenceDlg3)
@@ -1255,7 +1255,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             UpdateUserImportButton.Enabled = EnableUpdateUserImportButton
         End Sub
 
-        Private Sub ReferenceList_ItemActivate(sender As Object, e As System.EventArgs) Handles ReferenceList.ItemActivate
+        Private Sub ReferenceList_ItemActivate(sender As Object, e As EventArgs) Handles ReferenceList.ItemActivate
             Dim items As ListView.SelectedListViewItemCollection = Me.ReferenceList.SelectedItems
             If items.Count > 0 Then
                 DTE.ExecuteCommand("View.PropertiesWindow", String.Empty)
@@ -1271,13 +1271,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
-        Private Sub ReferenceList_SelectedIndexChanged(sender As Object, e As System.EventArgs) Handles ReferenceList.SelectedIndexChanged
+        Private Sub ReferenceList_SelectedIndexChanged(sender As Object, e As EventArgs) Handles ReferenceList.SelectedIndexChanged
             Me.EnableReferenceGroup()
 
             PushSelection()
         End Sub
 
-        Private Sub ReferenceList_Enter(sender As Object, e As System.EventArgs) Handles ReferenceList.Enter
+        Private Sub ReferenceList_Enter(sender As Object, e As EventArgs) Handles ReferenceList.Enter
             PushSelection()
         End Sub
 
@@ -1290,7 +1290,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             ListViewComparer.HandleColumnClick(ReferenceList, _referenceSorter, e)
         End Sub
 
-        Private Sub UpdateReferences_Click(sender As Object, e As System.EventArgs) Handles UpdateReferences.Click
+        Private Sub UpdateReferences_Click(sender As Object, e As EventArgs) Handles UpdateReferences.Click
             Using New WaitCursor
                 Dim items As ListView.SelectedListViewItemCollection = Me.ReferenceList.SelectedItems
                 For Each item As ListViewItem In items
@@ -1309,7 +1309,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Sub
 
 
-        Private Sub UnusedReferences_Click(sender As System.Object, e As System.EventArgs) Handles UnusedReferences.Click
+        Private Sub UnusedReferences_Click(sender As System.Object, e As EventArgs) Handles UnusedReferences.Click
             ' Take a snapshot of the user imports...
             Dim ImportsSnapshot As IDictionary(Of String, Boolean) = GetUserDefinedImportsSnapshot()
 
@@ -1326,7 +1326,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
-        Private Sub ReferencePathsButton_Click(sender As Object, e As System.EventArgs) Handles ReferencePathsButton.Click
+        Private Sub ReferencePathsButton_Click(sender As Object, e As EventArgs) Handles ReferencePathsButton.Click
             ShowChildPage(SR.GetString(SR.PPG_ReferencePaths_Title), GetType(ReferencePathsPropPage))
         End Sub
 
@@ -1352,7 +1352,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub ImportPanel_Enter(sender As Object, e As System.EventArgs) Handles addUserImportTableLayoutPanel.Enter
+        Private Sub ImportPanel_Enter(sender As Object, e As EventArgs) Handles addUserImportTableLayoutPanel.Enter
             ' We restore the selection through a message pump. 
             ' The reason is vswhidbey 496909.
             ' When the user clicks an item in the ListBox to select it, we will get OnEnter first, then we noticed the selection change.
@@ -1388,7 +1388,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub ImportPanel_Leave(sender As Object, e As System.EventArgs) Handles addUserImportTableLayoutPanel.Leave
+        Private Sub ImportPanel_Leave(sender As Object, e As EventArgs) Handles addUserImportTableLayoutPanel.Leave
             _hidingImportListSelectedItem = True
             Try
                 _importListSelectedItem = DirectCast(Me.ImportList.SelectedItem, String)
@@ -1623,7 +1623,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return HelpKeywords.VBProjPropReference
         End Function
 
-        Private Sub ImportList_Validated(sender As Object, e As System.EventArgs) Handles ImportList.Validated
+        Private Sub ImportList_Validated(sender As Object, e As EventArgs) Handles ImportList.Validated
         End Sub
 
         ''' <summary>
@@ -1632,7 +1632,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub AddUserImportButton_Click(sender As System.Object, e As System.EventArgs) Handles AddUserImportButton.Click
+        Private Sub AddUserImportButton_Click(sender As System.Object, e As EventArgs) Handles AddUserImportButton.Click
             Debug.Assert(UserImportTextBox.Text.Trim().Length > 0, "Why was the AddUserImportButton enabled when the UserImport text was empty?")
             ' Get the current list
             Dim CurrentImports As String() = GetCurrentImports()
@@ -1673,7 +1673,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub ImportList_SelectedIndexChanged(sender As System.Object, e As System.EventArgs) Handles ImportList.SelectedIndexChanged
+        Private Sub ImportList_SelectedIndexChanged(sender As System.Object, e As EventArgs) Handles ImportList.SelectedIndexChanged
 
             If Not _hidingImportListSelectedItem Then
                 _importListSelectedItem = Nothing
@@ -1689,7 +1689,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub UpdateUserImportButton_Click(sender As System.Object, e As System.EventArgs) Handles UpdateUserImportButton.Click
+        Private Sub UpdateUserImportButton_Click(sender As System.Object, e As EventArgs) Handles UpdateUserImportButton.Click
 
             Debug.Assert(ImportList.SelectedItems.Count <= 1 AndAlso
                         ImportListSelectedItem IsNot Nothing AndAlso
@@ -1740,7 +1740,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub UserImportTextBox_TextChanged(sender As Object, e As System.EventArgs) Handles UserImportTextBox.TextChanged
+        Private Sub UserImportTextBox_TextChanged(sender As Object, e As EventArgs) Handles UserImportTextBox.TextChanged
             EnableImportGroup()
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ServicesAuthenticationForm.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ServicesAuthenticationForm.vb
@@ -69,7 +69,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End Set
         End Property
 
-        Private Sub Cancel_Click(sender As System.Object, e As System.EventArgs) Handles Cancel.Click
+        Private Sub Cancel_Click(sender As System.Object, e As EventArgs) Handles Cancel.Click
             _loadAnonymous = True
             Me.DialogResult = System.Windows.Forms.DialogResult.OK
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ServicesPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ServicesPropPage.vb
@@ -78,7 +78,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             HelpLabel.LinkArea = New System.Windows.Forms.LinkArea(nonlabelText.Length, labelText.Length)
         End Sub
 
-        Private Sub EnableApplicationServices_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles EnableApplicationServices.CheckedChanged
+        Private Sub EnableApplicationServices_CheckedChanged(sender As System.Object, e As EventArgs) Handles EnableApplicationServices.CheckedChanged
             If _ignoreCheckedChanged Then
                 _ignoreCheckedChanged = False
                 Exit Sub
@@ -219,7 +219,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return HelpKeywords.VBProjPropServices
         End Function
 
-        Private Sub AdvancedSettings_Click(sender As Object, e As System.EventArgs) Handles AdvancedSettings.Click
+        Private Sub AdvancedSettings_Click(sender As Object, e As EventArgs) Handles AdvancedSettings.Click
             ShowChildPage(SR.GetString(SR.PPG_ServicesAdvancedPage_Title), GetType(AdvancedServicesDialog))
         End Sub
 
@@ -257,7 +257,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             _ignoreLostFocus = False
         End Sub
 
-        Private Sub RolesServiceUrl_Validated(sender As Object, e As System.EventArgs) Handles RolesServiceUrl.Validated
+        Private Sub RolesServiceUrl_Validated(sender As Object, e As EventArgs) Handles RolesServiceUrl.Validated
             If CurrentAppConfigDocument IsNot Nothing Then
                 If ServicesPropPageAppConfigHelper.SetRoleServiceUri(CurrentAppConfigDocument, RolesServiceUrl.Text, ProjectHierarchy) Then
                     WriteXml()
@@ -265,7 +265,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
-        Private Sub AuthenticationServiceUrl_Validated(sender As Object, e As System.EventArgs) Handles AuthenticationServiceUrl.Validated
+        Private Sub AuthenticationServiceUrl_Validated(sender As Object, e As EventArgs) Handles AuthenticationServiceUrl.Validated
             If CurrentAppConfigDocument IsNot Nothing Then
                 If ServicesPropPageAppConfigHelper.SetAuthenticationServiceUri(CurrentAppConfigDocument, AuthenticationServiceUrl.Text, ProjectHierarchy) Then
                     WriteXml()
@@ -273,7 +273,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
-        Private Sub CustomCredentialProviderType_Validated(sender As Object, e As System.EventArgs) Handles CustomCredentialProviderType.Validated
+        Private Sub CustomCredentialProviderType_Validated(sender As Object, e As EventArgs) Handles CustomCredentialProviderType.Validated
             If CurrentAppConfigDocument IsNot Nothing Then
                 If ServicesPropPageAppConfigHelper.SetCustomCredentialProviderType(CurrentAppConfigDocument, CustomCredentialProviderType.Text, ProjectHierarchy) Then
                     WriteXml()
@@ -281,7 +281,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
-        Private Sub WebSettingsUrl_Validated(sender As Object, e As System.EventArgs) Handles WebSettingsUrl.Validated
+        Private Sub WebSettingsUrl_Validated(sender As Object, e As EventArgs) Handles WebSettingsUrl.Validated
             If CurrentAppConfigDocument IsNot Nothing Then
                 If ServicesPropPageAppConfigHelper.SetAppServicesServiceUri(CurrentAppConfigDocument, WebSettingsUrl.Text) Then
                     WriteXml()
@@ -290,7 +290,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Sub
 
 
-        Private Sub WindowsBasedAuth_CheckedChanged(sender As Object, e As System.EventArgs) Handles WindowsBasedAuth.CheckedChanged
+        Private Sub WindowsBasedAuth_CheckedChanged(sender As Object, e As EventArgs) Handles WindowsBasedAuth.CheckedChanged
             'DevDiv Bugs 100690, disable Authentication service location and credential type
             'if Windows auth is selected
             AuthenticationServiceUrl.Enabled = Not WindowsBasedAuth.Checked
@@ -301,7 +301,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
-        Private Sub FormBasedAuth_CheckedChanged(sender As Object, e As System.EventArgs) Handles WindowsBasedAuth.CheckedChanged
+        Private Sub FormBasedAuth_CheckedChanged(sender As Object, e As EventArgs) Handles WindowsBasedAuth.CheckedChanged
             If FormBasedAuth.Checked And FormBasedAuth.Enabled Then
                 UpdateMembershipDefaultProviderToWindows(False)
             End If
@@ -315,7 +315,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Sub
 
-        Private Sub Loaded(sender As System.Object, e As System.EventArgs) Handles Me.Load
+        Private Sub Loaded(sender As System.Object, e As EventArgs) Handles Me.Load
             _frameworkVersionNumber = Utils.GetProjectTargetFrameworkVersion(ProjectHierarchy)
             EnsureXmlUpToDate()
         End Sub
@@ -339,13 +339,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             InvokeHelp()
         End Sub
 
-        Private Sub ValidateWhenHidden(sender As System.Object, e As System.EventArgs) Handles Me.VisibleChanged
+        Private Sub ValidateWhenHidden(sender As System.Object, e As EventArgs) Handles Me.VisibleChanged
             If Not Me.Visible Then
                 Me.Validate()
             End If
         End Sub
 
-        Private Sub ValidateWhenLostFocus(sender As System.Object, e As System.EventArgs) Handles AuthenticationServiceUrl.LostFocus, CustomCredentialProviderType.LostFocus, RolesServiceUrl.LostFocus, WebSettingsUrl.LostFocus
+        Private Sub ValidateWhenLostFocus(sender As System.Object, e As EventArgs) Handles AuthenticationServiceUrl.LostFocus, CustomCredentialProviderType.LostFocus, RolesServiceUrl.LostFocus, WebSettingsUrl.LostFocus
             Me.Validate()
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/SingleConfigPropertyControlData.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/SingleConfigPropertyControlData.vb
@@ -57,7 +57,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.New(Config, id, name, control, setter, getter, flags, Nothing)
         End Sub
 
-        Public Sub New(Config As Configs, id As Integer, name As String, control As Control, AssocControls As System.Windows.Forms.Control())
+        Public Sub New(Config As Configs, id As Integer, name As String, control As Control, AssocControls As Control())
             Me.New(Config, id, name, control, Nothing, Nothing, ControlDataFlags.None, AssocControls)
         End Sub
 
@@ -65,7 +65,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.New(Config, id, name, control, setter, getter, ControlDataFlags.None, Nothing)
         End Sub
 
-        Public Sub New(Config As Configs, id As Integer, name As String, control As Control, setter As SetDelegate, getter As GetDelegate, flags As ControlDataFlags, AssocControls As System.Windows.Forms.Control())
+        Public Sub New(Config As Configs, id As Integer, name As String, control As Control, setter As SetDelegate, getter As GetDelegate, flags As ControlDataFlags, AssocControls As Control())
             MyBase.New(id, name, control, setter, getter, flags, AssocControls)
             Select Case Config
                 Case Configs.Debug

--- a/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkPropertyControlData.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkPropertyControlData.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         Private _comboBox As ComboBox
 
-        Public Sub New(id As Integer, name As String, comboBox As ComboBox, setter As SetDelegate, getter As GetDelegate, flags As ControlDataFlags, AssocControls As System.Windows.Forms.Control())
+        Public Sub New(id As Integer, name As String, comboBox As ComboBox, setter As SetDelegate, getter As GetDelegate, flags As ControlDataFlags, AssocControls As Control())
             MyBase.New(id, name, comboBox, setter, getter, flags, AssocControls)
             Me._comboBox = comboBox
 
@@ -57,7 +57,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Sub
 
 
-        Private Sub ComboBox_DropDownClosed(sender As Object, e As System.EventArgs)
+        Private Sub ComboBox_DropDownClosed(sender As Object, e As EventArgs)
 
             If IsInstallOtherFrameworksSelected() Then
 
@@ -70,7 +70,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         End Sub
 
-        Protected Overrides Sub ComboBox_SelectionChangeCommitted(sender As Object, e As System.EventArgs)
+        Protected Overrides Sub ComboBox_SelectionChangeCommitted(sender As Object, e As EventArgs)
 
             If IsInstallOtherFrameworksSelected() Then
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/UnusedReferencePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/UnusedReferencePropPage.vb
@@ -508,7 +508,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             ListViewComparer.HandleColumnClick(UnusedReferenceList, _referenceSorter, e)
         End Sub
 
-        Private Sub GetUnusedRefsTimer_Tick(sender As Object, e As System.EventArgs)
+        Private Sub GetUnusedRefsTimer_Tick(sender As Object, e As EventArgs)
 
             ' Poll compiler
             GetUnusedRefs()
@@ -521,7 +521,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </Summary>
         ''' <param name="sender">Event args</param>
         ''' <param name="e">Event args</param>
-        Private Sub dialog_Shown(sender As Object, e As System.EventArgs) Handles m_HostDialog.Shown
+        Private Sub dialog_Shown(sender As Object, e As EventArgs) Handles m_HostDialog.Shown
 
             With CType(sender, PropPageHostDialog)
                 ' Set dialog appearance

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/AppDotXamlErrorControl.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/AppDotXamlErrorControl.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
             Me.ErrorText = errorText
         End Sub
 
-        Private Sub EditXamlButton_Click(sender As Object, e As System.EventArgs) Handles EditXamlButton.Click
+        Private Sub EditXamlButton_Click(sender As Object, e As EventArgs) Handles EditXamlButton.Click
             RaiseEvent EditXamlClicked()
         End Sub
 
@@ -35,7 +35,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
             End Set
         End Property
 
-        Private Sub AppDotXamlErrorControl_Load(sender As Object, e As System.EventArgs) Handles Me.Load
+        Private Sub AppDotXamlErrorControl_Load(sender As Object, e As EventArgs) Handles Me.Load
             Me.TableLayoutPanel1.Width = System.Math.Max(Me.Width, 400)
             Me.TableLayoutPanel1.Height = ErrorControl.Height + Me.EditXamlButton.Height + 100
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
@@ -386,15 +386,15 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         'Delegate to the base class for all functionality related to the icon combobox
         '
 
-        Private Sub IconCombobox_DropDown(sender As Object, e As System.EventArgs) Handles IconCombobox.DropDown
+        Private Sub IconCombobox_DropDown(sender As Object, e As EventArgs) Handles IconCombobox.DropDown
             MyBase.HandleIconComboboxDropDown(sender)
         End Sub
 
-        Private Sub IconCombobox_DropDownClosed(sender As Object, e As System.EventArgs) Handles IconCombobox.DropDownClosed
+        Private Sub IconCombobox_DropDownClosed(sender As Object, e As EventArgs) Handles IconCombobox.DropDownClosed
             MyBase.HandleIconComboboxDropDown(sender)
         End Sub
 
-        Private Sub IconCombobox_SelectionChangeCommitted(sender As Object, e As System.EventArgs) Handles IconCombobox.SelectionChangeCommitted
+        Private Sub IconCombobox_SelectionChangeCommitted(sender As Object, e As EventArgs) Handles IconCombobox.SelectionChangeCommitted
             MyBase.HandleIconComboboxSelectionChangeCommitted(sender)
         End Sub
 
@@ -418,7 +418,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub AssemblyInfoButton_Click(sender As Object, e As System.EventArgs) Handles AssemblyInfoButton.Click
+        Private Sub AssemblyInfoButton_Click(sender As Object, e As EventArgs) Handles AssemblyInfoButton.Click
             ShowChildPage(SR.GetString(SR.PPG_AssemblyInfo_Title), GetType(AssemblyInfoPropPage), HelpKeywords.VBProjPropAssemblyInfo)
         End Sub
 
@@ -993,7 +993,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub StartupObjectOrUriComboBox_DropDown(sender As Object, e As System.EventArgs) Handles StartupObjectOrUriComboBox.DropDown
+        Private Sub StartupObjectOrUriComboBox_DropDown(sender As Object, e As EventArgs) Handles StartupObjectOrUriComboBox.DropDown
             PopulateStartupObjectOrUriComboboxAndKeepCurrentEntry()
             Common.SetComboBoxDropdownWidth(DirectCast(sender, ComboBox))
         End Sub
@@ -1894,7 +1894,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub ViewUACSettingsButton_Click(sender As Object, e As System.EventArgs) Handles ViewUACSettingsButton.Click
+        Private Sub ViewUACSettingsButton_Click(sender As Object, e As EventArgs) Handles ViewUACSettingsButton.Click
             ViewUACSettings()
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/DialogQueryName.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/DialogQueryName.vb
@@ -190,7 +190,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub ButtonAdd_Click(sender As Object, e As System.EventArgs) Handles ButtonAdd.Click
+        Private Sub ButtonAdd_Click(sender As Object, e As EventArgs) Handles ButtonAdd.Click
             Dim ResourceView As ResourceEditorView = _rootDesigner.GetView()
             Debug.Assert(ResourceView IsNot Nothing, "Why there is no view?")
             If ResourceView IsNot Nothing Then
@@ -219,7 +219,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub ButtonCancel_Click(sender As Object, e As System.EventArgs) Handles ButtonCancel.Click
+        Private Sub ButtonCancel_Click(sender As Object, e As EventArgs) Handles ButtonCancel.Click
             Close()
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/FileWatcher.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/FileWatcher.vb
@@ -631,7 +631,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' Note that we're using a Windows Forms timer, which always fires its events
             '''   in the thread from which it was created.  So no synchronization issues.
             ''' </remarks>
-            Private Sub Timer_Elapsed(sender As Object, e As System.EventArgs) Handles _timer.Tick
+            Private Sub Timer_Elapsed(sender As Object, e As EventArgs) Handles _timer.Tick
                 Debug.WriteLineIf(Switches.RSEFileWatcher.TraceVerbose, "    FileWatcherEntry: Raising delayed FileChanged event: " & ToString() & ", Thread = " & Microsoft.VisualBasic.Hex(System.Threading.Thread.CurrentThread.GetHashCode) & ", Milliseconds = " & VB.Now.Millisecond)
 
                 'First thing to do is get rid of the timer - we don't need it anymore.

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/OpenFileWarningDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/OpenFileWarningDialog.vb
@@ -59,7 +59,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub ButtonOk_Click(sender As Object, e As System.EventArgs) Handles buttonOK.Click
+        Private Sub ButtonOk_Click(sender As Object, e As EventArgs) Handles buttonOK.Click
             Close()
         End Sub
         Friend WithEvents messageLabel2 As System.Windows.Forms.Label

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
@@ -275,7 +275,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 #Region "Events"
 
         ' Represents the method that handles the Disposed event of a Component.
-        Private Event Disposed(sender As Object, e As System.EventArgs) Implements IComponent.Disposed
+        Private Event Disposed(sender As Object, e As EventArgs) Implements IComponent.Disposed
 
 #End Region
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorFactory.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Friend Const ResourceEditor_EditorGuid As String = "ff4d6aca-9352-4a5f-821e-f4d6ebdcab11"
 
 
-        Private _vsTrackProjectDocumentsEventsCookie As UInt32
+        Private _vsTrackProjectDocumentsEventsCookie As UInteger
         Private _vsTrackProjectDocuments As IVsTrackProjectDocuments2
 
         ''' <summary>

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootDesigner.vb
@@ -711,7 +711,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' We need get undoEngine to monitor undo state. But it is not available when the designer is just loaded. We do this on the first transaction (change) happens in the designer.
         ''' </summary>
         ''' <remarks></remarks>
-        Private Sub DesignerHost_TransactionOpening(sender As Object, e As System.EventArgs) Handles _designerHost.TransactionOpening
+        Private Sub DesignerHost_TransactionOpening(sender As Object, e As EventArgs) Handles _designerHost.TransactionOpening
             If _undoEngine Is Nothing Then
                 _undoEngine = DirectCast(GetService(GetType(UndoEngine)), UndoEngine)
                 ' We get UndoEngine here, because we need monitor undo start/end event. But when this trasaction itself is caused by an UNDO operation,
@@ -832,7 +832,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub UndoEngine_Undoing(sender As Object, e As System.EventArgs) Handles _undoEngine.Undoing
+        Private Sub UndoEngine_Undoing(sender As Object, e As EventArgs) Handles _undoEngine.Undoing
             If _view IsNot Nothing Then
                 _view.OnUndoing()
             End If
@@ -844,7 +844,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub UndoEngine_Undone(sender As Object, e As System.EventArgs) Handles _undoEngine.Undone
+        Private Sub UndoEngine_Undone(sender As Object, e As EventArgs) Handles _undoEngine.Undone
             If _view IsNot Nothing Then
                 _view.OnUndone()
             End If

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -953,7 +953,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Received when the resource editor view window is resized.  Cause a layout.
         ''' </summary>
         ''' <remarks></remarks>
-        Protected Overrides Sub OnResize(e As System.EventArgs)
+        Protected Overrides Sub OnResize(e As EventArgs)
             MyBase.OnResize(e)
 
             LayOutResourceEditor()
@@ -1550,7 +1550,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub ResourceListView_SelectedIndexChanged(sender As Object, e As System.EventArgs) Handles _resourceListView.SelectedIndexChanged
+        Private Sub ResourceListView_SelectedIndexChanged(sender As Object, e As EventArgs) Handles _resourceListView.SelectedIndexChanged
             Try
                 PropertyGridUpdate()
                 RootDesigner.InvalidateFindLoop(ResourcesAddedOrRemoved:=False)
@@ -3405,7 +3405,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub ResourceListView_ItemActivate(sender As Object, e As System.EventArgs) Handles _resourceListView.ItemActivate
+        Private Sub ResourceListView_ItemActivate(sender As Object, e As EventArgs) Handles _resourceListView.ItemActivate
             If CanPlayResources(GetSelectedResources()) Then
                 MenuPlay(sender, e)
             Else
@@ -4082,7 +4082,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub Category_XXX_ResourcesExistChanged(sender As Object, e As System.EventArgs) _
+        Private Sub Category_XXX_ResourcesExistChanged(sender As Object, e As EventArgs) _
         Handles _
             _categoryAudio.ResourcesExistChanged, _
             _categoryFiles.ResourcesExistChanged, _
@@ -4099,7 +4099,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub MenuResourceTypeStrings(sender As Object, e As System.EventArgs)
+        Private Sub MenuResourceTypeStrings(sender As Object, e As EventArgs)
             SwitchToCategory(_categoryStrings)
         End Sub
 
@@ -4110,7 +4110,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub MenuResourceTypeImages(sender As Object, e As System.EventArgs)
+        Private Sub MenuResourceTypeImages(sender As Object, e As EventArgs)
             SwitchToCategory(_categoryImages)
         End Sub
 
@@ -4121,7 +4121,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub MenuResourceTypeIcons(sender As Object, e As System.EventArgs)
+        Private Sub MenuResourceTypeIcons(sender As Object, e As EventArgs)
             SwitchToCategory(_categoryIcons)
         End Sub
 
@@ -4132,7 +4132,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub MenuResourceTypeAudio(sender As Object, e As System.EventArgs)
+        Private Sub MenuResourceTypeAudio(sender As Object, e As EventArgs)
             SwitchToCategory(_categoryAudio)
         End Sub
 
@@ -4143,7 +4143,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub MenuResourceTypeFiles(sender As Object, e As System.EventArgs)
+        Private Sub MenuResourceTypeFiles(sender As Object, e As EventArgs)
             SwitchToCategory(_categoryFiles)
         End Sub
 
@@ -4154,7 +4154,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub MenuResourceTypeOther(sender As Object, e As System.EventArgs)
+        Private Sub MenuResourceTypeOther(sender As Object, e As EventArgs)
             SwitchToCategory(_categoryOther)
         End Sub
 
@@ -4169,7 +4169,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub ButtonAdd_ExistingFile_Click(sender As Object, e As System.EventArgs)
+        Private Sub ButtonAdd_ExistingFile_Click(sender As Object, e As EventArgs)
             Dim Title As String = SR.GetString(SR.RSE_DlgTitle_AddExisting)
             Dim FilterIndex As Integer = 0
             Dim Filter As String = GetFileDialogFilterForCategories(_categories, _currentCategory, FilterIndex)
@@ -4225,7 +4225,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub ButtonFixedAdd_Click(sender As Object, e As System.EventArgs)
+        Private Sub ButtonFixedAdd_Click(sender As Object, e As EventArgs)
             If Me.CurrentCategory.AddCommand IsNot Nothing Then
                 Me.CurrentCategory.AddCommand.Invoke(sender, e)
             End If
@@ -4245,7 +4245,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Handles the "Add.New String" ToolStripMenuItem
         ''' </summary>
         ''' <remarks></remarks>
-        Private Sub ButtonAdd_NewString_Click(sender As Object, e As System.EventArgs)
+        Private Sub ButtonAdd_NewString_Click(sender As Object, e As EventArgs)
             CommitPendingChanges()
 
             'We simply switch to the string table and place the cursor in the bottom row, which is the add/new row.
@@ -4258,7 +4258,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Handles the "Add.New Image.BMP Image" ToolStripMenuItem
         ''' </summary>
         ''' <remarks></remarks>
-        Private Sub ButtonAdd_NewImage_BMP_Click(sender As Object, e As System.EventArgs)
+        Private Sub ButtonAdd_NewImage_BMP_Click(sender As Object, e As EventArgs)
             QueryAddNewLinkedResource(ResourceTypeEditors.Bitmap, ResourceTypeEditorBitmap.EXT_BMP)
 
             ' Remember the type of the last added image
@@ -4270,7 +4270,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Handles the "Add.New Image.GIF Image" ToolStripMenuItem
         ''' </summary>
         ''' <remarks></remarks>
-        Private Sub ButtonAdd_NewImage_GIF_Click(sender As Object, e As System.EventArgs)
+        Private Sub ButtonAdd_NewImage_GIF_Click(sender As Object, e As EventArgs)
             QueryAddNewLinkedResource(ResourceTypeEditors.Bitmap, ResourceTypeEditorBitmap.EXT_GIF)
 
             ' Remember the type of the last added image
@@ -4282,7 +4282,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Handles the "Add.New Image.JPEG Image" ToolStripMenuItem
         ''' </summary>
         ''' <remarks></remarks>
-        Private Sub ButtonAdd_NewImage_JPEG_Click(sender As Object, e As System.EventArgs)
+        Private Sub ButtonAdd_NewImage_JPEG_Click(sender As Object, e As EventArgs)
             QueryAddNewLinkedResource(ResourceTypeEditors.Bitmap, ResourceTypeEditorBitmap.EXT_JPG)
 
             ' Remember the type of the last added image
@@ -4294,7 +4294,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Handles the "Add.New Image.PNG" ToolStripMenuItem
         ''' </summary>
         ''' <remarks></remarks>
-        Private Sub ButtonAdd_NewImage_PNG_Click(sender As Object, e As System.EventArgs)
+        Private Sub ButtonAdd_NewImage_PNG_Click(sender As Object, e As EventArgs)
             QueryAddNewLinkedResource(ResourceTypeEditors.Bitmap, ResourceTypeEditorBitmap.EXT_PNG)
 
             ' Remember the type of the last added image
@@ -4306,7 +4306,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Handles the "Add.New Image.TIFF Image" ToolStripMenuItem
         ''' </summary>
         ''' <remarks></remarks>
-        Private Sub ButtonAdd_NewImage_TIFF_Click(sender As Object, e As System.EventArgs)
+        Private Sub ButtonAdd_NewImage_TIFF_Click(sender As Object, e As EventArgs)
             QueryAddNewLinkedResource(ResourceTypeEditors.Bitmap, ResourceTypeEditorBitmap.EXT_TIF)
 
             ' Remember the type of the last added image
@@ -4318,7 +4318,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Handles the "Add.New Icon" ToolStripMenuItem
         ''' </summary>
         ''' <remarks></remarks>
-        Private Sub ButtonAdd_NewIcon_Click(sender As Object, e As System.EventArgs)
+        Private Sub ButtonAdd_NewIcon_Click(sender As Object, e As EventArgs)
             QueryAddNewLinkedResource(ResourceTypeEditors.Icon, ResourceTypeEditorIcon.EXT_ICO)
         End Sub
 
@@ -4327,7 +4327,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Handles the "Add.New Text File" ToolStripMenuItem
         ''' </summary>
         ''' <remarks></remarks>
-        Private Sub ButtonAdd_NewTextFile_Click(sender As Object, e As System.EventArgs)
+        Private Sub ButtonAdd_NewTextFile_Click(sender As Object, e As EventArgs)
             QueryAddNewLinkedResource(ResourceTypeEditors.TextFile, ResourceTypeEditorTextFile.EXT_TXT)
         End Sub
 
@@ -4489,7 +4489,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub ButtonFixedView_Click(sender As Object, e As System.EventArgs)
+        Private Sub ButtonFixedView_Click(sender As Object, e As EventArgs)
         End Sub
 
         ''' <summary>
@@ -4498,7 +4498,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub ButtonViews_List_Click(sender As Object, e As System.EventArgs)
+        Private Sub ButtonViews_List_Click(sender As Object, e As EventArgs)
             ChangeResourceView(Microsoft.VisualStudio.Editors.ResourceEditor.ResourceListView.ResourceView.List)
         End Sub
 
@@ -4509,7 +4509,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub ButtonViews_Details_Click(sender As Object, e As System.EventArgs)
+        Private Sub ButtonViews_Details_Click(sender As Object, e As EventArgs)
             ChangeResourceView(Microsoft.VisualStudio.Editors.ResourceEditor.ResourceListView.ResourceView.Details)
         End Sub
 
@@ -4520,7 +4520,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub ButtonViews_Thumbnail_Click(sender As Object, e As System.EventArgs)
+        Private Sub ButtonViews_Thumbnail_Click(sender As Object, e As EventArgs)
             ChangeResourceView(Microsoft.VisualStudio.Editors.ResourceEditor.ResourceListView.ResourceView.Thumbnail)
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Utility.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Utility.vb
@@ -392,7 +392,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Public Function IsWavSoundFile(Data As Byte()) As Boolean
             Try
                 Dim Position As Integer = 0
-                Dim wFormatTag As Int16 = -1
+                Dim wFormatTag As Short = -1
                 Dim FmtChunkFound As Boolean = False
 
                 ' validate the RIFF header
@@ -425,7 +425,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                             ' we are dealing w/ WAVEFORMATEX
                             ' do extra validation
                             Dim sizeOfWAVEFORMATEX As Integer = 18
-                            Dim cbSize As Int16 = BytesToInt16(Data(Position + 8 + sizeOfWAVEFORMATEX - 1), _
+                            Dim cbSize As Short = BytesToInt16(Data(Position + 8 + sizeOfWAVEFORMATEX - 1), _
                                                         Data(Position + 8 + sizeOfWAVEFORMATEX - 2))
                             If cbSize + sizeOfWAVEFORMATEX <> ChunkSize Then
                                 'Invalid wave header
@@ -469,7 +469,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="ch1">Second byte</param>
         ''' <returns>The Int16combined from the bytes</returns>
         ''' <remarks></remarks>
-        Private Function BytesToInt16(ch0 As Byte, ch1 As Byte) As Int16
+        Private Function BytesToInt16(ch0 As Byte, ch1 As Byte) As Short
             Return CShort(ch1) Or CShort(CInt(ch0) << 8)
         End Function
 

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DataGridViewUITypeEditorCell.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DataGridViewUITypeEditorCell.vb
@@ -257,7 +257,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             MyBase.OnEnter(rowIndex, throughMouseClick)
             If throughMouseClick Then
                 Dim dfxdgv As DesignerFramework.DesignerDataGridView = TryCast(Me.DataGridView, DesignerFramework.DesignerDataGridView)
-                Dim ec As New System.ComponentModel.CancelEventArgs(False)
+                Dim ec As New CancelEventArgs(False)
 
                 If dfxdgv IsNot Nothing Then
                     If dfxdgv.InMultiSelectionMode Then

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DesignTimeSettingInstance.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DesignTimeSettingInstance.vb
@@ -1141,7 +1141,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             Info.AddValue(s_SERIALIZATION_PROVIDER, _provider)
             Info.AddValue(s_SERIALIZATION_TYPE, _settingTypeName)
             Info.AddValue(s_SERIALIZATION_VALUE, _serializedValue)
-            Info.AddValue(s_SERIALIZATION_SCOPE, CType(_settingScope, Int32))
+            Info.AddValue(s_SERIALIZATION_SCOPE, CType(_settingScope, Integer))
         End Sub
 
 #End Region

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerLoader.vb
@@ -490,7 +490,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub ExternalChange(sender As Object, e As System.EventArgs)
+        Private Sub ExternalChange(sender As Object, e As EventArgs)
             If Not _flushing Then
                 Debug.Assert(_appConfigDocData IsNot Nothing, "Why did we get a change notification for a NULL App.Config DocData?")
                 Common.Switches.TraceSDSerializeSettings(TraceLevel.Info, "Queueing a reload due to an external change of the app.config DocData")

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
@@ -1426,7 +1426,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks>Kind of hacky...</remarks>
-        Private Sub m_SettingsGridView_CurrentCellDirtyStateChanged(sender As Object, e As System.EventArgs) Handles m_SettingsGridView.CurrentCellDirtyStateChanged
+        Private Sub m_SettingsGridView_CurrentCellDirtyStateChanged(sender As Object, e As EventArgs) Handles m_SettingsGridView.CurrentCellDirtyStateChanged
             If m_SettingsGridView.CurrentCellAddress.X = s_typeColumnNo Then
                 Dim cell As DataGridViewCell = m_SettingsGridView.CurrentCell
                 If cell IsNot Nothing Then

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypeEditorHostControl.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypeEditorHostControl.vb
@@ -317,7 +317,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub ShowEditorButton_Click(sender As System.Object, e As System.EventArgs) Handles _showEditorButton.Click
+        Private Sub ShowEditorButton_Click(sender As System.Object, e As EventArgs) Handles _showEditorButton.Click
             Debug.Assert(Not _typeEditor Is Nothing)
             ShowUITypeEditor()
         End Sub
@@ -447,10 +447,10 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         End Sub
 
         Private Sub DropDownHolderSizeChanged(sender As Object, e As EventArgs)
-            DropDownHolderSize(TryCast(sender, System.Windows.Forms.Control))
+            DropDownHolderSize(TryCast(sender, Control))
         End Sub
 
-        Private Sub DropDownHolderSize(control As System.Windows.Forms.Control)
+        Private Sub DropDownHolderSize(control As Control)
             If _dialog IsNot Nothing AndAlso control IsNot Nothing Then
 
                 ' Calculate size & position
@@ -486,7 +486,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             End If
         End Sub
 
-        Public Sub DropDownControl(control As System.Windows.Forms.Control) Implements System.Windows.Forms.Design.IWindowsFormsEditorService.DropDownControl
+        Public Sub DropDownControl(control As Control) Implements System.Windows.Forms.Design.IWindowsFormsEditorService.DropDownControl
             If _dialog Is Nothing Then
                 _dialog = New DropDownHolder
             End If
@@ -603,7 +603,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' </summary>
             ''' <param name="e"></param>
             ''' <remarks></remarks>
-            Protected Overrides Sub OnDeactivate(e As System.EventArgs)
+            Protected Overrides Sub OnDeactivate(e As EventArgs)
                 Me.HideForm()
             End Sub
 
@@ -651,7 +651,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub ValueComboBox_SelectedIndexChanged(sender As System.Object, e As System.EventArgs) Handles _valueComboBox.SelectedIndexChanged
+        Private Sub ValueComboBox_SelectedIndexChanged(sender As System.Object, e As EventArgs) Handles _valueComboBox.SelectedIndexChanged
             _innerValue = _valueComboBox.SelectedItem
             TextValueDirty = False
             OnValueChanged()
@@ -900,7 +900,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' </summary>
             ''' <param name="e"></param>
             ''' <remarks></remarks>
-            Protected Overrides Sub OnMouseEnter(e As System.EventArgs)
+            Protected Overrides Sub OnMouseEnter(e As EventArgs)
                 _drawHot = True
                 Invalidate()
                 MyBase.OnMouseEnter(e)
@@ -911,7 +911,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ''' </summary>
             ''' <param name="e"></param>
             ''' <remarks></remarks>
-            Protected Overrides Sub OnMouseLeave(e As System.EventArgs)
+            Protected Overrides Sub OnMouseLeave(e As EventArgs)
                 _drawHot = False
                 Invalidate()
                 MyBase.OnMouseLeave(e)

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypePickerDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypePickerDialog.vb
@@ -295,7 +295,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="sender"></param>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Private Sub m_OkButton_Click(sender As Object, e As System.EventArgs) Handles m_OkButton.Click
+        Private Sub m_OkButton_Click(sender As Object, e As EventArgs) Handles m_OkButton.Click
             If QueryClose() Then
                 Me.DialogResult = System.Windows.Forms.DialogResult.OK
                 Me.Hide()

--- a/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
@@ -50,7 +50,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         Private _oldGlobalObjects As Dictionary(Of Project, GlobalObjectCollection)
 
         Private _vsTrackProjectDocuments As IVsTrackProjectDocuments2
-        Private _vsTrackProjectDocumentsEventsCookie As UInt32
+        Private _vsTrackProjectDocumentsEventsCookie As UInteger
 
         Private _solutionEvents As SolutionEvents
         Private _rdt As IVsRunningDocumentTable

--- a/src/Microsoft.VisualStudio.Editors/interop/NativeMethods.vb
+++ b/src/Microsoft.VisualStudio.Editors/interop/NativeMethods.vb
@@ -249,7 +249,7 @@ Namespace Microsoft.VisualStudio.Editors.Interop
 
         <StructLayout(LayoutKind.Sequential)> _
         Friend Structure CRYPTOAPI_BLOB
-            Friend cbData As UInt32
+            Friend cbData As UInteger
             Friend pbData As IntPtr
         End Structure
 
@@ -272,7 +272,7 @@ Namespace Microsoft.VisualStudio.Editors.Interop
         End Function
 
         <DllImport("crypt32.dll", SetLastError:=True)> _
-        Friend Shared Function CryptAcquireCertificatePrivateKey(<[In]> CertContext As IntPtr, <[In]> flags As UInt32, <[In]> reserved As IntPtr, <[In], Out> ByRef CryptProv As IntPtr, <[In], Out> ByRef KeySpec As KeySpec, <[In], Out, MarshalAs(UnmanagedType.Bool)> ByRef CallerFreeProv As Boolean) As <MarshalAs(UnmanagedType.Bool)> Boolean
+        Friend Shared Function CryptAcquireCertificatePrivateKey(<[In]> CertContext As IntPtr, <[In]> flags As UInteger, <[In]> reserved As IntPtr, <[In], Out> ByRef CryptProv As IntPtr, <[In], Out> ByRef KeySpec As KeySpec, <[In], Out, MarshalAs(UnmanagedType.Bool)> ByRef CallerFreeProv As Boolean) As <MarshalAs(UnmanagedType.Bool)> Boolean
         End Function
 
         <DllImport("advapi32.dll", SetLastError:=True)> _
@@ -280,7 +280,7 @@ Namespace Microsoft.VisualStudio.Editors.Interop
         End Function
 
         <DllImport("advapi32.dll", SetLastError:=True)> _
-        Friend Shared Function CryptExportKey(<[In]> Key As IntPtr, <[In]> ExpKey As IntPtr, <[In]> type As BlobType, <[In]> Flags As UInt32, <[In]> Data As IntPtr, <[In], Out> ByRef DataLen As UInt32) As <MarshalAs(UnmanagedType.Bool)> Boolean
+        Friend Shared Function CryptExportKey(<[In]> Key As IntPtr, <[In]> ExpKey As IntPtr, <[In]> type As BlobType, <[In]> Flags As UInteger, <[In]> Data As IntPtr, <[In], Out> ByRef DataLen As UInteger) As <MarshalAs(UnmanagedType.Bool)> Boolean
         End Function
 
         Friend Enum BlobType
@@ -299,7 +299,7 @@ Namespace Microsoft.VisualStudio.Editors.Interop
         End Function
 
         <DllImport("advapi32.dll", SetLastError:=True)> _
-        Friend Shared Function CryptReleaseContext(<[In]> Prov As IntPtr, <[In]> Flags As UInt32) As <MarshalAs(UnmanagedType.Bool)> Boolean
+        Friend Shared Function CryptReleaseContext(<[In]> Prov As IntPtr, <[In]> Flags As UInteger) As <MarshalAs(UnmanagedType.Bool)> Boolean
         End Function
 
         <DllImport("crypt32.dll", SetLastError:=True)> _
@@ -494,9 +494,9 @@ Namespace Microsoft.VisualStudio.Editors.Interop
     <InterfaceType(ComInterfaceType.InterfaceIsIUnknown)> _
     <TypeLibType(TypeLibTypeFlags.FRestricted)> _
     Friend Interface IMetaDataDispenser
-        Function DefineScope(<[In]()> ByRef rclsid As Guid, <[In]()> dwCreateFlags As UInt32, <[In]()> ByRef riid As Guid) As <MarshalAs(UnmanagedType.Interface)> Object
-        <PreserveSig()> Function OpenScope(<[In](), MarshalAs(UnmanagedType.LPWStr)> szScope As String, <[In]()> dwOpenFlags As UInt32, <[In]()> ByRef riid As Guid, <Out(), MarshalAs(UnmanagedType.Interface)> ByRef obj As Object) As Integer
-        Function OpenScopeOnMemory(<[In]()> pData As IntPtr, <[In]()> cbData As UInt32, <[In]()> dwOpenFlags As UInt32, <[In]()> ByRef riid As Guid) As <MarshalAs(UnmanagedType.Interface)> Object
+        Function DefineScope(<[In]()> ByRef rclsid As Guid, <[In]()> dwCreateFlags As UInteger, <[In]()> ByRef riid As Guid) As <MarshalAs(UnmanagedType.Interface)> Object
+        <PreserveSig()> Function OpenScope(<[In](), MarshalAs(UnmanagedType.LPWStr)> szScope As String, <[In]()> dwOpenFlags As UInteger, <[In]()> ByRef riid As Guid, <Out(), MarshalAs(UnmanagedType.Interface)> ByRef obj As Object) As Integer
+        Function OpenScopeOnMemory(<[In]()> pData As IntPtr, <[In]()> cbData As UInteger, <[In]()> dwOpenFlags As UInteger, <[In]()> ByRef riid As Guid) As <MarshalAs(UnmanagedType.Interface)> Object
     End Interface
 
     <StructLayout(LayoutKind.Sequential)> _

--- a/src/Microsoft.VisualStudio.Editors/package/EditorToolsOptionsPanel.vb
+++ b/src/Microsoft.VisualStudio.Editors/package/EditorToolsOptionsPanel.vb
@@ -1,7 +1,9 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
-
 Option Strict On
 Option Explicit On
+
+Imports System.Windows.Forms
+
 Namespace Microsoft.VisualStudio.Editors.Package
     Public Class EditorToolsOptionsPanel
 
@@ -11,7 +13,7 @@ Namespace Microsoft.VisualStudio.Editors.Package
         '*
         '* Only allow numerical (and control i.e. backspace) characters
         '*
-        Private Sub FilterNumericInput(sender As Object, e As System.Windows.Forms.KeyPressEventArgs) _
+        Private Sub FilterNumericInput(sender As Object, e As KeyPressEventArgs) _
                 Handles _tabSizeTextBox.KeyPress, _indentSizeTextBox.KeyPress
             If Char.IsDigit(e.KeyChar) Or Char.IsControl(e.KeyChar) Then
                 e.Handled = False
@@ -103,7 +105,7 @@ Namespace Microsoft.VisualStudio.Editors.Package
         '* Try to set TabSize to the value in the tabsize text box. If failure (i.e non-numerical value)
         '* reset the contents of the text box to previous value...
         '*
-        Private Sub tabSizeTextBox_TextChanged(sender As Object, e As System.EventArgs) Handles _tabSizeTextBox.TextChanged
+        Private Sub tabSizeTextBox_TextChanged(sender As Object, e As EventArgs) Handles _tabSizeTextBox.TextChanged
             Try
                 TabSize = UShort.Parse(_tabSizeTextBox.Text)
             Catch ex As Exception
@@ -117,7 +119,7 @@ Namespace Microsoft.VisualStudio.Editors.Package
         '* Try to set IndentSize to the value in the indentsize text box. If failure (i.e non-numerical value)
         '* reset the contents of the text box to previous value...
         '*
-        Private Sub indentSizeTextBox_TextChanged(sender As Object, e As System.EventArgs) Handles _indentSizeTextBox.TextChanged
+        Private Sub indentSizeTextBox_TextChanged(sender As Object, e As EventArgs) Handles _indentSizeTextBox.TextChanged
             Try
                 IndentSize = UInt16.Parse(_indentSizeTextBox.Text)
             Catch ex As Exception

--- a/src/Microsoft.VisualStudio.Editors/package/EditorToolsOptionsPanel.vb
+++ b/src/Microsoft.VisualStudio.Editors/package/EditorToolsOptionsPanel.vb
@@ -105,7 +105,7 @@ Namespace Microsoft.VisualStudio.Editors.Package
         '*
         Private Sub tabSizeTextBox_TextChanged(sender As Object, e As System.EventArgs) Handles _tabSizeTextBox.TextChanged
             Try
-                TabSize = UInt16.Parse(_tabSizeTextBox.Text)
+                TabSize = UShort.Parse(_tabSizeTextBox.Text)
             Catch ex As Exception
                 ' Revert to old value
                 _tabSizeTextBox.Text = _tabSize.ToString()

--- a/src/Microsoft.VisualStudio.Editors/package/ScalingDialogPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/package/ScalingDialogPage.vb
@@ -65,7 +65,7 @@ Namespace Microsoft.VisualStudio.Editors.Package
         ''' </summary>
         ''' <param name="e"></param>
         ''' <remarks></remarks>
-        Protected Overrides Sub OnClosed(e As System.EventArgs)
+        Protected Overrides Sub OnClosed(e As EventArgs)
             _settingsLoaded = False
             MyBase.OnClosed(e)
         End Sub
@@ -184,7 +184,7 @@ Namespace Microsoft.VisualStudio.Editors.Package
             Next
         End Sub
 
-        Private Sub SetDirty(sender As Object, e As System.EventArgs)
+        Private Sub SetDirty(sender As Object, e As EventArgs)
             Debug.WriteLine(String.Format("Control {0} dirtied", DirectCast(sender, Control).Name))
             Me.Dirty = True
         End Sub

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
                 GetCommandStatusResult.Handled(GetCommandText(), CommandStatus.Enabled) :
                 GetCommandStatusResult.Unhandled;
 
-        protected override async Task<bool> TryHandleCommandAsync(IProjectTree node, bool focused, Int64 commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
+        protected override async Task<bool> TryHandleCommandAsync(IProjectTree node, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
         {
             if (!ShouldHandle(node)) return false;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/EditProjectFileCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/EditProjectFileCommand.cs
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
                 GetCommandStatusResult.Handled(GetCommandText(node), CommandStatus.Enabled) :
                 GetCommandStatusResult.Unhandled;
 
-        protected override async Task<bool> TryHandleCommandAsync(IProjectTree node, bool focused, Int64 commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
+        protected override async Task<bool> TryHandleCommandAsync(IProjectTree node, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
         {
             if (!ShouldHandle(node)) return false;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/OptionsSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/OptionsSettings.cs
@@ -3,6 +3,7 @@
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.Shell;
+using EnvDTE;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
@@ -25,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             _threadingService.VerifyOnUIThread();
 
-            EnvDTE.DTE dte = _serviceProvider.GetService<EnvDTE.DTE, EnvDTE.DTE>();
+            DTE dte = _serviceProvider.GetService<DTE, DTE>();
             var props = dte.Properties[category, page];
             if (props != null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileData.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileData.cs
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                             {
                                 case JTokenType.Boolean:
                                     {
-                                        bool value = Boolean.Parse(dataProperty.Value.ToString());
+                                        bool value = bool.Parse(dataProperty.Value.ToString());
                                         customSettings.Add(dataProperty.Name, value);
                                         break;
                                     }


### PR DESCRIPTION
Dogfooding the Roslyn feature across the tree, resulting in the following bugs:

https://github.com/dotnet/roslyn/issues/16001
https://github.com/dotnet/roslyn/issues/16000
https://github.com/dotnet/roslyn/issues/15999
https://github.com/dotnet/roslyn/issues/15998
https://github.com/dotnet/roslyn/issues/15997
https://github.com/dotnet/roslyn/issues/15996

NOTE: I gave up fixing all occurrences of this, due to https://github.com/dotnet/roslyn/issues/15997, it's too painful using Roslyn to fix it across the tree.