### PR TITLE
Implement Pack command

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -70,6 +70,8 @@
     <Compile Include="Mocks\ITextBufferFactory.cs" />
     <Compile Include="Mocks\ITextDocumentFactory.cs" />
     <Compile Include="Mocks\ITextDocumentFactoryServiceFactory.cs" />
+    <Compile Include="Mocks\IVsUpdateSolutionEventsFactory.cs" />
+    <Compile Include="Mocks\IVsSolutionBuildManager2Factory.cs" />
     <Compile Include="Mocks\IVsEditorAdaptersFactoryServiceFactory.cs" />
     <Compile Include="Mocks\IVsPersistDocDataFactory.cs" />
     <Compile Include="Mocks\IVsProjectSpecialFilesFactory.cs" />
@@ -113,6 +115,9 @@
     <Compile Include="ProjectSystem\VS\Generators\GeneratorExtensionRegistrationAttributeTests.cs" />
     <Compile Include="ProjectSystem\VS\Generators\SingleFileGeneratorFactoryAggregatorTests.cs" />
     <Compile Include="ProjectSystem\VS\Generators\RemoteCodeGenerationRegistrationAttributeTests.cs" />
+    <Compile Include="ProjectSystem\VS\Input\Commands\AbstractGenerateNuGetPackageCommandTests.cs" />
+    <Compile Include="ProjectSystem\VS\Input\Commands\GenerateNuGetPackageProjectContextMenuCommandTests.cs" />
+    <Compile Include="ProjectSystem\VS\Input\Commands\GenerateNuGetPackageTopLevelBuildMenuCommandTests.cs" />
     <Compile Include="ProjectSystem\VS\Input\Commands\EditProjectFileCommandTests.cs" />
     <Compile Include="ProjectSystem\VS\Input\Commands\AbstractOpenProjectDesignerCommandTests.cs" />
     <Compile Include="ProjectSystem\VS\Input\Commands\AbstractAddClassProjectCommandTests.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsSolutionBuildManager2Factory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsSolutionBuildManager2Factory.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+using System;
+
+namespace Microsoft.VisualStudio.Shell.Interop
+{
+    internal static class IVsSolutionBuildManager2Factory
+    {
+        public static IVsSolutionBuildManager2 Create(IVsUpdateSolutionEvents solutionEventsListener = null, IVsHierarchy hierarchyToBuild = null, Func<bool> isBuilding = null, bool cancelBuild = false)
+        {
+            var buildManager = new Mock<IVsSolutionBuildManager2>();
+
+            solutionEventsListener = solutionEventsListener ?? IVsUpdateSolutionEventsFactory.Create();
+            hierarchyToBuild = hierarchyToBuild ?? IVsHierarchyFactory.Create();
+
+            isBuilding = isBuilding ?? new Func<bool>(() => false);
+            var isBusy = isBuilding() ? 1 : 0;
+
+            buildManager.Setup(b => b.QueryBuildManagerBusy(out isBusy))
+                .Returns(VSConstants.S_OK);
+
+            if (hierarchyToBuild != null)
+            {
+                Func<int> onBuildStartedWithReturn = () => {
+                    solutionEventsListener.UpdateSolution_Begin(It.IsAny<int>());
+                    
+                    if (cancelBuild)
+                    {
+                        solutionEventsListener.UpdateSolution_Cancel();
+                    }
+                    else
+                    {
+                        solutionEventsListener.UpdateSolution_Done(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>());
+                    }
+
+                    return VSConstants.S_OK;
+                };
+
+                uint dwFlags = (uint)(VSSOLNBUILDUPDATEFLAGS.SBF_SUPPRESS_SAVEBEFOREBUILD_QUERY | VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD);
+                buildManager.Setup(b => b.StartSimpleUpdateProjectConfiguration(hierarchyToBuild, It.IsAny<IVsHierarchy>(), It.IsAny<string>(), dwFlags, It.IsAny<uint>(), It.IsAny<int>()))
+                    .Returns(onBuildStartedWithReturn);
+            }
+
+            return buildManager.Object;
+        }
+
+        private static int DefaultBuildManagerBusy(int isBusy)
+        {
+            return VSConstants.S_OK;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsSolutionBuildManager2Factory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsSolutionBuildManager2Factory.cs
@@ -7,16 +7,14 @@ namespace Microsoft.VisualStudio.Shell.Interop
 {
     internal static class IVsSolutionBuildManager2Factory
     {
-        public static IVsSolutionBuildManager2 Create(IVsUpdateSolutionEvents solutionEventsListener = null, IVsHierarchy hierarchyToBuild = null, Func<bool> isBuilding = null, bool cancelBuild = false)
+        public static IVsSolutionBuildManager2 Create(IVsUpdateSolutionEvents solutionEventsListener = null, IVsHierarchy hierarchyToBuild = null, bool isBuilding = false, bool cancelBuild = false)
         {
             var buildManager = new Mock<IVsSolutionBuildManager2>();
 
             solutionEventsListener = solutionEventsListener ?? IVsUpdateSolutionEventsFactory.Create();
             hierarchyToBuild = hierarchyToBuild ?? IVsHierarchyFactory.Create();
 
-            isBuilding = isBuilding ?? new Func<bool>(() => false);
-            var isBusy = isBuilding() ? 1 : 0;
-
+            int isBusy = isBuilding ? 1 : 0;
             buildManager.Setup(b => b.QueryBuildManagerBusy(out isBusy))
                 .Returns(VSConstants.S_OK);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsUpdateSolutionEventsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsUpdateSolutionEventsFactory.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+using System;
+
+namespace Microsoft.VisualStudio.Shell.Interop
+{
+    internal static class IVsUpdateSolutionEventsFactory
+    {
+        public static IVsUpdateSolutionEvents Create(Action onUpdateSolutionBegin = null, Action onUpdateSolutionCancel = null, Action onUpdateSolutionDone = null)
+        {
+            var solutionEventsListener = new Mock<IVsUpdateSolutionEvents>();
+
+            var anyInt = It.IsAny<int>();
+            solutionEventsListener.Setup(b => b.UpdateSolution_Begin(ref anyInt))
+                .Callback(() => onUpdateSolutionBegin?.Invoke())
+                .Returns(VSConstants.S_OK);
+
+            solutionEventsListener.Setup(b => b.UpdateSolution_Cancel())
+                    .Callback(() => onUpdateSolutionCancel?.Invoke())
+                    .Returns(VSConstants.S_OK);
+
+            solutionEventsListener.Setup(b => b.UpdateSolution_Done(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()))
+                    .Callback(() => onUpdateSolutionDone?.Invoke())
+                    .Returns(VSConstants.S_OK);
+            
+            return solutionEventsListener.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommandTests.cs
@@ -1,0 +1,169 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Input;
+using Microsoft.VisualStudio.Shell.Interop;
+using System;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Xunit;
+using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.ProjectSystem.Build;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+{
+    public abstract class AbstractGenerateNuGetPackageCommandTests
+    {
+        [Fact]
+        public void Constructor_NullAsUnconfiguredProject_ThrowsArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => CreateInstanceCore(null, IProjectThreadingServiceFactory.Create(), SVsServiceProviderFactory.Create(null), CreateGeneratePackageOnBuildPropertyProvider()));
+        }
+
+        [Fact]
+        public void Constructor_NullAsProjectThreadingServiceFactory_ThrowsArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => CreateInstanceCore(UnconfiguredProjectFactory.Create(), null, SVsServiceProviderFactory.Create(null), CreateGeneratePackageOnBuildPropertyProvider()));
+        }
+
+        [Fact]
+        public void Constructor_NullAsSVsServiceProvider_ThrowsArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => CreateInstanceCore(UnconfiguredProjectFactory.Create(), IProjectThreadingServiceFactory.Create(), null, CreateGeneratePackageOnBuildPropertyProvider()));
+        }
+
+        [Fact]
+        public void Constructor_NullAsGeneratePackageOnBuildPropertyProvider_ThrowsArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => CreateInstanceCore(UnconfiguredProjectFactory.Create(), IProjectThreadingServiceFactory.Create(), SVsServiceProviderFactory.Create(null), null));
+        }
+
+        [Fact]
+        public async Task TryHandleCommandAsync_InvokesBuild()
+        {
+            bool buildStarted = false, buildCancelled = false, buildCompleted = false;
+            Action onUpdateSolutionBegin = () => { buildStarted = true; };
+            Action onUpdateSolutionCancel = () => { buildCancelled = true; };
+            Action onUpdateSolutionDone = () => { buildCompleted = true; };
+
+            var solutionEventsListener = IVsUpdateSolutionEventsFactory.Create(onUpdateSolutionBegin, onUpdateSolutionCancel, onUpdateSolutionDone);
+            var command = CreateInstance(solutionEventsListener: solutionEventsListener);
+
+            var tree = ProjectTreeParser.Parse(@"
+Root (flags: {ProjectRoot})
+");
+
+            var nodes = ImmutableHashSet.Create(tree.Root);
+
+            var result = await command.TryHandleCommandAsync(nodes, GetCommandId(), true, 0, IntPtr.Zero, IntPtr.Zero);
+
+            Assert.True(result);
+            Assert.True(buildStarted);
+            Assert.True(buildCompleted);
+            Assert.False(buildCancelled);
+        }
+
+        [Fact]
+        public async Task TryHandleCommandAsync_OnBuildCancelled()
+        {
+            bool buildStarted = false, buildCancelled = false, buildCompleted = false;
+            Action onUpdateSolutionBegin = () => { buildStarted = true; };
+            Action onUpdateSolutionCancel = () => { buildCancelled = true; };
+            Action onUpdateSolutionDone = () => { buildCompleted = true; };
+
+            var solutionEventsListener = IVsUpdateSolutionEventsFactory.Create(onUpdateSolutionBegin, onUpdateSolutionCancel, onUpdateSolutionDone);
+            var command = CreateInstance(solutionEventsListener: solutionEventsListener, cancelBuild: true);
+
+            var tree = ProjectTreeParser.Parse(@"
+Root (flags: {ProjectRoot})
+");
+
+            var nodes = ImmutableHashSet.Create(tree.Root);
+
+            var result = await command.TryHandleCommandAsync(nodes, GetCommandId(), true, 0, IntPtr.Zero, IntPtr.Zero);
+
+            Assert.True(result);
+            Assert.True(buildStarted);
+            Assert.False(buildCompleted);
+            Assert.True(buildCancelled);
+        }
+
+        [Fact]
+        public async Task GetCommandStatusAsync_BuildInProgress()
+        {
+            var tree = ProjectTreeParser.Parse(@"
+Root (flags: {ProjectRoot})
+");
+
+            var nodes = ImmutableHashSet.Create(tree.Root);
+
+            // Command is enabled if there is no build in progress.
+            var command = CreateInstance(isBuilding: () => false);
+            var results = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            Assert.True(results.Handled);
+            Assert.Equal(CommandStatus.Enabled | CommandStatus.Supported, results.Status);
+
+            // Command is disabled if there is build in progress.
+            command = CreateInstance(isBuilding: () => true);
+            results = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+            Assert.True(results.Handled);
+            Assert.Equal(CommandStatus.Supported, results.Status);
+        }
+
+        [Fact]
+        public async Task TryHandleCommandAsync_BuildInProgress()
+        {
+            var tree = ProjectTreeParser.Parse(@"
+Root (flags: {ProjectRoot})
+");
+
+            var nodes = ImmutableHashSet.Create(tree.Root);
+
+            bool buildStarted = false, buildCancelled = false, buildCompleted = false;
+            Action onUpdateSolutionBegin = () => { buildStarted = true; };
+            Action onUpdateSolutionCancel = () => { buildCancelled = true; };
+            Action onUpdateSolutionDone = () => { buildCompleted = true; };
+            var solutionEventsListener = IVsUpdateSolutionEventsFactory.Create(onUpdateSolutionBegin, onUpdateSolutionCancel, onUpdateSolutionDone);
+
+            Func<bool> isBuilding = () => true;
+            var command = CreateInstance(solutionEventsListener: solutionEventsListener, isBuilding: isBuilding);
+
+            // Ensure we handle the command, but don't invoke build as there is a build already in progress.
+            var handled = await command.TryHandleCommandAsync(nodes, GetCommandId(), true, 0, IntPtr.Zero, IntPtr.Zero);
+            Assert.True(handled);
+            Assert.False(buildStarted);
+            Assert.False(buildCompleted);
+            Assert.False(buildCancelled);
+        }
+
+        internal abstract long GetCommandId();
+
+        internal AbstractGenerateNuGetPackageCommand CreateInstance(
+            GeneratePackageOnBuildPropertyProvider generatePackageOnBuildPropertyProvider = null,
+            IVsSolutionBuildManager2 buildManager = null,
+            IVsUpdateSolutionEvents solutionEventsListener = null,
+            Func<bool> isBuilding = null,
+            bool cancelBuild = false)
+        {
+            var hierarchy = IVsHierarchyFactory.Create();
+            var unconfiguredProject = UnconfiguredProjectFactory.Create(hierarchy);
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            buildManager = buildManager ?? IVsSolutionBuildManager2Factory.Create(solutionEventsListener, hierarchy, isBuilding, cancelBuild);
+            var serviceProvider = SVsServiceProviderFactory.Create(buildManager);
+            generatePackageOnBuildPropertyProvider = generatePackageOnBuildPropertyProvider ?? CreateGeneratePackageOnBuildPropertyProvider();
+
+            return CreateInstanceCore(unconfiguredProject, threadingService, serviceProvider, generatePackageOnBuildPropertyProvider);
+        }
+
+        private GeneratePackageOnBuildPropertyProvider CreateGeneratePackageOnBuildPropertyProvider(IProjectService projectService = null)
+        {
+            projectService = projectService ?? IProjectServiceFactory.Create();
+            return new GeneratePackageOnBuildPropertyProvider(projectService);
+        }
+
+        internal abstract AbstractGenerateNuGetPackageCommand CreateInstanceCore(
+            UnconfiguredProject unconfiguredProject,
+            IProjectThreadingService threadingService,
+            Shell.SVsServiceProvider serviceProvider,
+            GeneratePackageOnBuildPropertyProvider generatePackageOnBuildPropertyProvider);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommandTests.cs
@@ -95,13 +95,13 @@ Root (flags: {ProjectRoot})
             var nodes = ImmutableHashSet.Create(tree.Root);
 
             // Command is enabled if there is no build in progress.
-            var command = CreateInstance(isBuilding: () => false);
+            var command = CreateInstance(isBuilding: false);
             var results = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
             Assert.True(results.Handled);
             Assert.Equal(CommandStatus.Enabled | CommandStatus.Supported, results.Status);
 
             // Command is disabled if there is build in progress.
-            command = CreateInstance(isBuilding: () => true);
+            command = CreateInstance(isBuilding: true);
             results = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
             Assert.True(results.Handled);
             Assert.Equal(CommandStatus.Supported, results.Status);
@@ -122,8 +122,7 @@ Root (flags: {ProjectRoot})
             Action onUpdateSolutionDone = () => { buildCompleted = true; };
             var solutionEventsListener = IVsUpdateSolutionEventsFactory.Create(onUpdateSolutionBegin, onUpdateSolutionCancel, onUpdateSolutionDone);
 
-            Func<bool> isBuilding = () => true;
-            var command = CreateInstance(solutionEventsListener: solutionEventsListener, isBuilding: isBuilding);
+            var command = CreateInstance(solutionEventsListener: solutionEventsListener, isBuilding: true);
 
             // Ensure we handle the command, but don't invoke build as there is a build already in progress.
             var handled = await command.TryHandleCommandAsync(nodes, GetCommandId(), true, 0, IntPtr.Zero, IntPtr.Zero);
@@ -139,7 +138,7 @@ Root (flags: {ProjectRoot})
             GeneratePackageOnBuildPropertyProvider generatePackageOnBuildPropertyProvider = null,
             IVsSolutionBuildManager2 buildManager = null,
             IVsUpdateSolutionEvents solutionEventsListener = null,
-            Func<bool> isBuilding = null,
+            bool isBuilding = false,
             bool cancelBuild = false)
         {
             var hierarchy = IVsHierarchyFactory.Create();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommandTests.cs
@@ -1,13 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.VisualStudio.Input;
-using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
-using Xunit;
-using Microsoft.VisualStudio.Packaging;
 using Microsoft.VisualStudio.ProjectSystem.Build;
+using Microsoft.VisualStudio.Shell.Interop;
+using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageProjectContextMenuCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageProjectContextMenuCommandTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Packaging;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageProjectContextMenuCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageProjectContextMenuCommandTests.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.ProjectSystem.Build;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+{
+    [ProjectSystemTrait]
+    public class GenerateNuGetPackageProjectContextMenuCommandTests : AbstractGenerateNuGetPackageCommandTests
+    {
+        internal override long GetCommandId() => ManagedProjectSystemPackage.GenerateNuGetPackageProjectContextMenuCmdId;
+
+        internal override AbstractGenerateNuGetPackageCommand CreateInstanceCore(
+            UnconfiguredProject unconfiguredProject,
+            IProjectThreadingService threadingService,
+            Shell.SVsServiceProvider serviceProvider,
+            GeneratePackageOnBuildPropertyProvider generatePackageOnBuildPropertyProvider)
+        {
+            return new GenerateNuGetPackageProjectContextMenuCommand(unconfiguredProject, threadingService, serviceProvider, generatePackageOnBuildPropertyProvider);
+        }
+
+        [Fact]
+        public async Task GetCommandStatusAsync_RootFolderAsNodes_ReturnsHandled()
+        {
+            var command = CreateInstance();
+
+            var tree = ProjectTreeParser.Parse(@"
+Root (flags: {ProjectRoot})
+    Properties (flags: {AppDesignerFolder})
+");
+
+            var nodes = ImmutableHashSet.Create(tree.Root);
+
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+
+            Assert.True(result.Handled);
+        }
+
+        [Fact]
+        public async Task GetCommandStatusAsync_NonRootFolderAsNodes_ReturnsUnhandled()
+        {
+            var command = CreateInstance();
+
+            var tree = ProjectTreeParser.Parse(@"
+Root (flags: {ProjectRoot})
+    Properties (flags: {AppDesignerFolder})
+");
+
+            var nodes = ImmutableHashSet.Create(tree.Children[0]);
+
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+
+            Assert.False(result.Handled);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageTopLevelBuildMenuCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageTopLevelBuildMenuCommandTests.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.ProjectSystem.Build;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+{
+    [ProjectSystemTrait]
+    public class GenerateNuGetPackageTopLevelBuildMenuCommandTests : AbstractGenerateNuGetPackageCommandTests
+    {
+        internal override long GetCommandId() => ManagedProjectSystemPackage.GenerateNuGetPackageTopLevelBuildCmdId;
+
+        internal override AbstractGenerateNuGetPackageCommand CreateInstanceCore(
+            UnconfiguredProject unconfiguredProject,
+            IProjectThreadingService threadingService,
+            Shell.SVsServiceProvider serviceProvider,
+            GeneratePackageOnBuildPropertyProvider generatePackageOnBuildPropertyProvider)
+        {
+            return new GenerateNuGetPackageTopLevelBuildMenuCommand(unconfiguredProject, threadingService, serviceProvider, generatePackageOnBuildPropertyProvider);
+        }
+
+
+
+        [Fact]
+        public async Task GetCommandStatusAsync_RootFolderAsNodes_ReturnsHandled()
+        {
+            var command = CreateInstance();
+
+            var tree = ProjectTreeParser.Parse(@"
+Root (flags: {ProjectRoot})
+    Properties (flags: {AppDesignerFolder})
+");
+
+            var nodes = ImmutableHashSet.Create(tree.Root);
+
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+
+            Assert.True(result.Handled);
+        }
+
+        [Fact]
+        public async Task GetCommandStatusAsync_NonRootFolderAsNodes_ReturnsHandled()
+        {
+            var command = CreateInstance();
+
+            var tree = ProjectTreeParser.Parse(@"
+Root (flags: {ProjectRoot})
+    Properties (flags: {AppDesignerFolder})
+");
+
+            var nodes = ImmutableHashSet.Create(tree.Children[0]);
+
+            var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
+
+            Assert.True(result.Handled);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
@@ -1,19 +1,23 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Build;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 {
-    internal abstract class AbstractGenerateNuGetPackageCommand : AbstractSingleNodeProjectCommand, IVsUpdateSolutionEvents
+    internal abstract class AbstractGenerateNuGetPackageCommand : AbstractSingleNodeProjectCommand, IVsUpdateSolutionEvents, IDisposable
     {
         private readonly IProjectThreadingService _threadingService;
-        private readonly IVsSolutionBuildManager2 _buildManager;
+        private readonly IServiceProvider _serviceProvider;
         private readonly GeneratePackageOnBuildPropertyProvider _generatePackageOnBuildPropertyProvider;
+        private IVsSolutionBuildManager2 _buildManager;
+        private uint _solutionEventsCookie;
 
         protected AbstractGenerateNuGetPackageCommand(
             UnconfiguredProject unconfiguredProject,
@@ -21,16 +25,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             SVsServiceProvider serviceProvider,
             GeneratePackageOnBuildPropertyProvider generatePackageOnBuildPropertyProvider)
         {
+            Requires.NotNull(unconfiguredProject, nameof(unconfiguredProject));
+            Requires.NotNull(threadingService, nameof(threadingService));
             Requires.NotNull(serviceProvider, nameof(serviceProvider));
             Requires.NotNull(generatePackageOnBuildPropertyProvider, nameof(generatePackageOnBuildPropertyProvider));
 
             UnconfiguredProject = unconfiguredProject;
             _threadingService = threadingService;
-            _generatePackageOnBuildPropertyProvider = generatePackageOnBuildPropertyProvider;
-
-            uint cookie;
-            _buildManager = serviceProvider.GetService<IVsSolutionBuildManager2, SVsSolutionBuildManager>();
-            _buildManager.AdviseUpdateSolutionEvents(this, out cookie);
+            _serviceProvider = serviceProvider;
+            _generatePackageOnBuildPropertyProvider = generatePackageOnBuildPropertyProvider;            
         }
 
         protected UnconfiguredProject UnconfiguredProject { get; }
@@ -38,14 +41,41 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         protected abstract string GetCommandText();
         protected abstract bool ShouldHandle(IProjectTree node);
 
-        protected override Task<CommandStatusResult> GetCommandStatusAsync(IProjectTree node, bool focused, string commandText, CommandStatus progressiveStatus) =>
-            ShouldHandle(node) ?
-                GetCommandStatusResult.Handled(GetCommandText(), IsReadyToBuild() ? CommandStatus.Enabled : CommandStatus.Supported) :
-                GetCommandStatusResult.Unhandled;
-
-        private bool IsReadyToBuild()
+        protected async override Task<CommandStatusResult> GetCommandStatusAsync(IProjectTree node, bool focused, string commandText, CommandStatus progressiveStatus)
         {
-            return ErrorHandler.Succeeded(_buildManager.QueryBuildManagerBusy(out int busy)) && busy == 0;
+            if (ShouldHandle(node))
+            {
+                // Enable the command if the build manager is ready to build.
+                var commandStatus = await IsReadyToBuildAsync().ConfigureAwait(false) ? CommandStatus.Enabled : CommandStatus.Supported;
+                return await GetCommandStatusResult.Handled(GetCommandText(), commandStatus).ConfigureAwait(false);
+            }
+
+            return CommandStatusResult.Unhandled;
+        }
+
+        private async Task<bool> IsReadyToBuildAsync()
+        {
+            // Ensure build manager is initialized.
+            await EnsureBuildManagerInitializedAsync().ConfigureAwait(false);
+
+            ErrorHandler.ThrowOnFailure(_buildManager.QueryBuildManagerBusy(out int busy));
+            return busy == 0;
+        }
+
+        private async Task EnsureBuildManagerInitializedAsync()
+        {
+            if (_buildManager == null)
+            {
+                // Switch to UI thread for querying the build manager service.
+                await _threadingService.SwitchToUIThread();
+
+                var buildManager = _serviceProvider.GetService<IVsSolutionBuildManager2, SVsSolutionBuildManager>();
+                if (Interlocked.CompareExchange(ref _buildManager, buildManager, null) == null)
+                {
+                    // Register for solution build events.
+                    _buildManager.AdviseUpdateSolutionEvents(this, out _solutionEventsCookie);
+                }
+            }
         }
 
         protected override async Task<bool> TryHandleCommandAsync(IProjectTree node, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
@@ -55,16 +85,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
                 return false;
             }
 
-            await _threadingService.SwitchToUIThread();
-
-            // Save documents and kick off build.
-            var projectVsHierarchy = (IVsHierarchy)UnconfiguredProject.Services.HostObject;
-            int hr = _buildManager.SaveDocumentsBeforeBuild(projectVsHierarchy, (uint)VSConstants.VSITEMID.Root, 0 /*docCookie*/);
-            if (ErrorHandler.Succeeded(hr))
+            if (await IsReadyToBuildAsync().ConfigureAwait(false))
             {
+                // Save documents before build.
+                var projectVsHierarchy = (IVsHierarchy)UnconfiguredProject.Services.HostObject;
+                int hr = _buildManager.SaveDocumentsBeforeBuild(projectVsHierarchy, (uint)VSConstants.VSITEMID.Root, 0 /*docCookie*/);
+                ErrorHandler.ThrowOnFailure(hr);
+
                 // Enable generating package on build ("GeneratePackageOnBuild") for all projects being built.
                 _generatePackageOnBuildPropertyProvider.OverrideGeneratePackageOnBuild(true);
 
+                // Kick off the build.
                 uint dwFlags = (uint)(VSSOLNBUILDUPDATEFLAGS.SBF_SUPPRESS_SAVEBEFOREBUILD_QUERY | VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD);
                 hr = _buildManager.StartSimpleUpdateProjectConfiguration(projectVsHierarchy, null, null, dwFlags, 0, 0);
                 return ErrorHandler.Succeeded(hr);
@@ -99,6 +130,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         public int OnActiveProjectCfgChange(IVsHierarchy pIVsHierarchy)
         {
             return VSConstants.S_OK;
+        }
+        #endregion
+
+        #region IDisposable
+        public void Dispose()
+        {
+            var buildManager = _buildManager;
+            if (buildManager != null)
+            {
+                if (Interlocked.CompareExchange(ref _buildManager, null, buildManager) == buildManager)
+                {
+                    // Unregister solution build events.
+                    buildManager.UnadviseUpdateSolutionEvents(_solutionEventsCookie);
+                }
+            }
         }
         #endregion
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
@@ -2,18 +2,35 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Build;
 using Microsoft.VisualStudio.ProjectSystem.Input;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 {
-    internal abstract class AbstractGenerateNuGetPackageCommand : AbstractSingleNodeProjectCommand
+    internal abstract class AbstractGenerateNuGetPackageCommand : AbstractSingleNodeProjectCommand, IVsUpdateSolutionEvents
     {
         private readonly IProjectThreadingService _threadingService;
+        private readonly IVsSolutionBuildManager2 _buildManager;
+        private readonly GeneratePackageOnBuildPropertyProvider _generatePackageOnBuildPropertyProvider;
 
-        protected AbstractGenerateNuGetPackageCommand(UnconfiguredProject unconfiguredProject, IProjectThreadingService threadingService)
+        protected AbstractGenerateNuGetPackageCommand(
+            UnconfiguredProject unconfiguredProject,
+            IProjectThreadingService threadingService,
+            SVsServiceProvider serviceProvider,
+            GeneratePackageOnBuildPropertyProvider generatePackageOnBuildPropertyProvider)
         {
+            Requires.NotNull(serviceProvider, nameof(serviceProvider));
+            Requires.NotNull(generatePackageOnBuildPropertyProvider, nameof(generatePackageOnBuildPropertyProvider));
+
             UnconfiguredProject = unconfiguredProject;
             _threadingService = threadingService;
+            _generatePackageOnBuildPropertyProvider = generatePackageOnBuildPropertyProvider;
+
+            uint cookie;
+            _buildManager = serviceProvider.GetService<IVsSolutionBuildManager2, SVsSolutionBuildManager>();
+            _buildManager.AdviseUpdateSolutionEvents(this, out cookie);
         }
 
         protected UnconfiguredProject UnconfiguredProject { get; }
@@ -23,18 +40,66 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 
         protected override Task<CommandStatusResult> GetCommandStatusAsync(IProjectTree node, bool focused, string commandText, CommandStatus progressiveStatus) =>
             ShouldHandle(node) ?
-                GetCommandStatusResult.Handled(GetCommandText(), CommandStatus.Enabled) :
+                GetCommandStatusResult.Handled(GetCommandText(), IsReadyToBuild() ? CommandStatus.Enabled : CommandStatus.Supported) :
                 GetCommandStatusResult.Unhandled;
+
+        private bool IsReadyToBuild()
+        {
+            return ErrorHandler.Succeeded(_buildManager.QueryBuildManagerBusy(out int busy)) && busy == 0;
+        }
 
         protected override async Task<bool> TryHandleCommandAsync(IProjectTree node, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
         {
-            if (!ShouldHandle(node)) return false;
+            if (!ShouldHandle(node))
+            {
+                return false;
+            }
 
             await _threadingService.SwitchToUIThread();
 
-            // TODO: Generate NuGet package.
+            // Save documents and kick off build.
+            var projectVsHierarchy = (IVsHierarchy)UnconfiguredProject.Services.HostObject;
+            int hr = _buildManager.SaveDocumentsBeforeBuild(projectVsHierarchy, (uint)VSConstants.VSITEMID.Root, 0 /*docCookie*/);
+            if (ErrorHandler.Succeeded(hr))
+            {
+                // Enable generating package on build ("GeneratePackageOnBuild") for all projects being built.
+                _generatePackageOnBuildPropertyProvider.OverrideGeneratePackageOnBuild(true);
+
+                uint dwFlags = (uint)(VSSOLNBUILDUPDATEFLAGS.SBF_SUPPRESS_SAVEBEFOREBUILD_QUERY | VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD);
+                hr = _buildManager.StartSimpleUpdateProjectConfiguration(projectVsHierarchy, null, null, dwFlags, 0, 0);
+                return ErrorHandler.Succeeded(hr);
+            }
 
             return true;
         }
+
+        #region IVsUpdateSolutionEvents members
+        public int UpdateSolution_Begin(ref int pfCancelUpdate)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int UpdateSolution_Done(int fSucceeded, int fModified, int fCancelCommand)
+        {
+            _generatePackageOnBuildPropertyProvider.OverrideGeneratePackageOnBuild(false);
+            return VSConstants.S_OK;
+        }
+
+        public int UpdateSolution_Cancel()
+        {
+            _generatePackageOnBuildPropertyProvider.OverrideGeneratePackageOnBuild(false);
+            return VSConstants.S_OK;
+        }
+
+        public int UpdateSolution_StartUpdate(ref int pfCancelUpdate)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnActiveProjectCfgChange(IVsHierarchy pIVsHierarchy)
+        {
+            return VSConstants.S_OK;
+        }
+        #endregion
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
@@ -136,8 +136,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         public void Dispose()
         {
             // Build manager APIs require UI thread access.
-            ThreadHelper.Generic.Invoke(() =>
+            _threadingService.ExecuteSynchronously(async() =>
             {
+                await _threadingService.SwitchToUIThread();
+
                 if (_buildManager != null)
                 {
                     // Unregister solution build events.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageProjectContextMenuCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageProjectContextMenuCommand.cs
@@ -2,17 +2,23 @@
 
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.ProjectSystem.Build;
 using Microsoft.VisualStudio.ProjectSystem.Input;
+using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 {
     [ProjectCommand(ManagedProjectSystemPackage.ManagedProjectSystemCommandSet, ManagedProjectSystemPackage.GenerateNuGetPackageProjectContextMenuCmdId)]
-    //[AppliesTo(ProjectCapability.Pack)]
+    [AppliesTo(ProjectCapability.Pack)]
     internal class GenerateNuGetPackageProjectContextMenuCommand : AbstractGenerateNuGetPackageCommand
     {
         [ImportingConstructor]
-        public GenerateNuGetPackageProjectContextMenuCommand(UnconfiguredProject unconfiguredProject, IProjectThreadingService threadingService)
-            : base (unconfiguredProject, threadingService)
+        public GenerateNuGetPackageProjectContextMenuCommand(
+            UnconfiguredProject unconfiguredProject,
+            IProjectThreadingService threadingService,
+            SVsServiceProvider serviceProvider,
+            GeneratePackageOnBuildPropertyProvider generatePackageOnBuildPropertyProvider)
+            : base(unconfiguredProject, threadingService, serviceProvider, generatePackageOnBuildPropertyProvider)
         {
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageTopLevelBuildMenuCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageTopLevelBuildMenuCommand.cs
@@ -3,17 +3,23 @@
 using System.ComponentModel.Composition;
 using System.IO;
 using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.ProjectSystem.Build;
 using Microsoft.VisualStudio.ProjectSystem.Input;
+using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 {
     [ProjectCommand(ManagedProjectSystemPackage.ManagedProjectSystemCommandSet, ManagedProjectSystemPackage.GenerateNuGetPackageTopLevelBuildCmdId)]
-    //[AppliesTo(ProjectCapability.Pack)]
+    [AppliesTo(ProjectCapability.Pack)]
     internal class GenerateNuGetPackageTopLevelBuildMenuCommand : AbstractGenerateNuGetPackageCommand
     {
         [ImportingConstructor]
-        public GenerateNuGetPackageTopLevelBuildMenuCommand(UnconfiguredProject unconfiguredProject, IProjectThreadingService threadingService)
-            : base (unconfiguredProject, threadingService)
+        public GenerateNuGetPackageTopLevelBuildMenuCommand(
+            UnconfiguredProject unconfiguredProject,
+            IProjectThreadingService threadingService,
+            SVsServiceProvider serviceProvider,
+            GeneratePackageOnBuildPropertyProvider generatePackageOnBuildPropertyProvider)
+            : base (unconfiguredProject, threadingService, serviceProvider, generatePackageOnBuildPropertyProvider)
         {
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -37,6 +37,8 @@
     <Compile Include="ProjectSystem\Build\BuildProperty.cs" />
     <Compile Include="CommonConstants.cs" />
     <Compile Include="ProjectSystem\Build\CommandLineDesignTimeBuildPropertiesProvider.cs" />
+    <Compile Include="ProjectSystem\Build\GeneratePackageOnBuildDesignTimeBuildPropertyProvider.cs" />
+    <Compile Include="ProjectSystem\Build\GeneratePackageOnBuildPropertyProvider.cs" />
     <Compile Include="ProjectSystem\Build\TargetFrameworkGlobalBuildPropertyProvider.cs" />
     <Compile Include="ProjectSystem\ContractNames.cs" />
     <Compile Include="GlobalSuppressions.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/GeneratePackageOnBuildDesignTimeBuildPropertyProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/GeneratePackageOnBuildDesignTimeBuildPropertyProvider.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Build
+{
+    /// <summary>
+    /// Design time build property provider for <see cref="ConfigurationGeneralBrowseObject.GeneratePackageOnBuildProperty"/>.
+    /// </summary>
+    [ExportBuildGlobalPropertiesProvider(designTimeBuildProperties: true)]
+    [AppliesTo(ProjectCapability.Pack)]
+    internal class GeneratePackageOnBuildDesignTimeBuildPropertyProvider : StaticGlobalPropertiesProviderBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TargetFrameworkGlobalBuildPropertyProvider"/> class.
+        /// </summary>
+        [ImportingConstructor]
+        internal GeneratePackageOnBuildDesignTimeBuildPropertyProvider(IProjectService projectService)
+            : base(projectService.Services)
+        {
+        }
+
+        /// <summary>
+        /// Gets the set of global properties that should apply to the project(s) in this scope.
+        /// </summary>
+        /// <value>A map whose keys are case insensitive.  Never null, but may be empty.</value>
+        public override Task<IImmutableDictionary<string, string>> GetGlobalPropertiesAsync(CancellationToken cancellationToken)
+        {
+            // Never generate nuget package during design time build.
+            IImmutableDictionary<string, string> properties = Empty.PropertiesMap.Add(ConfigurationGeneralBrowseObject.GeneratePackageOnBuildProperty, "false");
+            return Task.FromResult(properties);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/GeneratePackageOnBuildPropertyProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/GeneratePackageOnBuildPropertyProvider.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Build
+{
+    /// <summary>
+    /// Build property provider for <see cref="ConfigurationGeneralBrowseObject.GeneratePackageOnBuildProperty"/> for solution build.
+    /// </summary>
+    [ExportBuildGlobalPropertiesProvider(designTimeBuildProperties: false)]
+    [Export(typeof(GeneratePackageOnBuildPropertyProvider))]
+    [AppliesTo(ProjectCapability.Pack)]
+    internal class GeneratePackageOnBuildPropertyProvider : StaticGlobalPropertiesProviderBase
+    {
+        private bool _overrideGeneratePackageOnBuild;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TargetFrameworkGlobalBuildPropertyProvider"/> class.
+        /// </summary>
+        [ImportingConstructor]
+        internal GeneratePackageOnBuildPropertyProvider(IProjectService projectService)
+            : base(projectService.Services)
+        {
+            _overrideGeneratePackageOnBuild = false;
+        }
+
+        public void OverrideGeneratePackageOnBuild(bool value)
+        {
+            _overrideGeneratePackageOnBuild = value;
+        }
+
+        /// <summary>
+        /// Gets the set of global properties that should apply to the project(s) in this scope.
+        /// </summary>
+        /// <value>A map whose keys are case insensitive.  Never null, but may be empty.</value>
+        public override Task<IImmutableDictionary<string, string>> GetGlobalPropertiesAsync(CancellationToken cancellationToken)
+        {
+            IImmutableDictionary<string, string> properties = Empty.PropertiesMap;
+
+            if (_overrideGeneratePackageOnBuild)
+            {
+                properties = properties.Add(ConfigurationGeneralBrowseObject.GeneratePackageOnBuildProperty, "true");
+            }
+
+            return Task.FromResult(properties);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #998

I verified that "Pack" command kicks off a *real* solution build for the selected project with "GeneratePackageOnBuild" property set to true, and is correctly reset to false at the end. Once NuGet implements https://github.com/NuGet/Home/issues/4145, this command should generate a NuGet package.