### PR TITLE
Fix our official build version numbers

### DIFF
--- a/build/Targets/GenerateAssemblyInfo.targets
+++ b/build/Targets/GenerateAssemblyInfo.targets
@@ -1,14 +1,38 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Choose>
+    <When Condition="'$(OfficialBuild)' != 'true'">
+      <!-- On non-official builds we don't burn in a git sha.  In large part because it 
+           hurts our determinism efforts as binaries which should be the same between
+           builds will not (due to developers building against different HEAD 
+           values -->
+      <PropertyGroup>
+        <GitHeadSha>&lt;developer build&gt;</GitHeadSha>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(BUILD_SOURCEVERSION)' != ''">
+      <PropertyGroup>
+        <GitHeadSha>$(BUILD_SOURCEVERSION)</GitHeadSha>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(BUILD_SOURCEVERSION)' == '' and '$(GIT_COMMIT)' != ''">
+      <PropertyGroup>
+        <GitHeadSha>$(GIT_COMMIT)</GitHeadSha>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <GitHeadSha>Not found</GitHeadSha>
+        <DotGitDir>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../../.git'))</DotGitDir>
+        <HeadFileContent Condition="Exists('$(DotGitDir)/HEAD')">$([System.IO.File]::ReadAllText('$(DotGitDir)/HEAD').Trim())</HeadFileContent>
+        <RefPath Condition="$(HeadFileContent.StartsWith('ref: '))">$(DotGitDir)/$(HeadFileContent.Substring(5))</RefPath>
+        <GitHeadSha Condition="'$(RefPath)' != '' and Exists('$(RefPath)')">$([System.IO.File]::ReadAllText('$(RefPath)').Trim())</GitHeadSha>
+        <GitHeadSha Condition="'$(HeadFileContent)' != '' and '$(RefPath)' == ''">$(HeadFileContent)</GitHeadSha>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  
   <PropertyGroup>
     <GeneratedAssemblyInfoFile>$(IntermediateOutputPath)GeneratedAssemblyInfo_$(BuildVersion)$(DefaultLanguageSourceExtension)</GeneratedAssemblyInfoFile>
-  </PropertyGroup>
-
-  <!-- Disable build warning CS7035/BC42366: "The specified version string does not conform to the recommended format - major.minor.build.revision" -->
-  <PropertyGroup Condition=" '$(Language)' == 'C#' ">
-    <NoWarn>$(NoWarn);CS7035</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Language)' == 'VB' ">
-    <NoWarn>$(NoWarn);BC42366</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,7 +49,7 @@
       <_Parameter1>$(BuildVersion)</_Parameter1>
     </AssemblyVersionAttribute>
     <AssemblyVersionAttribute Include="System.Reflection.AssemblyInformationalVersionAttribute">
-      <_Parameter1>$(BuildVersion)</_Parameter1>
+      <_Parameter1>$(RoslynNuGetPerBuildPreReleaseVersion). Commit Hash: $(GitHeadSha)</_Parameter1>
     </AssemblyVersionAttribute>
   </ItemGroup>
 

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -4,8 +4,17 @@
     <RoslynSemanticVersion Condition="'$(RoslynSemanticVersion)' == ''">2.0.0</RoslynSemanticVersion>
     <MicroBuildVersion>0.2.0</MicroBuildVersion>
     <BuildNumber Condition="'$(BuildNumber)' == ''">$(BUILD_BUILDNUMBER)</BuildNumber>
-    <BuildNumberPart1 Condition="'$(BuildNumber)' != ''">$(BuildNumber.Split('.')[0])</BuildNumberPart1>
-    <BuildNumberPart2 Condition="('$(BuildNumber)' != '') AND ($(BuildNumber.Split('.').Length) == 2)">$(BuildNumber.Split('.')[1].PadLeft(2,'0'))</BuildNumberPart2>
+
+    <!-- Split the build parts out from the BuildNumber which is given to us by MicroBuild in the format of yyyymmdd.nn
+         where BuildNumberFiveDigitDateStamp is mmmdd (such as 60615) and BuildNumberBuildOfTheDay is nn (which represents the nth build
+         started that day). So the first build of the day, 20160615.1, will produce something similar to BuildNumberFiveDigitDateStamp: 60615,
+         BuildNumberBuildOfTheDayPadded: 01;and the 12th build of the day, 20160615.12, will produce BuildNumberFiveDigitDateStamp: 60615, BuildNumberBuildOfTheDay: 12
+
+         Additionally, in order ensure the value fits in the 16-bit PE header fields, we will only take the last five digits of the BuildNumber, so
+         in the case of 20160615, we will set BuildNumberFiveDigitDateStamp to 60615. Unfortunately for releases in 2017 we can't go any higher, so
+         we will continue the month counting instead: the build after 61231 is 61301. -->
+    <BuildNumberFiveDigitDateStamp Condition="'$(BuildNumber)' != ''">$([MSBuild]::Subtract($(BuildNumber.Split('.')[0].Substring(3).Trim()), 8800))</BuildNumberFiveDigitDateStamp>
+    <BuildNumberBuildOfTheDayPadded Condition="('$(BuildNumber)' != '') AND ($(BuildNumber.Split('.').Length) == 2)">$(BuildNumber.Split('.')[1].PadLeft(2,'0'))</BuildNumberBuildOfTheDayPadded>
   </PropertyGroup>
 
   <Choose>
@@ -18,11 +27,11 @@
       </PropertyGroup>
     </When>
 
-    <When Condition="('$(BuildNumber)' != '') AND ('$(BuildNumberPart1)' != '') AND ('$(BuildNumberPart2)' != '')">
+    <When Condition="('$(BuildNumber)' != '') AND ('$(BuildNumberFiveDigitDateStamp)' != '') AND ('$(BuildNumberBuildOfTheDayPadded)' != '')">
       <!-- The user specified a build number, so we should use that. -->
       <PropertyGroup>
         <AssemblyVersion>$(RoslynSemanticVersion).0</AssemblyVersion>
-        <BuildVersion>$(RoslynSemanticVersion).$(BuildNumberPart1)$(BuildNumberPart2)</BuildVersion>
+        <BuildVersion>$(RoslynSemanticVersion).$(BuildNumberFiveDigitDateStamp)</BuildVersion>
       </PropertyGroup>
     </When>
 
@@ -31,7 +40,7 @@
           This happens if the build template does not pass BuildNumber down to MSBuild. -->
       <PropertyGroup>
         <AssemblyVersion>$(RoslynSemanticVersion).0</AssemblyVersion>
-        <BuildVersion>$(RoslynSemanticVersion).$(BuildNumberPart1)$(BuildNumberPart2)</BuildVersion>
+        <BuildVersion>$(RoslynSemanticVersion).$(BuildNumberFiveDigitDateStamp)</BuildVersion>
       </PropertyGroup>
     </When>
 
@@ -55,10 +64,10 @@
     <VSSemanticVersion>15.0.0</VSSemanticVersion>
 
     <RoslynNuGetPreReleaseVersion>$(RoslynSemanticVersion)-rc</RoslynNuGetPreReleaseVersion>
-    <RoslynNuGetPerBuildPreReleaseVersion Condition="'$(BuildNumberPart1)' != '' AND '$(BuildNumberPart2)' != ''">$(RoslynNuGetPreReleaseVersion)-$(BuildNumberPart1.Trim())-$(BuildNumberPart2.Trim())</RoslynNuGetPerBuildPreReleaseVersion>
+    <RoslynNuGetPerBuildPreReleaseVersion Condition="'$(BuildNumberFiveDigitDateStamp)' != '' AND '$(BuildNumberBuildOfTheDayPadded)' != ''">$(RoslynNuGetPreReleaseVersion)-$(BuildNumberFiveDigitDateStamp.Trim())-$(BuildNumberBuildOfTheDayPadded.Trim())</RoslynNuGetPerBuildPreReleaseVersion>
     <RoslynNuGetPerBuildPreReleaseVersion Condition="'$(RoslynNuGetPerBuildPreReleaseVersion)' == ''">1.0.0-rc</RoslynNuGetPerBuildPreReleaseVersion>
     <VSNuGetPreReleaseVersion>$(VSSemanticVersion)-rc</VSNuGetPreReleaseVersion>
-    <VSNuGetPerBuildPreReleaseVersion Condition="'$(BuildNumberPart1)' != '' AND '$(BuildNumberPart2)' != ''">$(VSNuGetPreReleaseVersion)-$(BuildNumberPart1.Trim())-$(BuildNumberPart2.Trim())</VSNuGetPerBuildPreReleaseVersion>
+    <VSNuGetPerBuildPreReleaseVersion Condition="'$(BuildNumberFiveDigitDateStamp)' != '' AND '$(BuildNumberBuildOfTheDayPadded)' != ''">$(VSNuGetPreReleaseVersion)-$(BuildNumberFiveDigitDateStamp.Trim())-$(BuildNumberBuildOfTheDayPadded.Trim())</VSNuGetPerBuildPreReleaseVersion>
     <VSNuGetPerBuildPreReleaseVersion Condition="'$(VSNuGetPerBuildPreReleaseVersion)' == ''">1.0.0-rc</VSNuGetPerBuildPreReleaseVersion>
   </PropertyGroup>
   


### PR DESCRIPTION
Match Roslyn PR https://github.com/dotnet/roslyn/pull/16208 to ensure correct version numbers for 2017.
This also fixes #798.
