### PR TITLE
Any error from xUnit should break build

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -104,7 +104,7 @@
       <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
     </Exec>
 
-    <Error Text="There were test failures, for full log see %(HtmlTestFile.FullPath)" Condition="$(ExitCode) == 1" />
+    <Error Text="There were test failures, for full log see %(HtmlTestFile.FullPath)" Condition="$(ExitCode) != 0" />
 
   </Target>
 


### PR DESCRIPTION
xUnit was returning 4 when there were test failures, as a result we were calling this a "successful build". Any non-zero exit code from xUnit will now break the build.