### PR TITLE
Supported for extending the debug property pages

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/DebugPageViewModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/DebugPageViewModelTests.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
-
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
@@ -20,6 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             public IList<ILaunchProfile> Profiles { get; set; }
             public ILaunchSettingsProvider ProfileProvider { get; set; }
             public ILaunchSettings LaunchProfiles { get; set; }
+            public IList<Lazy<ILaunchSettingsUIProvider, IOrderPrecedenceMetadataView>> UIProviders { get; set; } = new List<Lazy<ILaunchSettingsUIProvider, IOrderPrecedenceMetadataView>>();
         }
 
         private Mock<DebugPageViewModel> CreateViewModel(ViewModelData data)
@@ -59,6 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 
             viewModel.CallBase = true;
             viewModel.Protected().Setup<ILaunchSettingsProvider>("GetDebugProfileProvider").Returns(mockProfileProvider.Object);
+            viewModel.Protected().Setup<IEnumerable<Lazy<ILaunchSettingsUIProvider, IOrderPrecedenceMetadataView>>>("GetUIProviders").Returns(data.UIProviders);
             return viewModel;
         }
                
@@ -90,14 +92,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             await viewModel.Object.Initialize();
             Assert.False(viewModel.Object.HasProfiles);
             Assert.False(viewModel.Object.IsProfileSelected);
-            Assert.False(viewModel.Object.IsExecutable);
+            Assert.False(viewModel.Object.SupportsExecutable);
             Assert.False(viewModel.Object.HasLaunchOption);
             Assert.Equal(string.Empty, viewModel.Object.WorkingDirectory);
             Assert.Equal(string.Empty, viewModel.Object.LaunchPage);
             Assert.Equal(string.Empty, viewModel.Object.ExecutablePath);
             Assert.Equal(string.Empty, viewModel.Object.CommandLineArguments);
-            Assert.Equal(string.Empty, viewModel.Object.SelectedCommandName);
         }
-
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -84,9 +84,11 @@
     <Compile Include="ProjectSystem\VS\PropertyPages\DebugPageViewModel.cs" />
     <Compile Include="ProjectSystem\VS\PropertyPages\DebugPropertyPage.cs" />
     <Compile Include="ProjectSystem\VS\PropertyPages\EnvironmentGridTemplateColumn.cs" />
+    <Compile Include="ProjectSystem\VS\PropertyPages\ProjectLaunchSettingsUIProvider.cs" />
     <Compile Include="ProjectSystem\VS\PropertyPages\GetProfileNameDialog.xaml.cs">
       <DependentUpon>GetProfileNameDialog.xaml</DependentUpon>
     </Compile>
+    <Compile Include="ProjectSystem\VS\PropertyPages\ExecutableLaunchSettingsUIProvider.cs" />
     <Compile Include="ProjectSystem\VS\PropertyPages\IPageMetadata.cs" />
     <Compile Include="ProjectSystem\VS\PropertyPages\PropertyPage.cs">
       <SubType>UserControl</SubType>
@@ -235,8 +237,9 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="ProjectSystem\VS\PropertyPages\PropertyPageResources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
+      <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>PropertyPageResources.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="VSResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
@@ -50,13 +50,6 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <Label
                 Grid.Row="0"
@@ -76,12 +69,13 @@
                 VerticalContentAlignment="Center"
                 MinHeight="23"
                 Margin="5,6,2,7"
-                ItemsSource="{Binding Path=DebugProfiles}"
+                ItemsSource="{Binding Path=LaunchProfiles, Mode=OneWay}"
                 SelectedValue="{Binding Path=SelectedDebugProfile}">
                 <ComboBox.IsEnabled>
                     <MultiBinding Converter="{StaticResource MultiValueBoolToBoolAnd}">
                         <Binding Path="HasProfiles" Mode="OneWay"/>
                         <Binding Path="EnvironmentVariablesValid" Mode="OneWay"/>
+                        <Binding Path="DoesNotHaveErrors" Mode="OneWay"/>
                     </MultiBinding>
                 </ComboBox.IsEnabled>
             </ComboBox>
@@ -136,7 +130,6 @@
                 SelectedValue="{Binding Path=SelectedLaunchType, Mode=TwoWay}"
                 DisplayMemberPath="Name"
                 IsReadOnly="True"
-                IsEnabled="{Binding Path=IsCustomType}"
                 IsEditable="False">
             </ComboBox>
             <Label 
@@ -146,7 +139,7 @@
                 Content="E_xecutable:"
                 IsTabStop="False" 
                 VerticalAlignment="Center"
-                Visibility="{Binding Path=IsExecutable, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
+                Visibility="{Binding Path=SupportsExecutable, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
                 Target="{Binding ElementName=executableText}"/>
             <local:WatermarkTextBox
                 Grid.Row="2"
@@ -159,7 +152,7 @@
                 VerticalContentAlignment="Center"
                 VerticalAlignment="Center"
                 Text="{Binding Path=ExecutablePath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                Visibility="{Binding Path=IsExecutable, Mode=OneWay, Converter={StaticResource visibilityConverter}}"/>
+                Visibility="{Binding Path=SupportsExecutable, Mode=OneWay, Converter={StaticResource visibilityConverter}}"/>
             <Button
                 Grid.Row="2"
                 Grid.Column="2"
@@ -173,7 +166,7 @@
                 VerticalAlignment="Center"
                 Content="Browse..."
                 IsEnabled="{Binding Path=IsProfileSelected, Mode=OneWay}"
-                Visibility="{Binding Path=IsExecutable, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
+                Visibility="{Binding Path=SupportsExecutable, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
                 Command="{Binding Path=BrowseExecutableCommand}"/>
             <Label 
                 Grid.Row="4"
@@ -182,7 +175,7 @@
                 Content="_Application arguments:"
                 IsTabStop="False" 
                 VerticalAlignment="Top"
-                Visibility="{Binding Path=IsIISOrIISExpress, Mode=OneWay, Converter={StaticResource invertableVisibiltyConverter}, ConverterParameter=Inverted}"
+                Visibility="{Binding Path=SupportsArguments, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
                 Target="{Binding ElementName=txtArguments}"/>
             <local:WatermarkTextBox 
                 Grid.Row="4"
@@ -197,15 +190,14 @@
                 VerticalAlignment="Center"
                 Text="{Binding Path=CommandLineArguments, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 IsEnabled="{Binding Path=IsProfileSelected, Mode=OneWay}"
-                Visibility="{Binding Path=IsIISOrIISExpress, Mode=OneWay, Converter={StaticResource invertableVisibiltyConverter}, ConverterParameter=Inverted}">
-            </local:WatermarkTextBox>
+                Visibility="{Binding Path=SupportsArguments, Mode=OneWay, Converter={StaticResource visibilityConverter}}" />
             <Label 
                 Grid.Row="5"
                 x:Uid="workingDirectoryLabel"
                 Margin="4,4,3,5"
                 Content="W_orking directory:"
                 VerticalAlignment="Center"
-                Visibility="{Binding Path=IsIISOrIISExpress, Mode=OneWay, Converter={StaticResource invertableVisibiltyConverter}, ConverterParameter=Inverted}"
+                Visibility="{Binding Path=SupportsWorkingDirectory, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
                 Target="{Binding ElementName=txtWorkingDirectory}"/>
             <local:WatermarkTextBox  
                 Grid.Row="5"
@@ -218,7 +210,7 @@
                 MinHeight="23"
                 Margin="5,8,2,7"
                 IsEnabled="{Binding Path=IsProfileSelected, Mode=OneWay}"
-                Visibility="{Binding Path=IsIISOrIISExpress, Mode=OneWay, Converter={StaticResource invertableVisibiltyConverter}, ConverterParameter=Inverted}"
+                Visibility="{Binding Path=SupportsWorkingDirectory, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
                 MinWidth="200"/>
             <Button
                 Grid.Row="5"
@@ -233,7 +225,7 @@
                 VerticalAlignment="Center"
                 Content="Browse..."
                 IsEnabled="{Binding Path=IsProfileSelected, Mode=OneWay}"
-                Visibility="{Binding Path=IsIISOrIISExpress, Mode=OneWay, Converter={StaticResource invertableVisibiltyConverter}, ConverterParameter=Inverted}"
+                Visibility="{Binding Path=SupportsWorkingDirectory, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
                 Command="{Binding Path=BrowseDirectoryCommand}"/>
             <CheckBox 
                 Grid.Row="6"
@@ -244,6 +236,7 @@
                 Margin="9,7,3,7"
                 VerticalAlignment="Center"
                 IsEnabled="{Binding Path=IsProfileSelected, Mode=OneWay}"
+                Visibility="{Binding Path=SupportsLaunchUrl, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
                 VerticalContentAlignment="Center"
                 Content="Launch _URL:"/>
             <local:WatermarkTextBox 
@@ -255,6 +248,7 @@
                 VerticalAlignment="Center"
                 VerticalContentAlignment="Center"
                 Text="{Binding Path=LaunchPage, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                Visibility="{Binding Path=SupportsLaunchUrl, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
                 MinWidth="200"
                 MinHeight="23">
                 <local:WatermarkTextBox.IsEnabled>
@@ -265,15 +259,16 @@
                 </local:WatermarkTextBox.IsEnabled>
             </local:WatermarkTextBox>
             <Label 
-                Grid.Row="8"
+                Grid.Row="7"
                 x:Uid="envVarsLabel"
                 Margin="4,4,3,0"
                 IsTabStop="False"
                 VerticalAlignment="Top"
+                Visibility="{Binding Path=SupportsEnvironmentVariables, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
                 Content="Environment variables:"/>
             <DataGrid
                 x:Name="dataGridEnvironmentVariables"
-                Grid.Row="8"
+                Grid.Row="7"
                 Grid.Column="1"
                 Background="White"
                 Margin="5,4,2,4"
@@ -281,6 +276,7 @@
                 MinHeight="150"
                 MaxHeight="150"
                 IsEnabled="{Binding Path=IsProfileSelected, Mode=OneWay}"
+                Visibility="{Binding Path=SupportsEnvironmentVariables, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
                 ItemsSource="{Binding EnvironmentVariables, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 VerticalGridLinesBrush="{DynamicResource VsBrush.GridLine}" HorizontalGridLinesBrush="{DynamicResource VsBrush.GridLine}" 
                 SelectedIndex="{Binding EnvironmentVariablesRowSelectedIndex, Mode=TwoWay}"
@@ -351,7 +347,8 @@
 
                 </DataGrid.Columns>
             </DataGrid>
-            <StackPanel Orientation="Vertical" HorizontalAlignment="Left" Margin="6,20,0,0" Grid.Row="8" Grid.Column="2">
+            <StackPanel Orientation="Vertical" HorizontalAlignment="Left" Margin="6,20,0,0" Grid.Row="7" Grid.Column="2" 
+                        Visibility="{Binding Path=SupportsEnvironmentVariables, Mode=OneWay, Converter={StaticResource visibilityConverter}}">
                 <Button 
                     x:Uid="AddEnvironmentVariableButton" 
                     Name="AddEnvironmentVariableButton" 
@@ -381,6 +378,8 @@
                     Remo_ve
                 </Button>
             </StackPanel>
+            <!-- Where the custom control is placed for the active provider -->
+            <ContentPresenter Grid.Row="8" Grid.Column="0"  Grid.ColumnSpan="3" Content="{Binding ActiveProviderUserControl, Mode=OneWay}" />
         </Grid>
     </Grid>
 </local:PropertyPageControl>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
@@ -34,6 +34,7 @@
             <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
         <Grid
+            x:Name="_mainGrid"
             Grid.Row="0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
@@ -14,10 +15,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
     /// </summary>
     internal partial class DebugPageControl : PropertyPageControl
     {
+        bool _customControlLayoutUpdateRequired = false;
+
         public DebugPageControl()
         {
             InitializeComponent();
             DataContextChanged += DebugPageControlControl_DataContextChanged;
+            LayoutUpdated += DebugPageControl_LayoutUpdated;
         }
 
         void DebugPageControlControl_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
@@ -27,6 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 DebugPageViewModel viewModel = e.OldValue as DebugPageViewModel;
                 viewModel.FocusEnvironmentVariablesGridRow -= OnFocusEnvironmentVariableGridRow;
                 viewModel.ClearEnvironmentVariablesGridError -= OnClearEnvironmentVariableGridError;
+                viewModel.PropertyChanged -= ViewModel_PropertyChanged; 
             }
 
             if (e.NewValue != null && e.NewValue is DebugPageViewModel)
@@ -34,6 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 DebugPageViewModel viewModel = e.NewValue as DebugPageViewModel;
                 viewModel.FocusEnvironmentVariablesGridRow += OnFocusEnvironmentVariableGridRow;
                 viewModel.ClearEnvironmentVariablesGridError += OnClearEnvironmentVariableGridError;
+                viewModel.PropertyChanged += ViewModel_PropertyChanged; 
             }
         }
 
@@ -70,7 +76,59 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 cellErrorInfo.SetValue(dataGrid, false, null);
                 rowErrorInfo.SetValue(dataGrid, false, null);
             }
-            catch (Exception) { }
+            catch (Exception) 
+            { 
+            }
+        }
+        
+        /// <summary>
+        /// Called when a property changes on the view model. Used to detect when the custom UI changes so that
+        /// the size of its grids can be determined
+        /// </summary>
+        private void ViewModel_PropertyChanged(Object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if(e.PropertyName.Equals(nameof(DebugPageViewModel.ActiveProviderUserControl)))
+            {
+                _customControlLayoutUpdateRequired = true;
+            }
+        }
+
+        /// <summary>
+        /// Used to make sure the custom controls layout matches the rest of the dialog. Assumes the custom control has a 3 column
+        /// grid just like the main dialog page. If it doesn't no layout update is done.
+        /// </summary>
+        private void DebugPageControl_LayoutUpdated(Object sender, EventArgs e)
+        {
+            if(_customControlLayoutUpdateRequired)
+            {
+                _customControlLayoutUpdateRequired = false;
+                // Get our grid. We actually want the grid added to the the outer grid since that is the one which 
+                // ultimately contains the custom control
+                Grid outerGrid = Content as Grid;
+                foreach(var child in outerGrid.Children)
+                {
+                    if(child is Grid)
+                    {
+                        Grid hostingGrid = (Grid)child;
+
+                        // Get the control that was added to the grid
+                        var customControl = ((DebugPageViewModel)this.DataContext).ActiveProviderUserControl;
+                        if(customControl != null)
+                        {
+                            var childGrid = customControl.Content as Grid;
+                            if(childGrid != null && childGrid.ColumnDefinitions.Count == hostingGrid.ColumnDefinitions.Count)
+                            {
+                                for (int i = 0; i < childGrid.ColumnDefinitions.Count; i++)
+                                {
+                                    childGrid.ColumnDefinitions[i].Width = new GridLength(hostingGrid.ColumnDefinitions[i].ActualWidth);
+                                }
+                            }
+                        }
+
+                        break;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml.cs
@@ -99,33 +99,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// </summary>
         private void DebugPageControl_LayoutUpdated(Object sender, EventArgs e)
         {
-            if(_customControlLayoutUpdateRequired)
+            if(_customControlLayoutUpdateRequired && _mainGrid != null && DataContext != null)
             {
                 _customControlLayoutUpdateRequired = false;
-                // Get our grid. We actually want the grid added to the the outer grid since that is the one which 
-                // ultimately contains the custom control
-                Grid outerGrid = Content as Grid;
-                foreach(var child in outerGrid.Children)
+
+                // Get the control that was added to the grid
+                var customControl = ((DebugPageViewModel)DataContext).ActiveProviderUserControl;
+                if(customControl != null)
                 {
-                    if(child is Grid)
+                    if (customControl.Content is Grid childGrid && childGrid.ColumnDefinitions.Count == _mainGrid.ColumnDefinitions.Count)
                     {
-                        Grid hostingGrid = (Grid)child;
-
-                        // Get the control that was added to the grid
-                        var customControl = ((DebugPageViewModel)this.DataContext).ActiveProviderUserControl;
-                        if(customControl != null)
+                        for (int i = 0; i < childGrid.ColumnDefinitions.Count; i++)
                         {
-                            var childGrid = customControl.Content as Grid;
-                            if(childGrid != null && childGrid.ColumnDefinitions.Count == hostingGrid.ColumnDefinitions.Count)
-                            {
-                                for (int i = 0; i < childGrid.ColumnDefinitions.Count; i++)
-                                {
-                                    childGrid.ColumnDefinitions[i].Width = new GridLength(hostingGrid.ColumnDefinitions[i].ActualWidth);
-                                }
-                            }
+                            childGrid.ColumnDefinitions[i].Width = new GridLength(_mainGrid.ColumnDefinitions[i].ActualWidth);
                         }
-
-                        break;
                     }
                 }
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -51,7 +51,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 
         public DebugPageViewModel()
         {
-            
         }
 
         // for unit testing
@@ -142,7 +141,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             var customControl = ActiveProvider?.CustomUI;
             if(customControl != null)
             {
-                ActiveProvider?.ProfileSelected(CurrentLaunchSettings);
+                ActiveProvider.ProfileSelected(CurrentLaunchSettings);
 
                 context = customControl.DataContext as INotifyPropertyChanged;
                 if(context != null)
@@ -150,9 +149,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                     context.PropertyChanged += OnCustomUIStateChanged;
                 }
 
-                if(context is INotifyDataErrorInfo)
+                if(context is INotifyDataErrorInfo notifyDataErrorInfo)
                 {
-                    ((INotifyDataErrorInfo)context).ErrorsChanged += OnCustomUIErrorsChanged;
+                    notifyDataErrorInfo.ErrorsChanged += OnCustomUIErrorsChanged;
                 }
             }
         }
@@ -273,35 +272,50 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 
         public bool SupportsExecutable
         {
-            get {  return ActiveProviderSupportsProperty(UIProfilePropertyName.Executable); }
+            get 
+            {  
+                return ActiveProviderSupportsProperty(UIProfilePropertyName.Executable); 
+            }
         }
 
         public bool SupportsArguments
         {
-            get {  return ActiveProviderSupportsProperty(UIProfilePropertyName.Arguments); }
+            get 
+            {  
+                return ActiveProviderSupportsProperty(UIProfilePropertyName.Arguments); 
+            }
         }
 
         public bool SupportsWorkingDirectory
         {
-            get {  return ActiveProviderSupportsProperty(UIProfilePropertyName.WorkingDirectory); }
+            get 
+            {  
+                return ActiveProviderSupportsProperty(UIProfilePropertyName.WorkingDirectory); 
+            }
         }
 
         public bool SupportsLaunchUrl
         {
-            get {  return ActiveProviderSupportsProperty(UIProfilePropertyName.LaunchUrl); }
+            get 
+            {  
+                return ActiveProviderSupportsProperty(UIProfilePropertyName.LaunchUrl); 
+            }
         }
 
         public bool SupportsEnvironmentVariables
         {
-            get {  return ActiveProviderSupportsProperty(UIProfilePropertyName.EnvironmentVariables); }
+            get 
+            {  
+                return ActiveProviderSupportsProperty(UIProfilePropertyName.EnvironmentVariables); 
+            }
         }
 
         /// <summary>
-        /// Helper returns true if there is an actife provider and it supports the specified property
+        /// Helper returns true if there is an active provider and it supports the specified property
         /// </summary>
         private bool ActiveProviderSupportsProperty(string propertyName)
         {
-            var activeProvider = ActiveProvider;;
+            var activeProvider = ActiveProvider;
             return activeProvider?.ShouldEnableProperty(propertyName) ?? false;
         }
 
@@ -582,12 +596,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 NotifyProfileCollectionChanged();
 
                 // If we have a selection, we want to leave it as is
-                if (curProfileName == null || newSettings.Profiles.FirstOrDefault(p => { return LaunchProfile.IsSameProfileName(p.Name, curProfileName); }) == null)
+                if (curProfileName == null || newSettings.Profiles.FirstOrDefault(p => LaunchProfile.IsSameProfileName(p.Name, curProfileName)) == null)
                 {
                     // Note that we have to be careful since the collection can be empty. 
                     if (profiles.ActiveProfile != null && !string.IsNullOrEmpty(profiles.ActiveProfile.Name))
                     {
-                        SelectedDebugProfile = LaunchProfiles.Where((p) => LaunchProfile.IsSameProfileName(p.Name, profiles.ActiveProfile.Name)).Single();
+                        SelectedDebugProfile = LaunchProfiles.Where(p => LaunchProfile.IsSameProfileName(p.Name, profiles.ActiveProfile.Name)).Single();
                     }
                     else
                     {
@@ -603,7 +617,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 }
                 else
                 {
-                    SelectedDebugProfile = LaunchProfiles.Where((p) => LaunchProfile.IsSameProfileName(p.Name, curProfileName)).Single();
+                    SelectedDebugProfile = LaunchProfiles.Where(p => LaunchProfile.IsSameProfileName(p.Name, curProfileName)).Single();
                 }
             }
             finally
@@ -856,7 +870,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 
             NotifyProfileCollectionChanged();
             
-            // Todo: Do we need this extra property change
+            // Fire a property changed so we can get the page to be dirty when we add a new profile
             OnPropertyChanged("_NewProfile");
             SelectedDebugProfile = profile;
         }
@@ -984,13 +998,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         {
             get
             {
-                var notifyDataError = ActiveProvider?.CustomUI?.DataContext as INotifyDataErrorInfo;
-                if(notifyDataError != null)
+                if (ActiveProvider?.CustomUI?.DataContext is INotifyDataErrorInfo notifyDataError)
                 {
-                    if(notifyDataError.HasErrors)
-                    {
-                        return true;
-                    }
+                    return notifyDataError.HasErrors;
                 }
 
                 return false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -127,11 +127,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         public void SwitchProviders(ILaunchSettingsUIProvider oldProvider)
         {
             // Get the old custom control and disconnect from notifications
-            var context = oldProvider?.CustomUI?.DataContext as INotifyPropertyChanged;
-            if(context != null)
+            if (oldProvider?.CustomUI?.DataContext is INotifyPropertyChanged context)
             {
                 context.PropertyChanged -= OnCustomUIStateChanged;
-                if(context is INotifyDataErrorInfo)
+                if (context is INotifyDataErrorInfo)
                 {
                     ((INotifyDataErrorInfo)context).ErrorsChanged -= OnCustomUIErrorsChanged;
                 }
@@ -303,7 +302,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         private bool ActiveProviderSupportsProperty(string propertyName)
         {
             var activeProvider = ActiveProvider;;
-            return activeProvider == null? false: activeProvider.ShouldEnableProperty(propertyName);
+            return activeProvider?.ShouldEnableProperty(propertyName) ?? false;
         }
 
         public bool IsProfileSelected
@@ -574,7 +573,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 PushIgnoreEvents();
 
                 // Remember the current selection
-                string curProfileName = SelectedDebugProfile == null ? null : SelectedDebugProfile.Name;
+                string curProfileName = SelectedDebugProfile?.Name;
 
                 // Update the set of settings and generate a property change so the list of profiles gets updated. Note that we always
                 // clear the active profile on the CurrentLaunchSettings so that when we do set one and property changed event is set

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -1,15 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
+using System.Windows.Controls;
 using System.Windows.Input;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
@@ -17,7 +17,7 @@ using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 {
-    internal class DebugPageViewModel : PropertyPageViewModel
+    internal class DebugPageViewModel : PropertyPageViewModel, INotifyDataErrorInfo
     {
         private readonly string _executableFilter = string.Format("{0} (*.exe)|*.exe|{1} (*.*)|*.*", PropertyPageResources.ExecutableFiles, PropertyPageResources.AllFiles);
         private IDisposable _debugProfileProviderLink;
@@ -38,51 +38,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             }
         }
 
+        // The collection of UI providers.
+        private OrderPrecedenceImportCollection<ILaunchSettingsUIProvider> _uiProviders;
+
+        // Tracks the current set of settings being worked on
+        private IWritableLaunchSettings CurrentLaunchSettings { get; set; }
+
         public event EventHandler ClearEnvironmentVariablesGridError;
         public event EventHandler FocusEnvironmentVariablesGridRow;
+
+        public event EventHandler<DataErrorsChangedEventArgs> ErrorsChanged;
+
         public DebugPageViewModel()
         {
-
+            
         }
+
         // for unit testing
-        internal DebugPageViewModel(bool useTaskFactory,UnconfiguredProject unconfiguredProject)
+        internal DebugPageViewModel(bool useTaskFactory, UnconfiguredProject unconfiguredProject)
         {
             _useTaskFactory = useTaskFactory;
             UnconfiguredProject = unconfiguredProject;
-        }
-        
-        public string SelectedCommandName
-        {
-            get
-            {
-                if (!IsProfileSelected)
-                {
-                    return string.Empty;
-                }
-
-                return SelectedDebugProfile.CommandName;
-            }
-            set
-            {
-                if (SelectedDebugProfile != null && SelectedDebugProfile.CommandName != value)
-                {
-                    SelectedDebugProfile.CommandName = value;
-                    OnPropertyChanged(nameof(SelectedCommandName));
-                }
-            }
-        }
-
-        private ObservableCollection<string> _commandNames;
-        public ObservableCollection<string> CommandNames
-        {
-            get
-            {
-                return _commandNames;
-            }
-            set
-            {
-                OnPropertyChanged(ref _commandNames, value);
-            }
         }
         
         private List<LaunchType> _launchTypes;
@@ -107,6 +83,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             }
             set
             {
+                var oldActiveProvider = ActiveProvider;
                 if (OnPropertyChanged(ref _selectedLaunchType, value))
                 {
                     // Existing commands are shown in the UI as project
@@ -127,13 +104,69 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                             ExecutablePath = null;
                         }
 
-                        OnPropertyChanged(nameof(IsExecutable));
-                        OnPropertyChanged(nameof(IsProject));
+                        // Let the active provider know of the changes. 
+                        SwitchProviders(oldActiveProvider);
+
+                        // These are all controlled by the ui provider and is affected by changing the launch type
+                        OnPropertyChanged(nameof(SupportsExecutable));
+                        OnPropertyChanged(nameof(SupportsArguments));
+                        OnPropertyChanged(nameof(SupportsWorkingDirectory));
+                        OnPropertyChanged(nameof(SupportsLaunchUrl));
+                        OnPropertyChanged(nameof(SupportsEnvironmentVariables));
+                        OnPropertyChanged(nameof(ActiveProviderUserControl));
+                        OnPropertyChanged(nameof(DoesNotHaveErrors));
                     }
                 }
             }
         }
         
+        /// <summary>
+        /// If we have an existing CustomControl, we disconnect from its change notifications
+        /// and hook into the new ones. Assumes the activeProvider has already been changed
+        /// </summary>
+        public void SwitchProviders(ILaunchSettingsUIProvider oldProvider)
+        {
+            // Get the old custom control and disconnect from notifications
+            var context = oldProvider?.CustomUI?.DataContext as INotifyPropertyChanged;
+            if(context != null)
+            {
+                context.PropertyChanged -= OnCustomUIStateChanged;
+                if(context is INotifyDataErrorInfo)
+                {
+                    ((INotifyDataErrorInfo)context).ErrorsChanged -= OnCustomUIErrorsChanged;
+                }
+            }
+
+            // Now hook into the current providers notifications. We do that after having set the profile on the provider
+            // so that we don't get notifications while the control is initializing. Note that this is likely the first time the 
+            // custom control is asked for and we want to call it and have it created prior to setting the active profile
+            var customControl = ActiveProvider?.CustomUI;
+            if(customControl != null)
+            {
+                ActiveProvider?.ProfileSelected(CurrentLaunchSettings);
+
+                context = customControl.DataContext as INotifyPropertyChanged;
+                if(context != null)
+                {
+                    context.PropertyChanged += OnCustomUIStateChanged;
+                }
+
+                if(context is INotifyDataErrorInfo)
+                {
+                    ((INotifyDataErrorInfo)context).ErrorsChanged += OnCustomUIErrorsChanged;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Called from the CustomUI when a change occurs. This just fires a dummy property change
+        /// to dirty the page.
+        /// </summary>
+        private void OnCustomUIStateChanged(Object sender, PropertyChangedEventArgs e)
+        {
+            OnPropertyChanged("CustomUIDirty");
+        }
+
         public string CommandLineArguments
         {
             get
@@ -239,32 +272,40 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             }
         }
 
-        public bool IsExecutable
+        public bool SupportsExecutable
         {
-            get
-            {
-                if (SelectedLaunchType == null)
-                {
-                    return false;
-                }
-
-                return SelectedLaunchType.CommandName == ProfileCommandNames.Executable;
-            }
+            get {  return ActiveProviderSupportsProperty(UIProfilePropertyName.Executable); }
         }
 
-        public bool IsProject
+        public bool SupportsArguments
         {
-            get
-            {
-                if (SelectedLaunchType == null)
-                {
-                    return false;
-                }
-
-                return SelectedLaunchType.CommandName == ProfileCommandNames.Project;
-            }
+            get {  return ActiveProviderSupportsProperty(UIProfilePropertyName.Arguments); }
         }
-        
+
+        public bool SupportsWorkingDirectory
+        {
+            get {  return ActiveProviderSupportsProperty(UIProfilePropertyName.WorkingDirectory); }
+        }
+
+        public bool SupportsLaunchUrl
+        {
+            get {  return ActiveProviderSupportsProperty(UIProfilePropertyName.LaunchUrl); }
+        }
+
+        public bool SupportsEnvironmentVariables
+        {
+            get {  return ActiveProviderSupportsProperty(UIProfilePropertyName.EnvironmentVariables); }
+        }
+
+        /// <summary>
+        /// Helper returns true if there is an actife provider and it supports the specified property
+        /// </summary>
+        private bool ActiveProviderSupportsProperty(string propertyName)
+        {
+            var activeProvider = ActiveProvider;;
+            return activeProvider == null? false: activeProvider.ShouldEnableProperty(propertyName);
+        }
+
         public bool IsProfileSelected
         {
             get
@@ -273,58 +314,47 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             }
         }
 
-        private ObservableCollection<LaunchProfile> _debugProfiles;
-        public ObservableCollection<LaunchProfile> DebugProfiles
+        public List<IWritableLaunchProfile> LaunchProfiles
         {
             get
             {
-                return _debugProfiles;
-            }
-            set
-            {
-                var oldProfiles = _debugProfiles;
-                if (OnPropertyChanged(ref _debugProfiles, value))
-                {
-                    if (oldProfiles != null)
-                    {
-                        oldProfiles.CollectionChanged -= DebugProfiles_CollectionChanged;
-                    }
-                    if (_debugProfiles != null)
-                    {
-                        _debugProfiles.CollectionChanged += DebugProfiles_CollectionChanged;
-                    }
-                    OnPropertyChanged(nameof(HasProfiles));
-                    OnPropertyChanged(nameof(NewProfileEnabled));
-                }
+                return CurrentLaunchSettings?.Profiles;
             }
         }
 
-        private void DebugProfiles_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        /// <summary>
+        /// Helper called when a profile is added (new profile command), or a profile is deleted (delete profile command)
+        /// </summary>
+        private void NotifyProfileCollectionChanged()
         {
+            OnPropertyChanged(nameof(LaunchProfiles));
             OnPropertyChanged(nameof(HasProfiles));
+            OnPropertyChanged(nameof(NewProfileEnabled));
         }
         
         public bool HasProfiles
         {
             get
             {
-                return _debugProfiles != null && _debugProfiles.Count > 0;
+                return CurrentLaunchSettings != null && CurrentLaunchSettings.Profiles.Count > 0;
             }
         }
 
-        private LaunchProfile _selectedDebugProfile;
-        public LaunchProfile SelectedDebugProfile
+        /// <summary>
+        /// Use the active profile in the CurrentLaunchSettings
+        /// </summary>
+        public IWritableLaunchProfile SelectedDebugProfile
         {
             get
             {
-                return _selectedDebugProfile;
+                return CurrentLaunchSettings?.ActiveProfile;
             }
             set
             {
-                if (_selectedDebugProfile != value)
+                if (CurrentLaunchSettings != null && CurrentLaunchSettings.ActiveProfile != value)
                 {
-                    var oldProfile = _selectedDebugProfile;
-                    _selectedDebugProfile = value;
+                    var oldProfile = CurrentLaunchSettings.ActiveProfile;
+                    CurrentLaunchSettings.ActiveProfile = value;
                     NotifySelectedChanged(oldProfile);
                 }
             }
@@ -402,7 +432,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             }
         }
 
-        protected virtual void NotifySelectedChanged(LaunchProfile oldProfile)
+        /// <summary>
+        /// Provides binding to the current UI Provider usercontrol. 
+        /// </summary>
+        public UserControl ActiveProviderUserControl
+        {
+            get 
+            {
+                var provider = ActiveProvider;
+                return ActiveProvider?.CustomUI;
+            }
+        }
+
+        /// <summary>
+        /// Called when the selection does change. Note that this code relies on the fact the current selection has been
+        /// updated
+        /// </summary>
+        protected virtual void NotifySelectedChanged(IWritableLaunchProfile oldProfile)
         {
             // we need to keep the property page control from setting IsDirty when we are just switching between profiles.
             // we still need to notify the display of the changes though
@@ -418,12 +464,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 OnPropertyChanged(nameof(LaunchPage));
                 OnPropertyChanged(nameof(HasLaunchOption));
                 OnPropertyChanged(nameof(WorkingDirectory));
-                OnPropertyChanged(nameof(SelectedCommandName));
                 
-                SetLaunchType();
+                UpdateLaunchTypes();
 
-                OnPropertyChanged(nameof(IsExecutable));
-                OnPropertyChanged(nameof(IsProject));
                 OnPropertyChanged(nameof(IsProfileSelected));
                 OnPropertyChanged(nameof(DeleteProfileEnabled));
                 
@@ -455,38 +498,45 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         public async virtual System.Threading.Tasks.Task SaveLaunchSettings()
         {
             ILaunchSettingsProvider provider = GetDebugProfileProvider();
-            if (EnvironmentVariables != null && EnvironmentVariables.Count > 0)
+            if (EnvironmentVariables != null && EnvironmentVariables.Count > 0 && SelectedDebugProfile != null)
             {
-                SelectedDebugProfile.MutableEnvironmentVariables = EnvironmentVariables.CreateDictionary();
+                SelectedDebugProfile.EnvironmentVariables.Clear();
+                foreach(var kvp in EnvironmentVariables)
+                {
+                    SelectedDebugProfile.EnvironmentVariables.Add(kvp.Name, kvp.Value);
+                }
             }
             else if (SelectedDebugProfile != null)
             {
-                SelectedDebugProfile.MutableEnvironmentVariables = null;
+                SelectedDebugProfile.EnvironmentVariables.Clear();
             }
-            var globalSettings = provider.CurrentSnapshot.GlobalSettings;
-            await provider.UpdateAndSaveSettingsAsync(new LaunchSettings(DebugProfiles, globalSettings, SelectedDebugProfile?.Name)).ConfigureAwait(false);
+            await provider.UpdateAndSaveSettingsAsync(CurrentLaunchSettings.ToLaunchSettings()).ConfigureAwait(false);
         }
 
-        private void SetEnvironmentGrid(LaunchProfile oldProfile)
+        private void SetEnvironmentGrid(IWritableLaunchProfile oldProfile)
         {
             if (EnvironmentVariables != null && oldProfile != null)
             {
                 if (_environmentVariables.Count > 0)
                 {
-                    oldProfile.MutableEnvironmentVariables = EnvironmentVariables.CreateDictionary();
+                    oldProfile.EnvironmentVariables.Clear();
+                    foreach(var kvp in EnvironmentVariables)
+                    {
+                        oldProfile.EnvironmentVariables.Add(kvp.Name, kvp.Value);
+                    }
                 }
                 else
                 {
-                    oldProfile.MutableEnvironmentVariables = null;
+                    oldProfile.EnvironmentVariables.Clear();
                 }
                 EnvironmentVariables.ValidationStatusChanged -= EnvironmentVariables_ValidationStatusChanged;
                 EnvironmentVariables.CollectionChanged -= EnvironmentVariables_CollectionChanged;
                 ((INotifyPropertyChanged)EnvironmentVariables).PropertyChanged -= DebugPageViewModel_EnvironmentVariables_PropertyChanged;
             }
 
-            if (SelectedDebugProfile != null && SelectedDebugProfile.MutableEnvironmentVariables != null)
+            if (SelectedDebugProfile != null)
             {
-                EnvironmentVariables = SelectedDebugProfile.MutableEnvironmentVariables.CreateList();
+                EnvironmentVariables = SelectedDebugProfile.EnvironmentVariables.CreateList();
             }
             else
             {
@@ -506,74 +556,56 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// <summary>
         /// Called whenever the debug targets change. Note that after a save this function will be
         /// called. It looks for changes and applies them to the UI as needed. Switching profiles
-        /// will also cause this to change as the active profile is stored in profiles snaphost.
+        /// will also cause this to change as the active profile is stored in the profiles snapshot.
         /// </summary>
         internal virtual void InitializeDebugTargetsCore(ILaunchSettings profiles)
         {
-            bool profilesChanged = true;
-            bool IISSettingsChanged = true;
+            var newSettings = profiles.ToWritableLaunchSettings();
 
             // Since this get's reentered if the user saves or the user switches active profiles.
-            if (DebugProfiles != null)
+            if (CurrentLaunchSettings != null && !CurrentLaunchSettings.SetttingsDiffer(newSettings))
             {
-                profilesChanged = profiles.ProfilesAreDifferent(DebugProfiles.Select(p => (ILaunchProfile)p).ToList());
-                if (!profilesChanged && !IISSettingsChanged)
-                {
-                    return;
-                }
+                return;
             }
 
             try
             {
-                // This should never change the dirty state
+                // This should never change the dirty state when loading the dialog
                 PushIgnoreEvents();
 
-                if (profilesChanged)
+                // Remember the current selection
+                string curProfileName = SelectedDebugProfile == null ? null : SelectedDebugProfile.Name;
+
+                // Update the set of settings and generate a property change so the list of profiles gets updated. Note that we always
+                // clear the active profile on the CurrentLaunchSettings so that when we do set one and property changed event is set
+                CurrentLaunchSettings = newSettings;
+                CurrentLaunchSettings.ActiveProfile = null;
+                NotifyProfileCollectionChanged();
+
+                // If we have a selection, we want to leave it as is
+                if (curProfileName == null || newSettings.Profiles.FirstOrDefault(p => { return LaunchProfile.IsSameProfileName(p.Name, curProfileName); }) == null)
                 {
-                    // Remember the current selection
-                    string curProfileName = SelectedDebugProfile?.Name;
-
-                    // Load debug profiles
-                    var debugProfiles = new ObservableCollection<LaunchProfile>();
-
-                    foreach (var profile in profiles.Profiles)
+                    // Note that we have to be careful since the collection can be empty. 
+                    if (profiles.ActiveProfile != null && !string.IsNullOrEmpty(profiles.ActiveProfile.Name))
                     {
-                        // Don't show the dummy NoAction profile
-                        if (profile.CommandName != ProfileCommandNames.NoAction)
-                        {
-                            var newProfile = new LaunchProfile(profile);
-                            debugProfiles.Add(newProfile);
-                        }
-                    }
-                                        
-                    DebugProfiles = debugProfiles;
-
-                    // If we have a selection, we want to leave it as is
-                    if (curProfileName == null || profiles.Profiles.FirstOrDefault(p => { return LaunchProfile.IsSameProfileName(p.Name, curProfileName); }) == null)
-                    {
-                        // Note that we have to be careful since the collection can be empty. 
-                        if (!string.IsNullOrEmpty(profiles.ActiveProfile.Name))
-                        {
-                            SelectedDebugProfile = DebugProfiles.Where((p) => LaunchProfile.IsSameProfileName(p.Name, profiles.ActiveProfile.Name)).Single();
-                        }
-                        else
-                        {
-                            if (debugProfiles.Count > 0)
-                            {
-                                SelectedDebugProfile = debugProfiles[0];
-                            }
-                            else
-                            {
-                                SetEnvironmentGrid(null);
-                            }
-                        }
+                        SelectedDebugProfile = LaunchProfiles.Where((p) => LaunchProfile.IsSameProfileName(p.Name, profiles.ActiveProfile.Name)).Single();
                     }
                     else
                     {
-                        SelectedDebugProfile = DebugProfiles.Where((p) => LaunchProfile.IsSameProfileName(p.Name, curProfileName)).Single();
+                        if (LaunchProfiles.Count > 0)
+                        {
+                            SelectedDebugProfile = LaunchProfiles[0];
+                        }
+                        else
+                        {
+                            SetEnvironmentGrid(null);
+                        }
                     }
                 }
-                
+                else
+                {
+                    SelectedDebugProfile = LaunchProfiles.Where((p) => LaunchProfile.IsSameProfileName(p.Name, curProfileName)).Single();
+                }
             }
             finally
             {
@@ -582,9 +614,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         }
 
         /// <summary>
-        /// Initializes from the set of debug targets. It also hooks into debug provider so that it can update when the profile changes
+        /// The initialization entry point for the page It also hooks into debug provider so that it can update when the profile changes
         /// </summary>
-        protected virtual void InitializeDebugTargets()
+        protected void InitializePropertyPage()
         {
             if (_debugProfileProviderLink == null)
             {
@@ -602,12 +634,56 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 _debugProfileProviderLink = profileProvider.SourceBlock.LinkTo(
                     debugProfilesBlock,
                     linkOptions: new DataflowLinkOptions { PropagateCompletion = true });
+                
+                // We need to get the set of UI providers, if any.
+                InitializeUIProviders();
             }
         }
+
+        /// <summary>
+        /// initializes the collection of UI providers.
+        /// </summary>
+        private void InitializeUIProviders()
+        {
+            // We need to get the set of UI providers, if any.
+            _uiProviders = new OrderPrecedenceImportCollection<ILaunchSettingsUIProvider>(ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesFirst, UnconfiguredProject);
+            var uiProviders = GetUIProviders();
+            foreach (var uiProvider in uiProviders)
+            {
+                _uiProviders.Add(uiProvider);
+            }
+        }
+
+        /// <summary>
+        /// Gets the UI providers
+        /// </summary>
+        protected virtual IEnumerable<Lazy<ILaunchSettingsUIProvider, IOrderPrecedenceMetadataView>> GetUIProviders()
+        {
+            return UnconfiguredProject.Services.ExportProvider.GetExports<ILaunchSettingsUIProvider, IOrderPrecedenceMetadataView>();
+        }
+
+        /// <summary>
+        /// Returns the active UI provider for the current selected launchType or mull if no selection or the selected item
+        /// does not have a provider installed
+        /// </summary>
+        private ILaunchSettingsUIProvider ActiveProvider
+        {
+            get
+            {
+                if(SelectedLaunchType == null)
+                {
+                    return null;
+                }
+
+                var activeProvider =  _uiProviders.FirstOrDefault((p) => string.Equals(p.Value.CommandName, SelectedLaunchType.CommandName, StringComparison.OrdinalIgnoreCase));
+                return activeProvider?.Value;
+            }
+        }
+
         public override System.Threading.Tasks.Task Initialize()
         {
-            // Create the debug targets dropdown
-            InitializeDebugTargets();
+            // Initialize the page
+            InitializePropertyPage();
             return System.Threading.Tasks.Task.CompletedTask;
         }
 
@@ -616,6 +692,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// </summary>
         public async override Task<int> Save()
         {
+            if(HasErrors)
+            {
+                throw new Exception(PropertyPageResources.ErrorsMustBeCorrectedPriorToSaving);
+            }
+
             await SaveLaunchSettings().ConfigureAwait(false);
 
             return VSConstants.S_OK;
@@ -711,20 +792,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             }
         }
         
-        public string CopyHyperlinkText
-        {
-            get
-            {
-                // Can't use x:Static in xaml since our resources are internal.
-                return PropertyPageResources.CopyHyperlinkText;
-            }
-        }
-
         public bool NewProfileEnabled
         {
             get
             {
-                return _debugProfiles != null;
+                return LaunchProfiles != null;
             }
         }
 
@@ -771,26 +843,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                     {
                         var profileToRemove = SelectedDebugProfile;
                         SelectedDebugProfile = null;
-                        DebugProfiles.Remove(profileToRemove);
-                        SelectedDebugProfile = DebugProfiles.Count > 0 ? DebugProfiles[0] : null;
+                        LaunchProfiles.Remove(profileToRemove);
+                        SelectedDebugProfile = LaunchProfiles.Count > 0 ? LaunchProfiles[0] : null;
+                        NotifyProfileCollectionChanged();
                     }));
             }
         }
 
-        internal LaunchProfile CreateProfile(string name, string commandName)
+        internal void CreateProfile(string name, string commandName)
         {
-            var profile = new LaunchProfile() { Name = name, CommandName = commandName };
-            DebugProfiles.Add(profile);
+            var profile = new WritableLaunchProfile() { Name = name, CommandName = commandName };
+            CurrentLaunchSettings.Profiles.Add(profile);
 
-            // Fire a property changed so we can get the page to be dirty when we add a new profile
+            NotifyProfileCollectionChanged();
+            
+            // Todo: Do we need this extra property change
             OnPropertyChanged("_NewProfile");
             SelectedDebugProfile = profile;
-            return profile;
         }
 
         internal bool IsNewProfileNameValid(string name)
         {
-            return DebugProfiles.Where(
+            return LaunchProfiles.Where(
                 profile => LaunchProfile.IsSameProfileName(profile.Name, name)).Count() == 0;
         }
 
@@ -808,36 +882,50 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             return string.Empty;
         }
         
-        private void SetLaunchType()
+        /// <summary>
+        /// Called after every profile change to update the list of launch types based on the following:
+        /// 
+        ///     The list of UI providers as each provider provides a name
+        ///     The command name in the profile if it doesn't match one of the existing providers.
+        ///     
+        /// </summary>
+        private List<LaunchType> _providerLaunchTypes;
+        private void UpdateLaunchTypes()
         {
-            if (!IsProfileSelected)
+            // Populate the set of unique launch types from the list of providers since there can be duplicates with different priorities. However,
+            // the command name will be the same so we can grab the first one for the purposes of populating the list
+            if(_providerLaunchTypes == null)
             {
-                _launchTypes = new List<LaunchType>();
-            }
-            else if (SelectedDebugProfile.CommandName == ProfileCommandNames.Executable ||
-                     (SelectedDebugProfile.CommandName == ProfileCommandNames.IISExpress))
-            {
-
-                _launchTypes = LaunchType.GetExecutableOnlyLaunchTypes().ToList();
-
-            }
-            else
-            {
-                _launchTypes = LaunchType.GetBuiltInLaunchTypes().ToList();
+                _providerLaunchTypes =  new List<LaunchType>();
+                foreach(var provider in _uiProviders)
+                {
+                    if(_providerLaunchTypes.FirstOrDefault((lt) => lt.CommandName.Equals(provider.Value.CommandName)) == null)
+                    {
+                        _providerLaunchTypes.Add(new LaunchType() { CommandName = provider.Value.CommandName, Name = provider.Value.FriendlyName});
+                    }
+                }
             }
 
+            var selectedProfile = SelectedDebugProfile;
+            LaunchType selectedLaunchType = null;
+
+            _launchTypes = new List<LaunchType>();
+            if (selectedProfile != null)
+            {
+                _launchTypes.AddRange(_providerLaunchTypes);
+
+                selectedLaunchType = _launchTypes.FirstOrDefault((launchType) => string.Equals(launchType.CommandName, selectedProfile.CommandName));
+                if(selectedLaunchType == null)
+                {
+                    selectedLaunchType = new LaunchType() { CommandName = selectedProfile.CommandName, Name = selectedProfile.CommandName};
+                    _launchTypes.Insert(0, selectedLaunchType);
+                }
+            }
+
+            // Need to notify the list has changed prior to changing the selected one
             OnPropertyChanged(nameof(LaunchTypes));
 
-            // The selected launch type has to be tweaked for DotNet since in dotnet we don't want to support commands and yet user might have some commands 
-            if (!IsProfileSelected)
-            {
-                SelectedLaunchType = null;
-            }
-            else
-            {
-                var selCommandName = SelectedDebugProfile.CommandName;
-                SelectedLaunchType = LaunchType.GetAllLaunchTypes().Where(lt => lt.CommandName == selCommandName).SingleOrDefault();
-            }
+            SelectedLaunchType = selectedLaunchType;
         }
         
         private void EnvironmentVariables_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
@@ -864,13 +952,61 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             }
         }
         
-        [ExcludeFromCodeCoverage]
+        ILaunchSettingsProvider _launchSettingsProvider;
         protected virtual ILaunchSettingsProvider GetDebugProfileProvider()
         {
-            return UnconfiguredProject.Services.ExportProvider.GetExportedValue<ILaunchSettingsProvider>();
+            if(_launchSettingsProvider == null)
+            {
+                _launchSettingsProvider = UnconfiguredProject.Services.ExportProvider.GetExportedValue<ILaunchSettingsProvider>();
+            }
+
+            return _launchSettingsProvider;
         }
-                
-        internal class LaunchType
+
+        /// <summary>
+        /// Called by the currently active control when errors within the control have changed
+        /// </summary>
+        private void OnCustomUIErrorsChanged(Object sender, DataErrorsChangedEventArgs e)
+        {
+            ErrorsChanged?.Invoke(this, e);
+
+            OnPropertyChanged(nameof(DoesNotHaveErrors));
+        }
+
+        public IEnumerable GetErrors(string propertyName)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// We are considered in error if we have errors, or the currently active control has errors
+        /// </summary>
+        public bool HasErrors
+        {
+            get
+            {
+                var notifyDataError = ActiveProvider?.CustomUI?.DataContext as INotifyDataErrorInfo;
+                if(notifyDataError != null)
+                {
+                    if(notifyDataError.HasErrors)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        public bool DoesNotHaveErrors
+        {
+            get
+            {
+                return !HasErrors;
+            }
+        }
+
+        public class LaunchType
         {
             public string CommandName { get; set; }
             public string Name { get; set; }
@@ -889,31 +1025,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             {
                 return CommandName.GetHashCode();
             }
-
-            public static readonly LaunchType Executable = new LaunchType() { CommandName = ProfileCommandNames.Executable, Name = PropertyPageResources.ProfileKindExecutableName };
-            public static readonly LaunchType Project = new LaunchType() { CommandName = ProfileCommandNames.Project, Name = PropertyPageResources.ProfileKindProjectName };
-            public static readonly LaunchType IISExpress = new LaunchType() { CommandName = ProfileCommandNames.IISExpress, Name = PropertyPageResources.ProfileKindIISExpressName };
-
-            public static LaunchType[] GetAllLaunchTypes()
-            {
-                return _allLaunchTypes;
-            }
-            
-            public static LaunchType[] GetBuiltInLaunchTypes()
-            {
-                return  _builtInLaunchTypes;
-            }
-            
-            public static LaunchType[] GetExecutableOnlyLaunchTypes()
-            {
-                return _executableOnlyLaunchType;
-            }
-
-
-            private static readonly LaunchType[] _allLaunchTypes = new LaunchType[] { Executable, IISExpress, Project };
-            private static readonly LaunchType[] _builtInLaunchTypes = new LaunchType[] { Executable, Project };
-            private static readonly LaunchType[] _executableOnlyLaunchType = new LaunchType[] { Executable, Project };
-            
         }
     }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/ExecutableLaunchSettingsUIProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/ExecutableLaunchSettingsUIProvider.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using System.Windows.Controls;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
+{
+    /// <summary>
+    /// Interface definition which allows a launch settings provider to participate in the debug property page UI. The Set of 
+    /// LaunchSettingUIProviders provides the set of entries for the debug dropdown command list.
+    /// </summary>
+    [Export( typeof(ILaunchSettingsUIProvider))]
+    [AppliesTo(ProjectCapability.LaunchProfiles)]
+    [Order(0)]              // Lowest priority to llow this to be overridden
+    internal class ExecutableLaunchSettingsUIProvider : ILaunchSettingsUIProvider
+    {
+        [ImportingConstructor]
+        public ExecutableLaunchSettingsUIProvider(UnconfiguredProject uncProject)
+        {
+        
+        }
+
+        /// <summary>
+        /// The name of the command that is written to the launchSettings.json file
+        /// </summary>
+        public string CommandName
+        { 
+            get 
+            {
+                return LaunchSettingsProvider.RunExecutableCommandName;
+            } 
+        }
+
+        /// <summary>
+        /// The name to display in the dropdown for this command
+        /// </summary>
+        public string FriendlyName 
+        { 
+            get 
+            {
+                return PropertyPageResources.ProfileKindExecutableName;
+            } 
+        }
+
+        /// <summary>
+        /// Current supports these property names which map to the the default set of properties
+        ///     "Executable"
+        ///     "Arguments"
+        ///     "LaunchUrl"
+        ///     "EnvironmentVariables"
+        ///     "WorkingDirectory"
+        /// The names are case insensitive 
+        /// </summary>
+        public bool ShouldEnableProperty(string propertyName)
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// No custom UI
+        /// </summary>
+        public UserControl CustomUI { get {return null;} }
+
+        /// <summary>
+        /// Called when the selected profile changes to a profile which matches this command. curSettings will contain 
+        /// the current values from the page, and activeProfile will point to the active one.
+        /// </summary>
+        public void ProfileSelected(IWritableLaunchSettings curSettings)
+        {
+            return;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/ExecutableLaunchSettingsUIProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/ExecutableLaunchSettingsUIProvider.cs
@@ -7,18 +7,19 @@ using Microsoft.VisualStudio.ProjectSystem.Debug;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 {
     /// <summary>
-    /// Interface definition which allows a launch settings provider to participate in the debug property page UI. The Set of 
-    /// LaunchSettingUIProviders provides the set of entries for the debug dropdown command list.
+    /// Implementation of ILaunchSettingsUIProvider for the Executable launch type.
     /// </summary>
     [Export( typeof(ILaunchSettingsUIProvider))]
     [AppliesTo(ProjectCapability.LaunchProfiles)]
     [Order(0)]              // Lowest priority to llow this to be overridden
     internal class ExecutableLaunchSettingsUIProvider : ILaunchSettingsUIProvider
     {
+        /// <summary>
+        /// Required to control the MEF scope
+        /// </summary>
         [ImportingConstructor]
         public ExecutableLaunchSettingsUIProvider(UnconfiguredProject uncProject)
         {
-        
         }
 
         /// <summary>
@@ -44,13 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         }
 
         /// <summary>
-        /// Current supports these property names which map to the the default set of properties
-        ///     "Executable"
-        ///     "Arguments"
-        ///     "LaunchUrl"
-        ///     "EnvironmentVariables"
-        ///     "WorkingDirectory"
-        /// The names are case insensitive 
+        /// All controls are supported
         /// </summary>
         public bool ShouldEnableProperty(string propertyName)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/ProjectLaunchSettingsUIProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/ProjectLaunchSettingsUIProvider.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using System.Windows.Controls;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
+{
+    /// <summary>
+    /// Interface definition which allows a launch settings provider to participate in the debug property page UI. The Set of 
+    /// LaunchSettingUIProviders provides the set of entries for the debug dropdown command list.
+    /// </summary>
+    [Export(typeof(ILaunchSettingsUIProvider))]
+    [AppliesTo(ProjectCapability.LaunchProfiles)]
+    [Order(0)]              // Lowest priority to allow this to be overridden
+    internal class ProjectLaunchSettingsUIProvider : ILaunchSettingsUIProvider
+    {
+        [ImportingConstructor]
+        public ProjectLaunchSettingsUIProvider(UnconfiguredProject uncProject)
+        {
+        
+        }
+
+        /// <summary>
+        /// The name of the command that is written to the launchSettings.json file
+        /// </summary>
+        public string CommandName 
+        { 
+            get 
+            {
+                return LaunchSettingsProvider.RunProjectCommandName;
+            } 
+        }
+
+        /// <summary>
+        /// The name to display in the dropdown for this command
+        /// </summary>
+        public string FriendlyName 
+        { 
+            get 
+            {
+                return PropertyPageResources.ProfileKindProjectName;
+            } 
+        }
+
+        /// <summary>
+        /// Disable the executable controls
+        /// </summary>
+        public bool ShouldEnableProperty(string propertyName)
+        {
+            return string.Equals(propertyName, UIProfilePropertyName.Executable, System.StringComparison.OrdinalIgnoreCase)? false : true;
+        }
+
+        /// <summary>
+        /// No custom UI
+        /// </summary>
+        public UserControl CustomUI { get {return null;} }
+
+        /// <summary>
+        /// Called when the selected profile changes to a profile which matches this command. curSettings will contain 
+        /// the current values from the page, and activeProfile will point to the active one.
+        /// </summary>
+        public void ProfileSelected(IWritableLaunchSettings curSettings)
+        {
+            return;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/ProjectLaunchSettingsUIProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/ProjectLaunchSettingsUIProvider.cs
@@ -7,14 +7,16 @@ using Microsoft.VisualStudio.ProjectSystem.Debug;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 {
     /// <summary>
-    /// Interface definition which allows a launch settings provider to participate in the debug property page UI. The Set of 
-    /// LaunchSettingUIProviders provides the set of entries for the debug dropdown command list.
+    /// Implementation of ILaunchSettingsUIProvider for the Executable launch type.
     /// </summary>
     [Export(typeof(ILaunchSettingsUIProvider))]
     [AppliesTo(ProjectCapability.LaunchProfiles)]
     [Order(0)]              // Lowest priority to allow this to be overridden
     internal class ProjectLaunchSettingsUIProvider : ILaunchSettingsUIProvider
     {
+        /// <summary>
+        /// Required to control the MEF scope
+        /// </summary>
         [ImportingConstructor]
         public ProjectLaunchSettingsUIProvider(UnconfiguredProject uncProject)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.Designer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         private static global::System.Globalization.CultureInfo resourceCulture;
         
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        public PropertyPageResources() {
+        internal PropertyPageResources() {
         }
         
         /// <summary>
@@ -61,15 +61,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You must run Visual Studio in the context of an administrator account to create IIS Express sites with ports less than 1024..
-        /// </summary>
-        public static string AdminRequiredForPort {
-            get {
-                return ResourceManager.GetString("AdminRequiredForPort", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to All files.
         /// </summary>
         public static string AllFiles {
@@ -84,24 +75,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         public static string ApplicationArgumentsWatermark {
             get {
                 return ResourceManager.GetString("ApplicationArgumentsWatermark", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The URL of the application.
-        /// </summary>
-        public static string ApplicationUrlWatermark {
-            get {
-                return ResourceManager.GetString("ApplicationUrlWatermark", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Copy.
-        /// </summary>
-        public static string CopyHyperlinkText {
-            get {
-                return ResourceManager.GetString("CopyHyperlinkText", resourceCulture);
             }
         }
         
@@ -142,6 +115,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The errors on the page must be corrected prior to saving your changes..
+        /// </summary>
+        public static string ErrorsMustBeCorrectedPriorToSaving {
+            get {
+                return ResourceManager.GetString("ErrorsMustBeCorrectedPriorToSaving", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Executable files.
         /// </summary>
         public static string ExecutableFiles {
@@ -156,51 +138,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         public static string ExecutablePathWatermark {
             get {
                 return ResourceManager.GetString("ExecutablePathWatermark", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The IIS settings are missing the App Url property. This is required to configure IIS to run the site..
-        /// </summary>
-        public static string IISExpressMissingAppUrl {
-            get {
-                return ResourceManager.GetString("IISExpressMissingAppUrl", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The IIS settings are missing the App Url property. This is required to configure IIS to run the site..
-        /// </summary>
-        public static string IISMissingAppUrl {
-            get {
-                return ResourceManager.GetString("IISMissingAppUrl", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The Application Url is invalid. {0}.
-        /// </summary>
-        public static string InvalidAppUrl {
-            get {
-                return ResourceManager.GetString("InvalidAppUrl", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The IIS Application Url is invalid. {0}.
-        /// </summary>
-        public static string InvalidIISAppUrl {
-            get {
-                return ResourceManager.GetString("InvalidIISAppUrl", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The IIS Express Application Url is invalid. {0}.
-        /// </summary>
-        public static string InvalidIISExpressAppUrl {
-            get {
-                return ResourceManager.GetString("InvalidIISExpressAppUrl", resourceCulture);
             }
         }
         
@@ -237,15 +174,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         public static string NewProfileSeedName {
             get {
                 return ResourceManager.GetString("NewProfileSeedName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Command.
-        /// </summary>
-        public static string ProfileKindCommandName {
-            get {
-                return ResourceManager.GetString("ProfileKindCommandName", resourceCulture);
             }
         }
         

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.resx
@@ -117,20 +117,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="AdminRequiredForPort" xml:space="preserve">
-    <value>You must run Visual Studio in the context of an administrator account to create IIS Express sites with ports less than 1024.</value>
-  </data>
   <data name="AllFiles" xml:space="preserve">
     <value>All files</value>
   </data>
   <data name="ApplicationArgumentsWatermark" xml:space="preserve">
     <value>Arguments to be passed to the application</value>
-  </data>
-  <data name="ApplicationUrlWatermark" xml:space="preserve">
-    <value>The URL of the application</value>
-  </data>
-  <data name="CopyHyperlinkText" xml:space="preserve">
-    <value>Copy</value>
   </data>
   <data name="DebugPropertyPageTitle" xml:space="preserve">
     <value>Debug</value>
@@ -150,21 +141,6 @@
   <data name="ExecutablePathWatermark" xml:space="preserve">
     <value>Path to the executable to run</value>
   </data>
-  <data name="IISExpressMissingAppUrl" xml:space="preserve">
-    <value>The IIS settings are missing the App Url property. This is required to configure IIS to run the site.</value>
-  </data>
-  <data name="IISMissingAppUrl" xml:space="preserve">
-    <value>The IIS settings are missing the App Url property. This is required to configure IIS to run the site.</value>
-  </data>
-  <data name="InvalidAppUrl" xml:space="preserve">
-    <value>The Application Url is invalid. {0}</value>
-  </data>
-  <data name="InvalidIISAppUrl" xml:space="preserve">
-    <value>The IIS Application Url is invalid. {0}</value>
-  </data>
-  <data name="InvalidIISExpressAppUrl" xml:space="preserve">
-    <value>The IIS Express Application Url is invalid. {0}</value>
-  </data>
   <data name="LaunchUrlWatermark" xml:space="preserve">
     <value>Absolute or relative URL</value>
   </data>
@@ -176,9 +152,6 @@
   </data>
   <data name="NewProfileSeedName" xml:space="preserve">
     <value>newProfile</value>
-  </data>
-  <data name="ProfileKindCommandName" xml:space="preserve">
-    <value>Command</value>
   </data>
   <data name="ProfileKindExecutableName" xml:space="preserve">
     <value>Executable</value>
@@ -204,4 +177,6 @@
   <data name="WorkingDirectoryWatermark" xml:space="preserve">
     <value>Absolute path to working directory</value>
   </data>
-</root>
+  <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
+    <value>The errors on the page must be corrected prior to saving your changes.</value>
+  </data></root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -44,7 +44,12 @@
     <Compile Include="ProjectSystem\Debug\IDebugTokenReplacer.cs" />
     <Compile Include="ProjectSystem\Debug\DebugTokenReplacer.cs" />
     <Compile Include="ProjectSystem\Debug\IJsonSection.cs" />
+    <Compile Include="ProjectSystem\Debug\IWritableLaunchProfile.cs" />
+    <Compile Include="ProjectSystem\Debug\IWritableLaunchSettings.cs" />
+    <Compile Include="ProjectSystem\Debug\ILaunchSettingsUIProvider.cs" />
     <Compile Include="ProjectSystem\Debug\ILaunchSettingsSerializationProvider.cs" />
+    <Compile Include="ProjectSystem\Debug\WritableLaunchSettings.cs" />
+    <Compile Include="ProjectSystem\Debug\WritableLaunchProfile.cs" />
     <Compile Include="ProjectSystem\Debug\LaunchProfileData.cs" />
     <Compile Include="ProjectSystem\Debug\LaunchProfile.cs" />
     <Compile Include="ProjectSystem\Debug\ILaunchProfile.cs" />
@@ -404,6 +409,9 @@
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
       <SubType>Designer</SubType>
     </XamlPropertyRule>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="PresentationFramework" />
   </ItemGroup>
   <Import Project="..\..\build\Targets\VSL.Imports.targets" />
   <ItemDefinitionGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsUIProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsUIProvider.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Windows.Controls;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    public static class UIProfilePropertyName
+    {
+         public const string Executable = "Executable";
+         public const string Arguments = "Arguments";
+         public const string LaunchUrl = "LaunchUrl";
+         public const string EnvironmentVariables = "EnvironmentVariables";
+         public const string WorkingDirectory = "WorkingDirectory";
+    }
+
+    /// <summary>
+    /// Interface definition which allows a launch settings provider to participate in the debug property page UI. The Set of 
+    /// LaunchSettingUIProviders provides the set of entries for the debug dropdown command list.
+    /// </summary>
+    public interface ILaunchSettingsUIProvider
+    {
+        /// <summary>
+        /// The name of the command that is written to the launchSettings.json file
+        /// </summary>
+        string CommandName { get; }
+
+        /// <summary>
+        /// The name to display in the dropdown for this command
+        /// </summary>
+        string FriendlyName { get; }
+
+        /// <summary>
+        /// Current supports these property names which map to the the default set of properties
+        ///     "Executable"
+        ///     "Arguments"
+        ///     "LaunchUrl"
+        ///     "EnvironmentVariables"
+        ///     "WorkingDirectory"
+        /// The names are case insensitive 
+        /// </summary>
+        bool ShouldEnableProperty(string propertyName);
+
+        /// <summary>
+        /// The UI to be displayed. This control is placed below all the common controls on the dialog. It is OK to return
+        /// null if there are no custom controls but still want to add a new command to the list. Example is the Executable and Project
+        /// commands. Neither provide custom controls (though arguable executable should).
+        /// </summary>
+        UserControl CustomUI { get; }
+
+        /// <summary>
+        /// Called when the selected profile changes to a profile which matches this command. curSettings will contain 
+        /// the current values from the page, and activeProfile will point to the active one.
+        /// </summary>
+        void ProfileSelected(IWritableLaunchSettings curSettings);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IWritableLaunchProfile.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IWritableLaunchProfile.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+
+    /// <summary>
+    /// Interface definition for a writable launch profile
+    /// </summary>
+    public interface IWritableLaunchProfile
+    {
+        string Name { get; set; }
+        string CommandName{ get; set; }
+        string ExecutablePath { get; set; }
+        string CommandLineArgs{ get; set; }
+        string WorkingDirectory{ get; set; }
+        bool LaunchBrowser { get; set; }
+        string LaunchUrl { get; set; }
+        Dictionary<string, string> EnvironmentVariables { get; }
+        Dictionary<string, object> OtherSettings { get; }
+
+        // Convert back to the immutable form
+        ILaunchProfile ToLaunchProfile();
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IWritableLaunchSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IWritableLaunchSettings.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    /// <summary>
+    /// Interface definition for a modifiable launch settings
+    /// </summary>
+    public interface IWritableLaunchSettings
+    {
+        IWritableLaunchProfile  ActiveProfile { get; set; }        
+
+        List<IWritableLaunchProfile> Profiles { get; }
+
+        Dictionary<string, object>  GlobalSettings { get; }
+
+        // Convert back to the immutable form
+        ILaunchSettings ToLaunchSettings();
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfile.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfile.cs
@@ -46,9 +46,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
            OtherSettings = existingProfile.OtherSettings;
         }
 
-        /// <summary>
-        /// IDebug profile members
-        /// </summary>
+        public LaunchProfile(IWritableLaunchProfile writableProfile)
+        {
+           Name = writableProfile.Name;
+           ExecutablePath = writableProfile.ExecutablePath;
+           CommandName = writableProfile.CommandName;
+           CommandLineArgs = writableProfile.CommandLineArgs; 
+           WorkingDirectory = writableProfile.WorkingDirectory;
+           LaunchBrowser = writableProfile.LaunchBrowser;
+           LaunchUrl = writableProfile.LaunchUrl;
+
+           // If there are no env variables or settings we want to set them to null
+           EnvironmentVariables = writableProfile.EnvironmentVariables.Count == 0? null : ImmutableDictionary<string, string>.Empty.AddRange(writableProfile.EnvironmentVariables);
+           OtherSettings = writableProfile.OtherSettings.Count == 0? null : ImmutableDictionary<string, object>.Empty.AddRange(writableProfile.OtherSettings);
+        }
+
         public string Name { get; set; }
         public string CommandName { get; set; }
         public string ExecutablePath { get; set; }
@@ -56,34 +68,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public string WorkingDirectory { get; set; }
         public bool LaunchBrowser { get; set; }
         public string LaunchUrl { get; set; }
-
-        private IDictionary<string, string> _environmentVariables;
-        public ImmutableDictionary<string, string> EnvironmentVariables
-        {
-            get
-            {
-                return _environmentVariables == null ?
-                    null: ImmutableDictionary<string, string>.Empty.AddRange(_environmentVariables);
-            }
-            set
-            {
-                _environmentVariables = value;
-            }
-        }
-
-        private IDictionary<string, object> _otherSettings;
-        public ImmutableDictionary<string, object> OtherSettings
-        {
-            get
-            {
-                return _otherSettings == null ?
-                    null: ImmutableDictionary<string, object>.Empty.AddRange(_otherSettings);
-            }
-            set
-            {
-                _otherSettings = value;
-            }
-        }
+        public ImmutableDictionary<string, string> EnvironmentVariables { get; set; }
+        public ImmutableDictionary<string, object> OtherSettings { get; set; }
                
         /// <summary>
         /// Compares two profile names. Using this function ensures case comparison consistency
@@ -92,64 +78,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             return string.Equals(name1, name2, StringComparison.Ordinal);
         }
+    }
 
+    internal static class LaunchProfileExtensions
+    {
         /// <summary>
-        /// Compares two IDebugProfiles to see if they contain the same values. Note that it doesn't compare
-        /// the kind field unless includeProfileKind is true
+        /// Return a mutable instance
         /// </summary>
-        public static bool ProfilesAreEqual(ILaunchProfile debugProfile1, ILaunchProfile debugProfile2, bool includeProfileKind)
+        public static IWritableLaunchProfile ToWritableLaunchProfile(this ILaunchProfile curProfile)
         {
-            // Same instance better return they are equal
-            if (debugProfile1 == debugProfile2)
-            {
-                return true;
-            }
-
-            if (!string.Equals(debugProfile1.Name, debugProfile2.Name, StringComparison.Ordinal) ||
-               !string.Equals(debugProfile1.CommandName, debugProfile2.CommandName, StringComparison.Ordinal) ||
-               !string.Equals(debugProfile1.ExecutablePath, debugProfile2.ExecutablePath, StringComparison.Ordinal) ||
-               !string.Equals(debugProfile1.CommandLineArgs, debugProfile2.CommandLineArgs, StringComparison.Ordinal) ||
-               !string.Equals(debugProfile1.WorkingDirectory, debugProfile2.WorkingDirectory, StringComparison.Ordinal) ||
-               !string.Equals(debugProfile1.LaunchUrl, debugProfile2.LaunchUrl, StringComparison.Ordinal) ||
-               (debugProfile1.LaunchBrowser != debugProfile2.LaunchBrowser) ||
-               !DictionaryEqualityComparer<string, object>.Instance.Equals(debugProfile1.OtherSettings.ToImmutableDictionary(), debugProfile2.OtherSettings) ||
-               (includeProfileKind && debugProfile1.CommandName != debugProfile2.CommandName))
-            {
-                return false;
-            }
-
-            // Same collection or both null
-            if (debugProfile1.EnvironmentVariables == debugProfile2.EnvironmentVariables)
-            {
-                return true;
-            }
-
-            // XOR. One null the other non-null. Consider. Should empty dictionary be treated the same as null??
-            if ((debugProfile1.EnvironmentVariables == null) ^ (debugProfile2.EnvironmentVariables == null))
-            {
-                return false;
-            }
-            return DictionaryEqualityComparer<string, string>.Instance.Equals(debugProfile1.EnvironmentVariables, debugProfile2.EnvironmentVariables);
+            return new WritableLaunchProfile(curProfile);
         }
-        
-        internal IDictionary<string, string> MutableEnvironmentVariables
-        {
-            get
-            {
-                return _environmentVariables;
-            }
-            set
-            {
-                if (value == null)
-                {
-                    _environmentVariables = null;
-                }
-                else
-                {
-                    _environmentVariables = new Dictionary<string, string>(value);
-                }
-            }
-        }
-        
+
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettings.cs
@@ -52,9 +52,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             GlobalSettings = ImmutableDictionary<string, object>.Empty;
             foreach(var kvp in settings.GlobalSettings)
             {
-                if(kvp.Value is ICloneable)
+                if(kvp.Value is ICloneable clonableObject)
                 {
-                    GlobalSettings = GlobalSettings.Add(kvp.Key, ((ICloneable)kvp.Value).Clone());
+                    GlobalSettings = GlobalSettings.Add(kvp.Key, clonableObject.Clone());
                 }
                 else
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchProfile.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchProfile.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.VisualStudio.Collections;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+
+    /// <summary>
+    /// Represents one launch profile read from the launchSettings file.
+    /// </summary>
+    internal class WritableLaunchProfile : IWritableLaunchProfile
+    {
+        public WritableLaunchProfile()
+        {
+        }
+
+        public WritableLaunchProfile(ILaunchProfile profile)
+        {
+            Name = profile.Name;
+            ExecutablePath = profile.ExecutablePath;
+            CommandName = profile.CommandName;
+            CommandLineArgs = profile.CommandLineArgs; 
+            WorkingDirectory = profile.WorkingDirectory;
+            LaunchBrowser = profile.LaunchBrowser;
+            LaunchUrl = profile.LaunchUrl;
+
+            if(profile.EnvironmentVariables  != null)
+            {
+                EnvironmentVariables = new Dictionary<string, string>(profile.EnvironmentVariables, StringComparer.Ordinal);
+            }
+
+            if(profile.OtherSettings  != null)
+            {
+                OtherSettings = new Dictionary<string, object>(profile.OtherSettings, StringComparer.Ordinal);
+            }
+        }
+
+        /// <summary>
+        /// IWritableDebug profile members
+        /// </summary>
+        public string Name { get; set; }
+        public string CommandName { get; set; }
+        public string ExecutablePath { get; set; }
+        public string CommandLineArgs { get; set; }
+        public string WorkingDirectory { get; set; }
+        public bool LaunchBrowser { get; set; }
+        public string LaunchUrl { get; set; }
+
+        public Dictionary<string, string> EnvironmentVariables { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        public Dictionary<string, object> OtherSettings { get; } = new Dictionary<string, object>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Converts back to the immutable form
+        /// </summary>
+        public ILaunchProfile ToLaunchProfile()
+        {
+            return new LaunchProfile(this);
+        }
+
+        /// <summary>
+        /// Compares two IWritableLaunchProfile to see if they contain the same values.
+        /// </summary>
+        public static bool ProfilesAreEqual(IWritableLaunchProfile debugProfile1, IWritableLaunchProfile debugProfile2)
+        {
+            // Same instance are equal
+            if (debugProfile1 == debugProfile2)
+            {
+                return true;
+            }
+
+            if (!string.Equals(debugProfile1.Name, debugProfile2.Name, StringComparison.Ordinal) ||
+               !string.Equals(debugProfile1.CommandName, debugProfile2.CommandName, StringComparison.Ordinal) ||
+               !string.Equals(debugProfile1.ExecutablePath, debugProfile2.ExecutablePath, StringComparison.Ordinal) ||
+               !string.Equals(debugProfile1.CommandLineArgs, debugProfile2.CommandLineArgs, StringComparison.Ordinal) ||
+               !string.Equals(debugProfile1.WorkingDirectory, debugProfile2.WorkingDirectory, StringComparison.Ordinal) ||
+               !string.Equals(debugProfile1.LaunchUrl, debugProfile2.LaunchUrl, StringComparison.Ordinal) ||
+               debugProfile1.LaunchBrowser != debugProfile2.LaunchBrowser ||
+               !DictionaryEqualityComparer<string, object>.Instance.Equals(debugProfile1.OtherSettings.ToImmutableDictionary(), debugProfile2.OtherSettings.ToImmutableDictionary()) ||
+               !DictionaryEqualityComparer<string, string>.Instance.Equals(debugProfile1.EnvironmentVariables.ToImmutableDictionary(), debugProfile2.EnvironmentVariables.ToImmutableDictionary())
+               )
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchProfile.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchProfile.cs
@@ -38,9 +38,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             }
         }
 
-        /// <summary>
-        /// IWritableDebug profile members
-        /// </summary>
         public string Name { get; set; }
         public string CommandName { get; set; }
         public string ExecutablePath { get; set; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchSettings.cs
@@ -31,9 +31,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             {    
                 foreach(var kvp in settings.GlobalSettings)
                 {
-                    if(kvp.Value is ICloneable)
+                    if(kvp.Value is ICloneable clonableObject)
                     {
-                        GlobalSettings.Add(kvp.Key, ((ICloneable)kvp.Value).Clone());
+                        GlobalSettings.Add(kvp.Key, clonableObject.Clone());
                     }
                     else
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchSettings.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.VisualStudio.Collections;
+using Newtonsoft.Json;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    internal class WritableLaunchSettings : IWritableLaunchSettings
+    {
+        public WritableLaunchSettings()
+        {
+        }
+
+        public WritableLaunchSettings(ILaunchSettings settings)
+        {
+            if(settings.Profiles != null)
+            {
+                foreach(var profile in settings.Profiles)
+                {
+                    Profiles.Add(new WritableLaunchProfile(profile));
+                }
+            }
+            
+            // For global settings we want to make new copies of each entry so that the snapshot remains immutable. If the object implements 
+            // ICloneable that is used, otherwise, it is serialized back to json, and a new object rehydrated from that
+            if(settings.GlobalSettings != null)
+            {    
+                foreach(var kvp in settings.GlobalSettings)
+                {
+                    if(kvp.Value is ICloneable)
+                    {
+                        GlobalSettings.Add(kvp.Key, ((ICloneable)kvp.Value).Clone());
+                    }
+                    else
+                    {
+                        string jsonString = JsonConvert.SerializeObject(kvp.Value, Formatting.Indented, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore});
+                        object clonedObject = JsonConvert.DeserializeObject(jsonString, kvp.Value.GetType());
+                        GlobalSettings.Add(kvp.Key, clonedObject);
+                    }
+                }
+            }
+
+            if(settings.ActiveProfile != null)
+            {
+                ActiveProfile = Profiles.FirstOrDefault((profile) => LaunchProfile.IsSameProfileName(profile.Name, settings.ActiveProfile.Name));
+            }
+        }
+
+        public IWritableLaunchProfile ActiveProfile { get; set; }
+
+        public List<IWritableLaunchProfile> Profiles { get; } = new List<IWritableLaunchProfile>();
+        public Dictionary<String, object> GlobalSettings { get; } = new Dictionary<string, object>(StringComparer.Ordinal);
+
+        public ILaunchSettings ToLaunchSettings()
+        {
+            return new LaunchSettings(this);
+        }
+    }
+
+    internal static class WritableLaunchSettingsExtension
+    {
+        public static bool SetttingsDiffer(this IWritableLaunchSettings launchSettings, IWritableLaunchSettings settingsToCompare)
+        {
+            if(launchSettings.Profiles.Count != settingsToCompare.Profiles.Count)
+            {
+                return true;
+            }
+
+            // Now compare each item. We can compare in order. If the lists are different then the settings are different even
+            // if they contain the same items
+            for (int i=0; i< launchSettings.Profiles.Count; i++)
+            {
+                if (!WritableLaunchProfile.ProfilesAreEqual(launchSettings.Profiles[i], settingsToCompare.Profiles[i]))
+                {
+                    return true;
+                }
+            }
+            
+            // Check the global settings
+            return DictionaryEqualityComparer<string, object>.Instance.Equals(launchSettings.GlobalSettings.ToImmutableDictionary(), settingsToCompare.GlobalSettings.ToImmutableDictionary());
+        }
+
+    }
+}


### PR DESCRIPTION
The high level design notes are:
1. The list of commands which appear in the Launch dropdown are provided by the set of ILaunchSettingsUIProvider's. There are implementations for Project and executable in the base project system to support Console\ClassLibraries
![image](https://cloud.githubusercontent.com/assets/1553785/21664045/f031f45e-d298-11e6-9f5b-82d603418460.png)

2. The providers can optionally add Custom UI to the dialog to make it easy to set custom values. This UI appears after the default values. 
3. Default properties can be hidden if they don't apply using the EnableProperty method
4. Sequence
    a. Dialog loads the providers to build the dropdown list. If there are commands in the current launch settings for which there isn't a provider installed, the command will be shown when that profile is active, but other profiles can't be converted to it. All fields are disabled and it becomes R/O. Note we should allow deletion.
    b. When the profile is changed (or set for the first time), the ProfileSelected() method will be called on the provider which matches the command and the current set of profiles is passed to it.  Changes made to settings need to be applied to this set of profiles. 
    c. If the provider has a control it will be inserted into the dialog and resized to match the existing layout. In general the control should match the 3 column style of the main control.
    d. When the provider changes, the debug view model listens to property changes its controls control datacontext (assuming it has a custom control, it may not) so that changes to the control affect the dirty state of the dialog. When the active provider changes it disconnects from the current provider and connects to the new one.
    e. Similarly, for validation, the control  hooks into INotifyDataErrorInfo of the controls datacontext. If there are errors in the control, the profile dropdown is disabled until the errors are corrected (this is what is done for env variables already). 
    f. If there are validation errors, save will fail with an error message informing the user they need to correct the errors before  save can continue.
5. Writable versions of ILaunchSettings\ILaunchProfile are used to hold settings in the dialog. This ensures the current immutable snapshot is not perturbed while the editing is going on. 

Unit tests still need to be completed

@jinujoseph @srivatsn @abpiskunov 

