### PR TITLE
Add ExportProjectNodeComServiceAttribute

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -40,6 +40,7 @@
     <Compile Include="ProjectSystem\VS\Editor\EditProjectFileVsFrameEvents.cs" />
     <Compile Include="ProjectSystem\VS\Editor\IMsBuildModelWatcher.cs" />
     <Compile Include="ProjectSystem\VS\Editor\MsBuildModelWatcher.cs" />
+    <Compile Include="ProjectSystem\VS\ExportProjectNodeComServiceAttribute.cs" />
     <Compile Include="ProjectSystem\VS\Input\Commands\GenerateNuGetPackageTopLevelBuildMenuCommand.cs" />
     <Compile Include="ProjectSystem\VS\Input\Commands\GenerateNuGetPackageProjectContextMenuCommand.cs" />
     <Compile Include="ProjectSystem\VS\Input\Commands\AbstractGenerateNuGetPackageCommand.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/EditAndContinue/EditAndContinueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/EditAndContinue/EditAndContinueProvider.cs
@@ -12,11 +12,8 @@ using EncInterop = Microsoft.VisualStudio.LanguageServices.Implementation.EditAn
 namespace Microsoft.VisualStudio.ProjectSystem.Managed.VS.EditAndContinue
 {
 
-    [Export(ExportContractNames.VsTypes.ProjectNodeComExtension)]
+    [ExportProjectNodeComService(typeof(IVsENCRebuildableProjectCfg), typeof(EncInterop.IVsENCRebuildableProjectCfg2), typeof(EncInterop.IVsENCRebuildableProjectCfg4))]
     [AppliesTo(ProjectCapability.EditAndContinue)]
-    [ComServiceIid(typeof(IVsENCRebuildableProjectCfg))]
-    [ComServiceIid(typeof(EncInterop.IVsENCRebuildableProjectCfg2))]
-    [ComServiceIid(typeof(EncInterop.IVsENCRebuildableProjectCfg4))]
     internal class EditAndContinueProvider : IVsENCRebuildableProjectCfg, EncInterop.IVsENCRebuildableProjectCfg2, EncInterop.IVsENCRebuildableProjectCfg4
     {
         private readonly ILanguageServiceHost _host;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ExportProjectNodeComServiceAttribute.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ExportProjectNodeComServiceAttribute.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.ComponentModel.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <summary>
+    ///     Exports a service to be aggregated with the project node.
+    /// </summary>
+    [MetadataAttribute]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Interface, AllowMultiple = true)]
+    internal class ExportProjectNodeComServiceAttribute : ExportAttribute
+    {
+        public ExportProjectNodeComServiceAttribute(params Type[] comTypes)
+        : base(ExportContractNames.VsTypes.ProjectNodeComExtension)
+        {
+            Iid = GetIids(comTypes);
+        }
+
+        public string[] Iid
+        {
+            get;
+        }
+
+        public bool IncludeInherited
+        {
+            get => false;
+        }
+
+        private static string[] GetIids(Type[] comTypes)
+        {
+            Requires.NotNull(comTypes, nameof(comTypes));
+
+            // Reuse ComServiceIdAttribute's logic for calculating IIDs.
+            return comTypes.Select(type => new ComServiceIidAttribute(type))
+                           .SelectMany(attribute => attribute.Iid)
+                           .ToArray();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Generators/SingleFileGeneratorFactoryAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Generators/SingleFileGeneratorFactoryAggregator.cs
@@ -6,9 +6,8 @@ using System.ComponentModel.Composition;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Generators
 {
-    [Export(ExportContractNames.VsTypes.ProjectNodeComExtension)]
+    [ExportProjectNodeComService(typeof(IVsSingleFileGeneratorFactory))]
     [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
-    [ComServiceIid(typeof(IVsSingleFileGeneratorFactory))]
     internal class SingleFileGeneratorFactoryAggregator : IVsSingleFileGeneratorFactory
     {
         // Constants for the generator information registry keys

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/BuildMacroInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/BuildMacroInfo.cs
@@ -8,9 +8,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
     /// <summary>
     /// Implements the <see cref="IVsBuildMacroInfo"/> interface to be consumed by project properties.
     /// </summary>
-    [Export(ExportContractNames.VsTypes.ProjectNodeComExtension)]
+    [ExportProjectNodeComService((typeof(IVsBuildMacroInfo)))]
     [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
-    [ComServiceIid(typeof(IVsBuildMacroInfo))]
     internal class BuildMacroInfo : IVsBuildMacroInfo
     {
         /// <summary>


### PR DESCRIPTION
This simplifies the logic for exporting a ProjectNode service.

Ran into this implementing the new IVsDesignTimeAssemblyResolution service, and pulled it out to simplify the review.