### PR TITLE
Bug fixes for Project nodes hierarchy

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesGraphProjectContextProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesGraphProjectContextProviderFactory.cs
@@ -36,6 +36,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             return mock.Object;
         }
 
+        public static IDependenciesGraphProjectContextProvider ImplementMultipleProjects(
+                                IDictionary<string, IProjectDependenciesSubTreeProvider> contexts,
+                                MockBehavior? mockBehavior = null)
+        {
+            var behavior = mockBehavior ?? MockBehavior.Default;
+            var mock = new Mock<IDependenciesGraphProjectContextProvider>(behavior);
+            var listOfAllContexts = new List<IDependenciesGraphProjectContext>();
+
+            foreach(var kvp in contexts)
+            {
+                var mockProjectContext = new Mock<IDependenciesGraphProjectContext>();
+                mock.Setup(x => x.GetProjectContext(kvp.Key)).Returns(mockProjectContext.Object);
+                mockProjectContext.Setup(x => x.GetProvider("MyProvider")).Returns(kvp.Value);
+                listOfAllContexts.Add(mockProjectContext.Object);
+            }
+
+            mock.Setup(x => x.GetProjectContexts()).Returns(listOfAllContexts);
+
+            return mock.Object;
+        }
+
         public static IDependenciesGraphProjectContext ImplementProjectContext(
                         string projectPath,
                         MockBehavior? mockBehavior = null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectDependenciesSubTreeProviderMock.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectDependenciesSubTreeProviderMock.cs
@@ -11,6 +11,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     internal class IProjectDependenciesSubTreeProviderMock: IProjectDependenciesSubTreeProvider
     {
+        private string _providerTestType = "MyDefaultTestProvider";
+        public string ProviderTestType
+        {
+            get
+            {
+                return _providerTestType;
+            }
+            set
+            {
+                _providerTestType = value;
+            }
+        }
+
         public string ProviderType
         {
             get

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyNodeIdTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyNodeIdTests.cs
@@ -21,71 +21,82 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Theory]
-        [InlineData("MyProviderType", "MyItemSpec", "MyItemType", "MyUniqueToken",
-                    "file:///[MyProviderType;MyItemSpec;MyItemType;MyUniqueToken]")]
-        [InlineData("MyProviderType", "MyItemSpec", "MyItemType", null,
-                    "file:///[MyProviderType;MyItemSpec;MyItemType;]")]
-        [InlineData("MyProviderType", "MyItemSpec", "", null,
-                    "file:///[MyProviderType;MyItemSpec;;]")]
-        [InlineData("MyProviderType", null, null, null,
-                    "file:///[MyProviderType;;;]")]
-        [InlineData("MyProviderType", null, "MyItemType", null,
-                    "file:///[MyProviderType;;MyItemType;]")]
-        [InlineData("MyProviderType", null, null, "MyUniqueToken",
-                    "file:///[MyProviderType;;;MyUniqueToken]")]
+        [InlineData("MyProviderType", "..\\MyItemSpec", "MyItemType", "MyUniqueToken", "..\\MyContextProject",
+                    "file:///[MyProviderType;**\\MyItemSpec;MyItemType;MyUniqueToken;**\\MyContextProject]")]
+        [InlineData("MyProviderType", "MyItemSpec", "MyItemType", null, null,
+                    "file:///[MyProviderType;MyItemSpec;MyItemType;;]")]
+        [InlineData("MyProviderType", "MyItemSpec", "", null, null,
+                    "file:///[MyProviderType;MyItemSpec;;;]")]
+        [InlineData("MyProviderType", null, null, null, null,
+                    "file:///[MyProviderType;;;;]")]
+        [InlineData("MyProviderType", null, "MyItemType", null, null,
+                    "file:///[MyProviderType;;MyItemType;;]")]
+        [InlineData("MyProviderType", null, null, "MyUniqueToken", null,
+                    "file:///[MyProviderType;;;MyUniqueToken;]")]
         public void DependencyNodeId_ToString(string providerType,
-                                                   string itemSpec,
-                                                   string itemType,
-                                                   string uniqueToken,
-                                                   string expectedResult)
+                                              string itemSpec,
+                                              string itemType,
+                                              string uniqueToken,
+                                              string contextProject,
+                                              string expectedResult)
         {
             var id = new DependencyNodeId(providerType, itemSpec, itemType, uniqueToken);
+            if (!string.IsNullOrEmpty(contextProject))
+            {
+                id.ContextProject = contextProject;
+            }
 
             Assert.Equal(expectedResult, id.ToString());
         }
 
         [Theory]
-        [InlineData("MyProviderType", @"c:/somepath/xxx", "MyItemType", "c:/otherfolder/otherpath",
-                    @"file:///[MyProviderType;c:\somepath\xxx;MyItemType;c:\otherfolder\otherpath]")]
-        [InlineData("MyProviderType", @"c:/somepath/xxx", "MyItemType", null,
-                    @"file:///[MyProviderType;c:\somepath\xxx;MyItemType;]")]
-        [InlineData("MyProviderType", null, null, null,
-                    "file:///[MyProviderType;;;]")]
+        [InlineData("MyProviderType", @"c:/somepath/xxx", "MyItemType", "c:/otherfolder/otherpath", @"c:/mycontextproject/path",
+                    @"file:///[MyProviderType;c:\somepath\xxx;MyItemType;c:\otherfolder\otherpath;c:\mycontextproject\path]")]
+        [InlineData("MyProviderType", @"c:/somepath/xxx", "MyItemType", null, null,
+                    @"file:///[MyProviderType;c:\somepath\xxx;MyItemType;;]")]
+        [InlineData("MyProviderType", null, null, null, null,
+                    "file:///[MyProviderType;;;;]")]
         public void DependencyNodeId_ToNormalizedId(string providerType,
                                                    string itemSpec,
                                                    string itemType,
                                                    string uniqueToken,
+                                                   string contextProject,
                                                    string expectedResult)
         {
             var id = new DependencyNodeId(providerType, itemSpec, itemType, uniqueToken);
+            if (!string.IsNullOrEmpty(contextProject))
+            {
+                id.ContextProject = contextProject;
+            }
 
             Assert.Equal(expectedResult, id.ToNormalizedId().ToString());
         }
 
         [Theory]
-        [InlineData("file:///[MyProviderType;MyItemSpec;MyItemType;MyUniqueToken]",
-                    "MyProviderType", "MyItemSpec", "MyItemType", "MyUniqueToken")]
+        [InlineData("file:///[MyProviderType;**\\MyItemSpec;MyItemType;MyUniqueToken;**\\MyContextProject]",
+                    "MyProviderType", "..\\MyItemSpec", "MyItemType", "MyUniqueToken", "..\\MyContextProject")]
         [InlineData("",
-                    null, null, null, null)]
+                    null, null, null, null, null)]
         [InlineData(null,
-                    null, null, null, null)]
+                    null, null, null, null, null)]
         [InlineData("file:///MyProviderType;MyItemSpec;MyItemType;MyUniqueToken",
-                    null, null, null, null)]
+                    null, null, null, null, null)]
         [InlineData("MyProviderType;MyItemSpec;MyItemType;MyUniqueToken",
-                    null, null, null, null)]
+                    null, null, null, null, null)]
         [InlineData("file:///[MyProviderType;MyItemSpec;MyItemType]",
-                    "MyProviderType", "MyItemSpec", "MyItemType", "")]
+                    "MyProviderType", "MyItemSpec", "MyItemType", "", "")]
         [InlineData("file:///[MyProviderType;MyItemSpec]",
-                    "MyProviderType", "MyItemSpec", "", "")]
+                    "MyProviderType", "MyItemSpec", "", "", "")]
         [InlineData("file:///[MyProviderType]",
-                    "MyProviderType", "", "", "")]
+                    "MyProviderType", "", "", "", "")]
         [InlineData("file:///[]",
-                    null, null, null, null)]
+                    null, null, null, null, null)]
         public void DependencyNodeId_FromString(string input,
                                                      string expectedProviderType,
                                                      string expectedItemSpec,
                                                      string expectedItemType,
-                                                     string expectedUniqueToken)
+                                                     string expectedUniqueToken,
+                                                     string expectedContextProject)
                                                    
         {
 
@@ -102,6 +113,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 Assert.Equal(expectedItemSpec, id.ItemSpec);
                 Assert.Equal(expectedItemType, id.ItemType);
                 Assert.Equal(expectedUniqueToken, id.UniqueToken);
+                Assert.Equal(expectedContextProject, id.ContextProject);
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/ProjectDependenciesSubTreeProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/ProjectDependenciesSubTreeProviderTests.cs
@@ -51,10 +51,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
     ""Id"": {
         ""ProviderType"": ""ProviderUnderTest"",
-        ""ItemSpec"": ""MyDependencyNodeItemSpec1"",
-        ""UniqueToken"":""c:\\myproject\\project.csproj""
+        ""ItemSpec"": ""MyDependencyNodeItemSpec1""
     }
 }");
+            myDependencyNode1.Id.ContextProject = "c:\\myproject\\project.csproj";
 
             myTopNode1.Children.Add(myDependencyNode1);
             myRootNode.Children.Add(myTopNode1);
@@ -155,7 +155,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var resultNode = provider.TestCreateDependencyNode(testProjectPath, "myItemType");
 
             Assert.Equal(resultNode.Id.ItemSpec, testProjectPath);
-            Assert.Equal(resultNode.Id.UniqueToken, 
+            Assert.Equal(resultNode.Id.ContextProject, 
                          Path.GetFullPath(Path.Combine(Path.GetDirectoryName(projectPath), testProjectPath)));
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -227,7 +227,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         ///     - dependency sub tree nodes
         ///     - dependency sub tree top level nodes
         /// (deeper levels will be graph nodes with additional info, not direct dependencies
-        /// specified in the project file or project.json)
+        /// specified in the project file)
         /// </summary>
         public override IProjectTree FindByPath(IProjectTree root, string path)
         {
@@ -237,11 +237,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 return null;
             }
 
-            // Note: all dependency nodes file path starts with file:/// to make sure we have 
-            // valid absolute path everytime.
+            // Note: all dependency nodes file path starts with file:///, but FindByPath is called eventually 
+            // from ParseCanonicalName, which in turn called from progression's SourceFileToHierarchyItem where
+            // LocalPath of the Uri is passed, not full Uri during search. Thus here we need to append file:/// 
+            // if it is not there.
             if (!path.StartsWith("file:///"))
             {
-                // just in case if given path is not in uri format
                 path = "file:///" + path.Trim('/');
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ProjectDependenciesSubTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ProjectDependenciesSubTreeProvider.cs
@@ -99,8 +99,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var id = new DependencyNodeId(ProviderType,
                                           itemSpec,
                                           itemType ?? ResolvedProjectReference.PrimaryDataSourceItemType,
-                                          uniqueToken: projectPath);
-
+                                          uniqueToken: null)
+            {
+                ContextProject = projectPath
+            };
             return CreateDependencyNode(id, priority, properties, resolved);
         }
 
@@ -147,12 +149,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 return null;
             }
 
-            if (string.IsNullOrEmpty(nodeId.UniqueToken))
+            if (string.IsNullOrEmpty(nodeId.ContextProject))
             {
                 return node;
             }
 
-            var projectPath = nodeId.UniqueToken;
+            var projectPath = nodeId.ContextProject;
             var projectContext = ProjectContextProvider.GetProjectContext(projectPath);
             if (projectContext == null)
             {


### PR DESCRIPTION
There were several issues with Project nodes hierarchy:

- when A -> B and B is several levels above A, like ..\..\..\b.csproj, progression code cut node id string when converted it toUri.LocalPath. We need to Escape . with some other symbol (*) to avoid that.
- other issue is we need to use Project B dependency providers when querying hierarchy nodes under project A Dependencies to show hierarchy correctly: A -> B (and B has packages specific to B) . Before we used providers from project A and they did not know about nodes specific to B and worked only when A also had same packages as B.