### PR TITLE
Revert "Enable Extension deployment in Jenkins build"

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -9,6 +9,7 @@ set NodeReuse=true
 set DeveloperCommandPrompt=%VS150COMNTOOLS%\VsDevCmd.bat
 set MSBuildAdditionalArguments=/m
 set RunTests=true
+set DeployVsixExtension=true
 
 :ParseArguments
 if "%1" == "" goto :DoneParsing
@@ -19,6 +20,7 @@ if /I "%1" == "/rebuild" set MSBuildTarget=Rebuild&&shift&& goto :ParseArguments
 if /I "%1" == "/restore" set MSBuildTarget=RestorePackages&&shift&& goto :ParseArguments
 if /I "%1" == "/modernvsixonly" set MSBuildTarget=BuildModernVsixPackages&&shift&& goto :ParseArguments
 if /I "%1" == "/skiptests" set RunTests=false&&shift&& goto :ParseArguments
+if /I "%1" == "/no-deploy-extension" set DeployVsixExtension=false&&shift&& goto :ParseArguments
 if /I "%1" == "/no-node-reuse" set NodeReuse=false&&shift&& goto :ParseArguments
 if /I "%1" == "/no-multi-proc" set MSBuildAdditionalArguments=&&shift&& goto :ParseArguments
 call :Usage && exit /b 1
@@ -47,7 +49,7 @@ set BinariesDirectory=%Root%bin\%BuildConfiguration%\
 set LogFile=%BinariesDirectory%Build.log
 if not exist "%BinariesDirectory%" mkdir "%BinariesDirectory%" || goto :BuildFailed
 
-msbuild /nologo /nodeReuse:%NodeReuse% /consoleloggerparameters:Verbosity=minimal /fileLogger /fileloggerparameters:LogFile="%LogFile%";verbosity=diagnostic /t:"%MSBuildTarget%" /p:Configuration="%BuildConfiguration%" /p:RunTests="%RunTests%" "%Root%build\build.proj" %MSBuildAdditionalArguments%
+msbuild /nologo /nodeReuse:%NodeReuse% /consoleloggerparameters:Verbosity=minimal /fileLogger /fileloggerparameters:LogFile="%LogFile%";verbosity=diagnostic /t:"%MSBuildTarget%" /p:Configuration="%BuildConfiguration%" /p:RunTests="%RunTests%" /p:DeployVsixExtension="%DeployVsixExtension%" "%Root%build\build.proj" %MSBuildAdditionalArguments%
 if ERRORLEVEL 1 (
     echo.
     call :PrintColor Red "Build failed, for full log see %LogFile%."
@@ -73,6 +75,7 @@ echo     /release                 Perform release build
 echo     /no-node-reuse           Prevents MSBuild from reusing existing MSBuild instances,
 echo                              useful for avoiding unexpected behavior on build machines
 echo     /no-multi-proc           No multi-proc build, useful for diagnosing build logs
+echo     /no-deploy-extension     Does not deploy the VSIX extension when building the solution
 goto :eof
 
 :BuildFailed

--- a/netci.groovy
+++ b/netci.groovy
@@ -21,7 +21,7 @@ def branch = GithubBranchName
 SET VSSDK150Install=%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\Enterprise\\VSSDK\\
 SET VSSDKInstall=%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\Enterprise\\VSSDK\\
 
-build.cmd /${configuration.toLowerCase()}""")
+build.cmd /no-deploy-extension /${configuration.toLowerCase()}""")
             }
         }
 

--- a/src/ProjectSystemDogfoodSetup/ProjectSystemDogfoodSetup.csproj
+++ b/src/ProjectSystemDogfoodSetup/ProjectSystemDogfoodSetup.csproj
@@ -17,6 +17,7 @@
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
     <ImportVSSDKTargets>true</ImportVSSDKTargets>
+    <DeployExtension Condition="'$(DeployVsixExtension)' == 'false'">false</DeployExtension>
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>

--- a/src/ProjectSystemSetup/ProjectSystemSetup.csproj
+++ b/src/ProjectSystemSetup/ProjectSystemSetup.csproj
@@ -17,6 +17,7 @@
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
     <ImportVSSDKTargets>true</ImportVSSDKTargets>
+    <DeployExtension Condition="'$(DeployVsixExtension)' == 'false'">false</DeployExtension>
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>

--- a/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
+++ b/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
@@ -20,6 +20,7 @@
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
     <ImportVSSDKTargets>true</ImportVSSDKTargets>
+    <DeployExtension Condition="'$(DeployVsixExtension)' == 'false'">false</DeployExtension>
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>


### PR DESCRIPTION
Reverts dotnet/roslyn-project-system#918. The auto-imaged machines are having licensing issues. @tannergooding is working on it, but until then, deploying extensions will randomly fail. Tagging @dotnet/project-system for review.