### PR TITLE
Attempt to get clean on naming

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -774,7 +774,7 @@ string JsonString1 = @"{
         {
             return FileChangeScheduler == null &&
                    FileWatcher == null &&
-                   _projectRuleSubscriptionLink == null && 
+                   ProjectRuleSubscriptionLink == null && 
                    _broadcastBlock == null;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/GetProfileNameDialog.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/GetProfileNameDialog.xaml.cs
@@ -11,10 +11,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
     [ExcludeFromCodeCoverage]
     public partial class GetProfileNameDialog : DialogWindow
     {
-        private Predicate<string> _validator { get; set; }
+        private readonly Predicate<string> _validator;
+        private readonly SVsServiceProvider _serviceProvider;
+        private readonly IProjectThreadingService _threadingService;
+
         public string ProfileName { get; set; }
-        private SVsServiceProvider _serviceProvider { get; set; }
-        private IProjectThreadingService _threadingService { get; set; }
 
         public GetProfileNameDialog(SVsServiceProvider sp, IProjectThreadingService threadingService, string suggestedName, Predicate<string> validator)
             : base()// Pass help topic to base if there is one

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
@@ -23,6 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         private bool _useJoinableTaskFactory = true;
         private IVsDebugger _debugger;
         private uint _debuggerCookie;
+        internal IProjectThreadingService _threadHandling;
 
         // WIN32 Constants
         private const int
@@ -52,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         }
 
         internal UnconfiguredProject UnconfiguredProject { get; set; }
-        internal IProjectThreadingService _threadHandling { get; set; }
+        
         
         ///--------------------------------------------------------------------------------------------
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             _useJoinableTaskFactory = useJoinableTaskFactory;
         }
 
-        internal UnconfiguredProject _unconfiguredProject { get; set; }
+        internal UnconfiguredProject UnconfiguredProject { get; set; }
         internal IProjectThreadingService _threadHandling { get; set; }
         
         ///--------------------------------------------------------------------------------------------
@@ -340,7 +340,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 
         public void SetObjects(UInt32 cObjects, Object[] ppunk)
         {
-            _unconfiguredProject = null;
+            UnconfiguredProject = null;
             if (cObjects == 0)
             {
                 // If we have never configured anything (maybe a failure occurred on open so app designer is closing us). In this case
@@ -367,12 +367,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                     int hr = browseObj.GetProjectItem(out IVsHierarchy hier, out uint itemid);
                     if (hr == VSConstants.S_OK && itemid == VSConstants.VSITEMID_ROOT)
                     {
-                        _unconfiguredProject = GetUnconfiguredProject(hier);
+                        UnconfiguredProject = GetUnconfiguredProject(hier);
 
                         // We need to save ThreadHandling because the appdesigner will call SetObjects with null, and then call
                         // Deactivate(). We need to run Async code during Deactivate() which requires ThreadHandling.
 
-                        IUnconfiguredProjectVsServices projectVsServices = _unconfiguredProject.Services.ExportProvider.GetExportedValue<IUnconfiguredProjectVsServices>();
+                        IUnconfiguredProjectVsServices projectVsServices = UnconfiguredProject.Services.ExportProvider.GetExportedValue<IUnconfiguredProjectVsServices>();
                         _threadHandling = projectVsServices.ThreadingService;
                     }
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WpfBasedPropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WpfBasedPropertyPage.cs
@@ -88,10 +88,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             wpfHostPanel.Controls.Add(host);
 
             ResumeLayout(true);
-            control.StatusChanged += _control_OnControlStatusChanged;
+            control.StatusChanged += OnControlStatusChanged;
         }
 
-        private void _control_OnControlStatusChanged(object sender, EventArgs e)
+        private void OnControlStatusChanged(object sender, EventArgs e)
         {
             if (IsDirty != control.IsDirty)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WpfBasedPropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WpfBasedPropertyPage.cs
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             }
 
             viewModel = CreatePropertyPageViewModel();
-            viewModel.UnconfiguredProject = base._unconfiguredProject;
+            viewModel.UnconfiguredProject = base.UnconfiguredProject;
             await viewModel.Initialize().ConfigureAwait(false);
             control.InitializePropertyPage(viewModel);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/ObservableList.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/ObservableList.cs
@@ -24,10 +24,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
             }
 
             foreach (INotifyPropertyChanged item in list)
-                item.PropertyChanged += item_PropertyChanged;
+                item.PropertyChanged += OnItemPropertyChanged;
         }
 
-        void item_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void OnItemPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             OnPropertyChanged(new PropertyChangedEventArgs("Items"));
         }
@@ -46,11 +46,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
             {
                 if (e.OldItems != null)
                     foreach (INotifyPropertyChanged item in e.OldItems)
-                        item.PropertyChanged -= item_PropertyChanged;
+                        item.PropertyChanged -= OnItemPropertyChanged;
 
                 if (e.NewItems != null)
                     foreach (INotifyPropertyChanged item in e.NewItems)
-                        item.PropertyChanged += item_PropertyChanged;
+                        item.PropertyChanged += OnItemPropertyChanged;
             }
 
             base.OnCollectionChanged(e);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettings.cs
@@ -8,6 +8,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
     internal class LaunchSettings : ILaunchSettings
     {
+        private readonly string _activeProfileName;
+
         /// <summary>
         /// Represents the current set of launch settings. Creation from an existing set of profiles. 
         /// </summary>
@@ -39,9 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             Profiles = ImmutableList<ILaunchProfile>.Empty;
             GlobalSettings = ImmutableDictionary<string, object>.Empty;
-        }
-
-        private string  _activeProfileName { get; } 
+        }        
 
         public ImmutableList<ILaunchProfile> Profiles { get; }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
         private TaskCompletionSource<bool> _firstSnapshotCompletionSource = new TaskCompletionSource<bool>();
 
-        protected IDisposable _projectRuleSubscriptionLink {get; set;}
+        protected IDisposable ProjectRuleSubscriptionLink {get; set;}
 
         /// <summary>
         /// Returns the full path to the launch settings file
@@ -204,7 +204,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             {
                 var projectChangesBlock = new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(ProjectRuleBlock_ChangedAsync);
 
-                _projectRuleSubscriptionLink = ProjectSubscriptionService.ProjectRuleSource.SourceBlock.LinkTo(
+                ProjectRuleSubscriptionLink = ProjectSubscriptionService.ProjectRuleSource.SourceBlock.LinkTo(
                     projectChangesBlock,
                     ruleNames: ProjectDebugger.SchemaName,
                     linkOptions: new DataflowLinkOptions { PropagateCompletion = true });
@@ -650,10 +650,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                     _broadcastBlock = null;
                 }
 
-                if(_projectRuleSubscriptionLink != null)
+                if(ProjectRuleSubscriptionLink != null)
                 {
-                    _projectRuleSubscriptionLink.Dispose();
-                    _projectRuleSubscriptionLink = null;
+                    ProjectRuleSubscriptionLink.Dispose();
+                    ProjectRuleSubscriptionLink = null;
                 }
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -23,20 +23,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     /// that many of the methods are protected so that unit tests can derive from this class and poke them as
     /// needed w/o making them public
     /// </summary>
-    [Export (typeof(ILaunchSettingsProvider))]
+    [Export(typeof(ILaunchSettingsProvider))]
     [AppliesTo(ProjectCapability.LaunchProfiles)]
     internal class LaunchSettingsProvider : OnceInitializedOnceDisposed, ILaunchSettingsProvider
     {
 
         [ImportingConstructor]
-        public LaunchSettingsProvider(UnconfiguredProject unconfiguredProject, IUnconfiguredProjectServices projectServices, 
-                                      IFileSystem fileSystem,   IUnconfiguredProjectCommonServices commonProjectServices, 
+        public LaunchSettingsProvider(UnconfiguredProject unconfiguredProject, IUnconfiguredProjectServices projectServices,
+                                      IFileSystem fileSystem, IUnconfiguredProjectCommonServices commonProjectServices,
                                       IActiveConfiguredProjectSubscriptionService projectSubscriptionService)
         {
             ProjectServices = projectServices;
             FileManager = fileSystem;
             CommonProjectServices = commonProjectServices;
-            JsonSerializationProviders = new OrderPrecedenceImportCollection<ILaunchSettingsSerializationProvider, IJsonSection>(ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesFirst, 
+            JsonSerializationProviders = new OrderPrecedenceImportCollection<ILaunchSettingsSerializationProvider, IJsonSection>(ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesFirst,
                                                                                                                     unconfiguredProject);
             SourceControlIntegrations = new OrderPrecedenceImportCollection<ISourceCodeControlIntegration>(projectCapabilityCheckProvider: unconfiguredProject);
 
@@ -63,22 +63,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         protected IFileSystem FileManager { get; set; }
 
         // Used to track our errors so we can flush them later
-        public  const string ErrorOwnerString = nameof(LaunchSettingsProvider);
-        
+        public const string ErrorOwnerString = nameof(LaunchSettingsProvider);
+
         public const string LaunchSettingsFilename = @"launchSettings.json";
         public const string DefaultSettingsFileFolder = "Properties";
         public const string ProfilesSectionName = "profiles";
 
         // Command that means run this project
-        public  const string RunProjectCommandName = "Project";
+        public const string RunProjectCommandName = "Project";
 
         //  Command that means run an executable
         public const string RunExecutableCommandName = "Executable";
 
         // These are used internally to loop in debuggers to handle F5 when there are errors in 
         // the launch settings file or when there are no profiles specified (like class libraries)
-        public  const string ErrorProfileCommandName = "ErrorProfile";
-       
+        public const string ErrorProfileCommandName = "ErrorProfile";
+
         protected SimpleFileWatcher FileWatcher { get; set; }
 
         // When we are saveing the file we set this to minimize noise from the file change
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
         private TaskCompletionSource<bool> _firstSnapshotCompletionSource = new TaskCompletionSource<bool>();
 
-        protected IDisposable ProjectRuleSubscriptionLink {get; set;}
+        protected IDisposable ProjectRuleSubscriptionLink { get; set; }
 
         /// <summary>
         /// Returns the full path to the launch settings file
@@ -103,9 +103,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         private string _launchSettingsFile;
         public string LaunchSettingsFile
         {
-            get 
+            get
             {
-                if(_launchSettingsFile == null)
+                if (_launchSettingsFile == null)
                 {
                     _launchSettingsFile = Path.Combine(Path.GetDirectoryName(CommonProjectServices.Project.FullPath), LaunchSettingsFileFolder, LaunchSettingsFilename);
                 }
@@ -121,15 +121,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             get
             {
-                if(_launchSettingsFileFolder == null)
+                if (_launchSettingsFileFolder == null)
                 {
-                    _launchSettingsFileFolder = CommonProjectServices.ThreadingService.ExecuteSynchronously(async () => 
-                    {
+                    _launchSettingsFileFolder = CommonProjectServices.ThreadingService.ExecuteSynchronously(async () => {
                         var props = await CommonProjectServices.ActiveConfiguredProjectProperties.GetAppDesignerPropertiesAsync().ConfigureAwait(true);
                         return await props.FolderName.GetValueAsync().ConfigureAwait(true) as string;
                     });
 
-                    if(string.IsNullOrEmpty(_launchSettingsFileFolder))
+                    if (string.IsNullOrEmpty(_launchSettingsFileFolder))
                     {
                         _launchSettingsFileFolder = DefaultSettingsFileFolder;
                     }
@@ -142,12 +141,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// Returns the active profile. Looks up the value of the ActiveProfile property. If the value doesn't match the
         /// any of the profiles, the first one is returned
         /// </summary>
-        public ILaunchProfile ActiveProfile 
-        { 
+        public ILaunchProfile ActiveProfile
+        {
             get
             {
                 var snapshot = CurrentSnapshot;
-                return snapshot ?.ActiveProfile;
+                return snapshot?.ActiveProfile;
             }
         }
         /// <summary>
@@ -161,7 +160,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 return _changedSourceBlock;
             }
         }
-           
+
         /// <summary>
         /// IOebugProfileProvider
         /// Access to the current set of profile information
@@ -177,7 +176,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             protected set
             {
                 // If this is the first snapshot, complete the taskCompletionSource
-                if(_currentSnapshot == null)
+                if (_currentSnapshot == null)
                 {
                     _firstSnapshotCompletionSource.TrySetResult(true);
                 }
@@ -192,7 +191,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         protected override void Initialize()
         {
-            
+
             // Create our broadcast block for subscribers to get new ILaunchProfiles Information
             _broadcastBlock = new BroadcastBlock<ILaunchSettings>(s => s);
             _changedSourceBlock = _broadcastBlock.SafePublicize();
@@ -220,11 +219,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         protected async Task ProjectRuleBlock_ChangedAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> projectSubscriptionUpdate)
         {
-            if (projectSubscriptionUpdate.Value.CurrentState.TryGetValue(ProjectDebugger.SchemaName, out IProjectRuleSnapshot ruleSnapshot) )
+            if (projectSubscriptionUpdate.Value.CurrentState.TryGetValue(ProjectDebugger.SchemaName, out IProjectRuleSnapshot ruleSnapshot))
             {
                 ruleSnapshot.Properties.TryGetValue(ProjectDebugger.ActiveDebugProfileProperty, out string activeProfile);
                 var snapshot = CurrentSnapshot;
-                if(snapshot == null || !LaunchProfile.IsSameProfileName(activeProfile, snapshot.ActiveProfile?.Name))
+                if (snapshot == null || !LaunchProfile.IsSameProfileName(activeProfile, snapshot.ActiveProfile?.Name))
                 {
                     await UpdateActiveProfileInSnapshotAsync(activeProfile).ConfigureAwait(false);
                 }
@@ -238,14 +237,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         protected async Task UpdateActiveProfileInSnapshotAsync(string activeProfile)
         {
             var snapshot = CurrentSnapshot;
-            if(snapshot == null || SettingsFileHasChanged())
+            if (snapshot == null || SettingsFileHasChanged())
             {
                 await UpdateProfilesAsync(activeProfile).ConfigureAwait(false);
                 return;
             }
 
             var newSnapshot = new LaunchSettings(snapshot.Profiles, snapshot.GlobalSettings, activeProfile);
-            FinishUpdate(newSnapshot); 
+            FinishUpdate(newSnapshot);
         }
 
 
@@ -259,7 +258,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             try
             {
                 // If no active profile specified, try to get one
-                if(activeProfile == null)
+                if (activeProfile == null)
                 {
                     var props = await CommonProjectServices.ActiveConfiguredProjectProperties.GetProjectDebuggerPropertiesAsync().ConfigureAwait(true);
                     if (await props.ActiveDebugProfile.GetValueAsync().ConfigureAwait(true) is IEnumValue activeProfileVal)
@@ -273,14 +272,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
                 // If there are no profiles, we will add a default profile to run the prroject. W/o it our debugger
                 // won't be called on F5 and the user will see a poor error message
-                if(launchSettingData.Profiles.Count == 0)
+                if (launchSettingData.Profiles.Count == 0)
                 {
-                    launchSettingData.Profiles.Add(new LaunchProfileData() {Name=Path.GetFileNameWithoutExtension(CommonProjectServices.Project.FullPath), CommandName=RunProjectCommandName});
+                    launchSettingData.Profiles.Add(new LaunchProfileData() { Name = Path.GetFileNameWithoutExtension(CommonProjectServices.Project.FullPath), CommandName = RunProjectCommandName });
                 }
 
                 var newSnapshot = new LaunchSettings(launchSettingData, activeProfile);
 
-                FinishUpdate(newSnapshot); 
+                FinishUpdate(newSnapshot);
 
             }
             catch (Exception ex)
@@ -289,11 +288,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 // However, if we have never created a snapshot it means there is some error in the file and we want
                 // to have the user see that, so we add a dummy profile which will bind to an existing debugger which will
                 // display the error when run
-                if(CurrentSnapshot == null)
+                if (CurrentSnapshot == null)
                 {
-                    var errorProfile = new LaunchProfile() {Name = Resources.NoActionProfileName, CommandName=LaunchSettingsProvider.ErrorProfileCommandName};
-                    errorProfile.OtherSettings = ImmutableDictionary<string,object>.Empty.Add("ErrorString", ex.Message);
-                    var snapshot = new LaunchSettings(new List<ILaunchProfile>() {errorProfile},  null, errorProfile.Name);
+                    var errorProfile = new LaunchProfile() { Name = Resources.NoActionProfileName, CommandName = LaunchSettingsProvider.ErrorProfileCommandName };
+                    errorProfile.OtherSettings = ImmutableDictionary<string, object>.Empty.Add("ErrorString", ex.Message);
+                    var snapshot = new LaunchSettings(new List<ILaunchProfile>() { errorProfile }, null, errorProfile.Name);
                     FinishUpdate(snapshot);
                 }
             }
@@ -315,7 +314,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             CurrentSnapshot = newSnapshot;
 
-            if(_broadcastBlock != null)
+            if (_broadcastBlock != null)
             {
                 _broadcastBlock.Post(newSnapshot);
             }
@@ -338,8 +337,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         protected LaunchSettingsData GetLaunchSettings()
         {
-            LaunchSettingsData  settings;
-            if(FileManager.FileExists(LaunchSettingsFile))
+            LaunchSettingsData settings;
+            if (FileManager.FileExists(LaunchSettingsFile))
             {
                 settings = ReadSettingsFileFromDisk();
             }
@@ -352,7 +351,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             }
 
             // Make sure there is at least an empty profile list 
-            if(settings.Profiles == null)
+            if (settings.Profiles == null)
             {
                 settings.Profiles = new List<LaunchProfileData>();
             }
@@ -374,14 +373,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
                 // Since the sections in the settings file are extensible we iterate through each one and have the appropriate provider
                 // serialize their section. Unfortunately, this means the data is string to object which is messy to deal with
-                var launchSettingsData = new LaunchSettingsData() {OtherSettings = new Dictionary<string, object>(StringComparer.Ordinal)};
+                var launchSettingsData = new LaunchSettingsData() { OtherSettings = new Dictionary<string, object>(StringComparer.Ordinal) };
                 JObject jsonObject = JObject.Parse(jsonString);
                 foreach (var pair in jsonObject)
                 {
                     if (pair.Key.Equals(ProfilesSectionName, StringComparison.Ordinal) && pair.Value is JObject)
                     {
                         var profiles = LaunchProfileData.DeserializeProfiles((JObject)pair.Value);
-                        launchSettingsData.Profiles =FixupProfilesAndLogErrors(profiles);
+                        launchSettingsData.Profiles = FixupProfilesAndLogErrors(profiles);
                     }
                     else
                     {
@@ -405,19 +404,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 LastSettingsFileSyncTime = FileManager.LastFileWriteTime(LaunchSettingsFile);
                 return launchSettingsData;
             }
-            catch(JsonReaderException readerEx)
+            catch (JsonReaderException readerEx)
             {
-                string err = string.Format(Resources.JsonErrorReadingLaunchSettings,  readerEx.Message);
+                string err = string.Format(Resources.JsonErrorReadingLaunchSettings, readerEx.Message);
                 LogError(err, LaunchSettingsFile, readerEx.LineNumber, readerEx.LinePosition, false);
                 throw;
             }
-            catch(JsonException jsonEx)
+            catch (JsonException jsonEx)
             {
-                string err = string.Format(Resources.JsonErrorReadingLaunchSettings,  jsonEx.Message);
+                string err = string.Format(Resources.JsonErrorReadingLaunchSettings, jsonEx.Message);
                 LogError(err, LaunchSettingsFile, -1, -1, false);
                 throw;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 string err = string.Format(Resources.ErrorReadingLaunchSettings, Path.Combine(LaunchSettingsFileFolder, LaunchSettingsFilename), ex.Message);
                 LogError(err, false);
@@ -431,15 +430,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         private List<LaunchProfileData> FixupProfilesAndLogErrors(Dictionary<string, LaunchProfileData> profilesData)
         {
-            if(profilesData == null)
+            if (profilesData == null)
             {
                 return null;
             }
 
             List<LaunchProfileData> validProfiles = new List<LaunchProfileData>();
-            foreach(var kvp in profilesData)
+            foreach (var kvp in profilesData)
             {
-                if(!string.IsNullOrWhiteSpace(kvp.Key))
+                if (!string.IsNullOrWhiteSpace(kvp.Key))
                 {
                     // The name is if the profile is set to the value key
                     kvp.Value.Name = kvp.Key;
@@ -447,7 +446,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 }
             }
 
-            if(validProfiles.Count < profilesData.Count)
+            if (validProfiles.Count < profilesData.Count)
             {
                 LogError(Resources.ProfileMissingName, false);
             }
@@ -484,7 +483,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 EnsureSettingsFolder();
 
                 // We don't want to write null values. We want to keep the file as small as possible
-                JsonSerializerSettings settings = new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore};
+                JsonSerializerSettings settings = new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore };
                 string jsonString = JsonConvert.SerializeObject(serializationData, Formatting.Indented, settings);
 
                 IgnoreFileChanges = true;
@@ -493,7 +492,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 // Update the last write time
                 LastSettingsFileSyncTime = FileManager.LastFileWriteTime(LaunchSettingsFile);
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 string err = string.Format(Resources.ErrorWritingDebugSettings, LaunchSettingsFile, ex.Message);
                 LogError(err, false);
@@ -511,10 +510,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         protected Dictionary<string, object> GetSettingsToSerialize(ILaunchSettings curSettings)
         {
-            var profileData = new Dictionary<string,Dictionary<string, object>>(StringComparer.Ordinal);
-            foreach(var profile in curSettings.Profiles)
+            var profileData = new Dictionary<string, Dictionary<string, object>>(StringComparer.Ordinal);
+            foreach (var profile in curSettings.Profiles)
             {
-                if(ProfileShouldBePersisted(profile))
+                if (ProfileShouldBePersisted(profile))
                 {
                     profileData.Add(profile.Name, LaunchProfileData.ToSerializableForm(profile));
                 }
@@ -522,17 +521,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             Dictionary<string, object> dataToSave = new Dictionary<string, object>(StringComparer.Ordinal);
 
-            foreach(var setting in curSettings.GlobalSettings)
+            foreach (var setting in curSettings.GlobalSettings)
             {
                 dataToSave.Add(setting.Key, setting.Value);
             }
 
-            if(profileData.Count > 0)
+            if (profileData.Count > 0)
             {
                 dataToSave.Add(ProfilesSectionName, profileData);
             }
 
-            return dataToSave;            
+            return dataToSave;
         }
 
         /// <summary>
@@ -562,17 +561,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         protected void LaunchSettingsFile_Changed(object sender, FileSystemEventArgs e)
         {
-            
-            if(!IgnoreFileChanges)
+
+            if (!IgnoreFileChanges)
             {
                 // Only do something if the file is truly different than what we synced. Here, we want to 
                 // throttle. 
-                if(!FileManager.FileExists(LaunchSettingsFile) || FileManager.LastFileWriteTime(LaunchSettingsFile) != LastSettingsFileSyncTime)
+                if (!FileManager.FileExists(LaunchSettingsFile) || FileManager.LastFileWriteTime(LaunchSettingsFile) != LastSettingsFileSyncTime)
                 {
-                    FileChangeScheduler.ScheduleAsyncTask(async token => 
-                    {
+                    FileChangeScheduler.ScheduleAsyncTask(async token => {
 
-                        if(token.IsCancellationRequested)
+                        if (token.IsCancellationRequested)
                         {
                             return;
                         }
@@ -600,8 +598,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// Cleans up our watcher on the debugsettings.Json file
         /// </summary>
         private void CleanupFileWatcher()
-        {               
-            if(FileWatcher != null)
+        {
+            if (FileWatcher != null)
             {
                 FileWatcher.Dispose();
                 FileWatcher = null;
@@ -614,17 +612,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         private void WatchLaunchSettingsFile()
         {
-            if(FileWatcher == null)
+            if (FileWatcher == null)
             {
                 // Create our scheduler for processing file chagnes
                 FileChangeScheduler = new TaskDelayScheduler(FileChangeProcessingDelay, CommonProjectServices.ThreadingService,
                     ProjectServices.ProjectAsynchronousTasks.UnloadCancellationToken);
 
-                FileWatcher = new SimpleFileWatcher(Path.GetDirectoryName(CommonProjectServices.Project.FullPath), 
-                                                    true, 
-                                                    NotifyFilters.FileName | NotifyFilters.Size |  NotifyFilters.LastWrite, 
-                                                    LaunchSettingsFilename, 
-                                                    LaunchSettingsFile_Changed, 
+                FileWatcher = new SimpleFileWatcher(Path.GetDirectoryName(CommonProjectServices.Project.FullPath),
+                                                    true,
+                                                    NotifyFilters.FileName | NotifyFilters.Size | NotifyFilters.LastWrite,
+                                                    LaunchSettingsFilename,
+                                                    LaunchSettingsFile_Changed,
                                                     LaunchSettingsFile_Changed);
             }
         }
@@ -635,22 +633,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// <param name="disposing"></param>
         protected override void Dispose(bool disposing)
         {
-            if(disposing)
+            if (disposing)
             {
                 CleanupFileWatcher();
-                if(FileChangeScheduler != null)
+                if (FileChangeScheduler != null)
                 {
                     FileChangeScheduler.Dispose();
                     FileChangeScheduler = null;
                 }
 
-                if(_broadcastBlock != null)
+                if (_broadcastBlock != null)
                 {
                     _broadcastBlock.Complete();
                     _broadcastBlock = null;
                 }
 
-                if(ProjectRuleSubscriptionLink != null)
+                if (ProjectRuleSubscriptionLink != null)
                 {
                     ProjectRuleSubscriptionLink.Dispose();
                     ProjectRuleSubscriptionLink = null;
@@ -681,7 +679,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         public async Task<ILaunchSettings> WaitForFirstSnapshot(int timeout)
         {
-            if(CurrentSnapshot != null)
+            if (CurrentSnapshot != null)
             {
                 return CurrentSnapshot;
             }


### PR DESCRIPTION
We're turning on the naming/code style rules by default (see https://github.com/dotnet/roslyn-project-system/pull/1002), the following fixes the naming issues across the tree.