### PR TITLE
Bug fixes for Project dependency tree nodes hierarchy

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -160,6 +160,7 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="WindowsBase" />
   </ItemGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesGraphProjectContextProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesGraphProjectContextProviderFactory.cs
@@ -36,6 +36,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             return mock.Object;
         }
 
+        public static IDependenciesGraphProjectContextProvider ImplementMultipleProjects(
+                                IDictionary<string, IProjectDependenciesSubTreeProvider> contexts,
+                                MockBehavior? mockBehavior = null)
+        {
+            var behavior = mockBehavior ?? MockBehavior.Default;
+            var mock = new Mock<IDependenciesGraphProjectContextProvider>(behavior);
+            var listOfAllContexts = new List<IDependenciesGraphProjectContext>();
+
+            foreach(var kvp in contexts)
+            {
+                var mockProjectContext = new Mock<IDependenciesGraphProjectContext>();
+                mock.Setup(x => x.GetProjectContext(kvp.Key)).Returns(mockProjectContext.Object);
+                mockProjectContext.Setup(x => x.GetProvider("MyProvider")).Returns(kvp.Value);
+                listOfAllContexts.Add(mockProjectContext.Object);
+            }
+
+            mock.Setup(x => x.GetProjectContexts()).Returns(listOfAllContexts);
+
+            return mock.Object;
+        }
+
         public static IDependenciesGraphProjectContext ImplementProjectContext(
                         string projectPath,
                         MockBehavior? mockBehavior = null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectDependenciesSubTreeProviderMock.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectDependenciesSubTreeProviderMock.cs
@@ -11,6 +11,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     internal class IProjectDependenciesSubTreeProviderMock: IProjectDependenciesSubTreeProvider
     {
+        private string _providerTestType = "MyDefaultTestProvider";
+        public string ProviderTestType
+        {
+            get
+            {
+                return _providerTestType;
+            }
+            set
+            {
+                _providerTestType = value;
+            }
+        }
+
         public string ProviderType
         {
             get

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyNodeIdTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyNodeIdTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Web;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
@@ -21,45 +22,55 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Theory]
-        [InlineData("MyProviderType", "MyItemSpec", "MyItemType", "MyUniqueToken",
-                    "file:///[MyProviderType;MyItemSpec;MyItemType;MyUniqueToken]")]
-        [InlineData("MyProviderType", "MyItemSpec", "MyItemType", null,
-                    "file:///[MyProviderType;MyItemSpec;MyItemType;]")]
-        [InlineData("MyProviderType", "MyItemSpec", "", null,
-                    "file:///[MyProviderType;MyItemSpec;;]")]
-        [InlineData("MyProviderType", null, null, null,
-                    "file:///[MyProviderType;;;]")]
-        [InlineData("MyProviderType", null, "MyItemType", null,
-                    "file:///[MyProviderType;;MyItemType;]")]
-        [InlineData("MyProviderType", null, null, "MyUniqueToken",
-                    "file:///[MyProviderType;;;MyUniqueToken]")]
+        [InlineData("MyProviderType", "MyItemSpec", "MyItemType", "MyUniqueToken", "MyContextProject",
+                    "file:///[MyProviderType;MyItemSpec;MyItemType;MyUniqueToken;MyContextProject]")]
+        [InlineData("MyProviderType", "MyItemSpec", "MyItemType", null, null,
+                    "file:///[MyProviderType;MyItemSpec;MyItemType;;]")]
+        [InlineData("MyProviderType", "MyItemSpec", "", null, null,
+                    "file:///[MyProviderType;MyItemSpec;;;]")]
+        [InlineData("MyProviderType", null, null, null, null,
+                    "file:///[MyProviderType;;;;]")]
+        [InlineData("MyProviderType", null, "MyItemType", null, null,
+                    "file:///[MyProviderType;;MyItemType;;]")]
+        [InlineData("MyProviderType", null, null, "MyUniqueToken", null,
+                    "file:///[MyProviderType;;;MyUniqueToken;]")]
         public void DependencyNodeId_ToString(string providerType,
-                                                   string itemSpec,
-                                                   string itemType,
-                                                   string uniqueToken,
-                                                   string expectedResult)
+                                              string itemSpec,
+                                              string itemType,
+                                              string uniqueToken,
+                                              string contextProject,
+                                              string expectedResult)
         {
             var id = new DependencyNodeId(providerType, itemSpec, itemType, uniqueToken);
+            if (!string.IsNullOrEmpty(contextProject))
+            {
+                id.ContextProject = contextProject;
+            }
 
-            Assert.Equal(expectedResult, id.ToString());
+            Assert.Equal(HttpUtility.UrlEncode(expectedResult), id.ToString());
         }
 
         [Theory]
-        [InlineData("MyProviderType", @"c:/somepath/xxx", "MyItemType", "c:/otherfolder/otherpath",
-                    @"file:///[MyProviderType;c:\somepath\xxx;MyItemType;c:\otherfolder\otherpath]")]
-        [InlineData("MyProviderType", @"c:/somepath/xxx", "MyItemType", null,
-                    @"file:///[MyProviderType;c:\somepath\xxx;MyItemType;]")]
-        [InlineData("MyProviderType", null, null, null,
-                    "file:///[MyProviderType;;;]")]
+        [InlineData("MyProviderType", @"c:/somepath/xxx", "MyItemType", "c:/otherfolder/otherpath", @"c:/mycontextproject/path",
+                    @"file:///[MyProviderType;c:\somepath\xxx;MyItemType;c:\otherfolder\otherpath;c:\mycontextproject\path]")]
+        [InlineData("MyProviderType", @"c:/somepath/xxx", "MyItemType", null, null,
+                    @"file:///[MyProviderType;c:\somepath\xxx;MyItemType;;]")]
+        [InlineData("MyProviderType", null, null, null, null,
+                    "file:///[MyProviderType;;;;]")]
         public void DependencyNodeId_ToNormalizedId(string providerType,
                                                    string itemSpec,
                                                    string itemType,
                                                    string uniqueToken,
+                                                   string contextProject,
                                                    string expectedResult)
         {
             var id = new DependencyNodeId(providerType, itemSpec, itemType, uniqueToken);
+            if (!string.IsNullOrEmpty(contextProject))
+            {
+                id.ContextProject = contextProject;
+            }
 
-            Assert.Equal(expectedResult, id.ToNormalizedId().ToString());
+            Assert.Equal(HttpUtility.UrlEncode(expectedResult), id.ToNormalizedId().ToString());
         }
 
         [Theory]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/ProjectDependenciesSubTreeProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/ProjectDependenciesSubTreeProviderTests.cs
@@ -51,10 +51,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
     ""Id"": {
         ""ProviderType"": ""ProviderUnderTest"",
-        ""ItemSpec"": ""MyDependencyNodeItemSpec1"",
-        ""UniqueToken"":""c:\\myproject\\project.csproj""
+        ""ItemSpec"": ""MyDependencyNodeItemSpec1""
     }
 }");
+            myDependencyNode1.Id.ContextProject = "c:\\myproject\\project.csproj";
 
             myTopNode1.Children.Add(myDependencyNode1);
             myRootNode.Children.Add(myTopNode1);
@@ -155,7 +155,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var resultNode = provider.TestCreateDependencyNode(testProjectPath, "myItemType");
 
             Assert.Equal(resultNode.Id.ItemSpec, testProjectPath);
-            Assert.Equal(resultNode.Id.UniqueToken, 
+            Assert.Equal(resultNode.Id.ContextProject, 
                          Path.GetFullPath(Path.Combine(Path.GetDirectoryName(projectPath), testProjectPath)));
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -264,6 +264,7 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="WindowsBase" />
     <Reference Include="WindowsFormsIntegration" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProvider.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     /// </summary>
     [GraphProvider(Name = "Microsoft.VisualStudio.ProjectSystem.VS.Tree.DependenciesNodeGraphProvider",
                    ProjectCapability = "DependenciesTree")]
-    internal class DependenciesGraphProvider : OnceInitializedOnceDisposedAsync, IGraphProvider, IGraphNodeBrowsablePropertiesProvider
+    internal class DependenciesGraphProvider : OnceInitializedOnceDisposedAsync, IGraphProvider
     {
         private readonly GraphCommand ContainsGraphCommand = new GraphCommand(
                 GraphCommandDefinition.Contains,
@@ -122,22 +122,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// </summary>
         T IGraphProvider.GetExtension<T>(GraphObject graphObject, T previous)
         {
-            var graphNode = graphObject as GraphNode;
-            if (graphNode == null)
-            {
-                return null;
-            }
-
-            if (graphNode.GetValue<IDependencyNode>(DependenciesGraphSchema.DependencyNodeProperty) == null)
-            {
-                return null;
-            }
-
-            if (typeof(T) == typeof(IGraphNodeBrowsablePropertiesProvider))
-            {
-                return this as T;
-            }
-
             return null;
         }
 
@@ -246,7 +230,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     continue;
                 }
 
-                var (node, subTreeProvider) = await GetDependencyNodeInfo(graphContext, inputGraphNode, projectPath).ConfigureAwait(false);
+                var (node, subTreeProvider) = await GetDependencyNodeInfo(graphContext, inputGraphNode, projectPath)
+                                                        .ConfigureAwait(false);
                 if (node == null || subTreeProvider == null)
                 {
                     continue;
@@ -293,7 +278,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     continue;
                 }
 
-                var (node, subTreeProvider) = await GetDependencyNodeInfo(graphContext, inputGraphNode, projectPath).ConfigureAwait(false);
+                var (node, subTreeProvider) = await GetDependencyNodeInfo(graphContext, inputGraphNode, projectPath)
+                                                        .ConfigureAwait(false);
                 if (node == null || subTreeProvider == null)
                 {
                     continue;
@@ -452,14 +438,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// clicks on "Scope To This" context menu we get GetChildrenAsync call right away and need to be 
         /// able to discover IDependencyNode form the scratch.
         /// </summary>
-        private async Task<(IDependencyNode node, IProjectDependenciesSubTreeProvider subTreeProvider)> GetDependencyNodeInfo(IGraphContext graphContext,
-                                                                     GraphNode inputGraphNode,
-                                                                     string projectPath)
+        private async Task<(IDependencyNode node, IProjectDependenciesSubTreeProvider subTreeProvider)> 
+            GetDependencyNodeInfo(IGraphContext graphContext, GraphNode inputGraphNode, string projectPath)
         {
             (IDependencyNode node, IProjectDependenciesSubTreeProvider subTreeProvider) = (null, null);
 
-            node = inputGraphNode.GetValue<IDependencyNode>(
-                                DependenciesGraphSchema.DependencyNodeProperty);
+            node = inputGraphNode.GetValue<IDependencyNode>(DependenciesGraphSchema.DependencyNodeProperty);
             if (node == null)
             {
                 // All graph nodes generated here will have this unique node id, root node will have it equal to null

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -227,7 +227,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         ///     - dependency sub tree nodes
         ///     - dependency sub tree top level nodes
         /// (deeper levels will be graph nodes with additional info, not direct dependencies
-        /// specified in the project file or project.json)
+        /// specified in the project file)
         /// </summary>
         public override IProjectTree FindByPath(IProjectTree root, string path)
         {
@@ -237,13 +237,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 return null;
             }
 
-            // Note: all dependency nodes file path starts with file:/// to make sure we have 
-            // valid absolute path everytime.
-            if (!path.StartsWith("file:///"))
-            {
-                // just in case if given path is not in uri format
-                path = "file:///" + path.Trim('/');
-            }
+            // Note: all dependency nodes file path starts with file%3a (encoded 'file:'). 
+            // So if given path is not starting with file%3a, we are not responsible for it.
+            //if (!path.StartsWith("file%3a"))
+            //{
+            //    return null;
+            //}
 
             var node = dependenciesNode.FindNodeByPath(path);
             if (node == null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
@@ -34,13 +34,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// Note: when dependency has ProjectTreeFlags.Common.BrokenReference flag, GraphProvider API are not 
         /// called for that node.
         /// </summary>
-        private static readonly ProjectTreeFlags UnresolvedReferenceFlags
+        protected static readonly ProjectTreeFlags UnresolvedReferenceFlags
                 = BaseReferenceFlags.Add(ProjectTreeFlags.Common.BrokenReference);
 
         /// <summary>
         /// The set of flags to assign to resolved Reference nodes.
         /// </summary>
-        private static readonly ProjectTreeFlags ResolvedReferenceFlags
+        protected static readonly ProjectTreeFlags ResolvedReferenceFlags
                 = BaseReferenceFlags.Add(ProjectTreeFlags.Common.ResolvedReference);
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ProjectDependenciesSubTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ProjectDependenciesSubTreeProvider.cs
@@ -99,8 +99,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var id = new DependencyNodeId(ProviderType,
                                           itemSpec,
                                           itemType ?? ResolvedProjectReference.PrimaryDataSourceItemType,
-                                          uniqueToken: projectPath);
-
+                                          uniqueToken: null)
+            {
+                ContextProject = projectPath
+            };
             return CreateDependencyNode(id, priority, properties, resolved);
         }
 
@@ -147,12 +149,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 return null;
             }
 
-            if (string.IsNullOrEmpty(nodeId.UniqueToken))
+            if (string.IsNullOrEmpty(nodeId.ContextProject))
             {
                 return node;
             }
 
-            var projectPath = nodeId.UniqueToken;
+            var projectPath = nodeId.ContextProject;
             var projectContext = ProjectContextProvider.GetProjectContext(projectPath);
             if (projectContext == null)
             {


### PR DESCRIPTION
There were several issues with Project nodes hierarchy:
- when A -> B and B is several levels above A, like ..\..\..\b.csproj, progression code cut node id string when coverted it to AbsoluteOr Relative Uri. We need to UrlEncode/Decode id string for nodes.
- other issue is we need to use Project B dependency providers when querying hierarchy nodes under project A Dependencies to show hierarchy correctly: A -> B (and B has packages specific to B) . Before we used providers from project A and they did not know about nodes specific to B and worked only when A also had same packages as B.
