### PR TITLE
This change fixes several issues:

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Mocks\IDebugLaunchProviderMetadataViewFactory.cs" />
     <Compile Include="Mocks\IDteServicesFactory.cs" />
     <Compile Include="Mocks\ExportFactoryFactory.cs" />
+    <Compile Include="Mocks\IVsHiearchyItemFactory.cs" />
     <Compile Include="Mocks\IProjectFileEditorPresenterFactory.cs" />
     <Compile Include="Mocks\IFrameOpenCloseListenerFactory.cs" />
     <Compile Include="Mocks\IProjectXmlAccessorFactory.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IGraphContextFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IGraphContextFactory.cs
@@ -6,9 +6,9 @@ using System.Threading;
 using Microsoft.VisualStudio.GraphModel;
 using Microsoft.VisualStudio.GraphModel.Schemas;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Moq;
-using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IGraphContextFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IGraphContextFactory.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.GraphModel.Schemas;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
 using Microsoft.VisualStudio.Shell.Interop;
 using Moq;
+using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
@@ -20,7 +21,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         public static GraphNode CreateNode(string projectPath, 
                                            string nodeIdString, 
-                                           IDependencyNode node = null)
+                                           IDependencyNode node = null,
+                                           IVsHierarchyItem hierarchyItem = null)
         {
             var graph = new Graph();
             var id = GraphNodeId.GetNested(
@@ -32,6 +34,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             if (node != null)
             {
                 graphNode.SetValue(DependenciesGraphSchema.DependencyNodeProperty, node);
+            }
+            if (hierarchyItem != null)
+            {
+                graphNode.SetValue(HierarchyGraphNodeProperties.HierarchyItem, hierarchyItem);
             }
 
             return graphNode;
@@ -120,10 +126,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             var mockSearchQuery = new Mock<IVsSearchQuery>();
             mockSearchQuery.Setup(q => q.SearchString).Returns(searchString);
 
-            var mockSearchParameters = new Mock<Shell.ISolutionSearchParameters>();
+            var mockSearchParameters = new Mock<ISolutionSearchParameters>();
             mockSearchParameters.Setup(s => s.SearchQuery).Returns(mockSearchQuery.Object);
 
-            mock.Setup(g => g.GetValue<Shell.ISolutionSearchParameters>(It.IsAny<string>())).Returns(mockSearchParameters.Object);
+            mock.Setup(g => g.GetValue<ISolutionSearchParameters>(It.IsAny<string>())).Returns(mockSearchParameters.Object);
             mock.Setup(x => x.OnCompleted());
             mock.Setup(x => x.Graph).Returns(new Graph());
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsHiearchyItemFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsHiearchyItemFactory.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             return Mock.Of<IVsHierarchyItem>();
         }
 
-        public static IVsHierarchyItem Implement(string text = null,
+        public static IVsHierarchyItem ImplementTextProperty(string text = null,
                                                  MockBehavior? mockBehavior = null)
         {
             var behavior = mockBehavior ?? MockBehavior.Default;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsHiearchyItemFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsHiearchyItemFactory.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Shell;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    internal static class IVsHierarchyItemFactory
+    {
+        public static IVsHierarchyItem Create()
+        {
+            return Mock.Of<IVsHierarchyItem>();
+        }
+
+        public static IVsHierarchyItem Implement(string text = null,
+                                                 MockBehavior? mockBehavior = null)
+        {
+            var behavior = mockBehavior ?? MockBehavior.Default;
+            var mock = new Mock<IVsHierarchyItem>(behavior);
+
+            if (text != null)
+            {
+                mock.Setup(x => x.Text).Returns(text);
+            }
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsHiearchyItemFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsHiearchyItemFactory.cs
@@ -12,8 +12,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             return Mock.Of<IVsHierarchyItem>();
         }
 
-        public static IVsHierarchyItem ImplementTextProperty(string text = null,
-                                                 MockBehavior? mockBehavior = null)
+        public static IVsHierarchyItem ImplementProperties(string text = null,
+                                                           string parentCanonicalName = null,
+                                                           MockBehavior? mockBehavior = null)
         {
             var behavior = mockBehavior ?? MockBehavior.Default;
             var mock = new Mock<IVsHierarchyItem>(behavior);
@@ -21,6 +22,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             if (text != null)
             {
                 mock.Setup(x => x.Text).Returns(text);
+            }
+
+            if (parentCanonicalName != null)
+            {
+                var parentMock = new Mock<IVsHierarchyItem>(behavior);
+                parentMock.Setup(x => x.CanonicalName).Returns(parentCanonicalName);
+                mock.Setup(x => x.Parent).Returns(parentMock.Object);
             }
 
             return mock.Object;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProviderTests.cs
@@ -22,8 +22,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             var projectPath = @"c:\myproject\project.csproj";
             var nodeIdString = @"file:///[MyProvider;MyNodeItemSpec]";
-            var inputNode = IGraphContextFactory.CreateNode(projectPath, nodeIdString);
-
+            var mockVsHierarchyItem = IVsHierarchyItemFactory.Implement(text: "MyNodeItemSpec");
+            var inputNode = IGraphContextFactory.CreateNode(projectPath, 
+                                                            nodeIdString, 
+                                                            hierarchyItem: mockVsHierarchyItem);
+            var rootNode = IDependencyNodeFactory.FromJson(@"
+{
+    ""Id"": {
+        ""ProviderType"": ""MyProvider"",
+        ""ItemSpec"": ""MyRootNode""
+    }
+}");
             var existingNode = IDependencyNodeFactory.FromJson(@"
 {
     ""Id"": {
@@ -38,10 +47,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         ""ItemSpec"": ""MyChildNodeItemSpec""
     }   
 }");
-
+            rootNode.AddChild(existingNode);
             existingNode.Children.Add(existingChildNode);
 
             var mockProvider = new IProjectDependenciesSubTreeProviderMock();
+            mockProvider.RootNode = rootNode;
             mockProvider.AddTestDependencyNodes(new[] { existingNode });
 
             var mockProjectContextProvider = IDependenciesGraphProjectContextProviderFactory.Implement(projectPath, mockProvider);
@@ -109,19 +119,31 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             var projectPath = @"c:\myproject\project.csproj";
             var nodeIdString = @"file:///[MyProvider;MyNodeItemSpec]";
-            var inputNode = IGraphContextFactory.CreateNode(projectPath, nodeIdString);
 
-            var nodeJson = @"
+            var mockVsHierarchyItem = IVsHierarchyItemFactory.Implement(text: "MyNodeItemSpec");
+            var inputNode = IGraphContextFactory.CreateNode(projectPath, 
+                                                            nodeIdString, 
+                                                            hierarchyItem: mockVsHierarchyItem);
+            var rootNode = IDependencyNodeFactory.FromJson(@"
+{
+    ""Id"": {
+        ""ProviderType"": ""MyProvider"",
+        ""ItemSpec"": ""MyRootNode""
+    }
+}");
+            var existingNode = IDependencyNodeFactory.FromJson(@"
 {
     ""Id"": {
         ""ProviderType"": ""MyProvider"",
         ""ItemSpec"": ""MyNodeItemSpec""
     }
-}";
+}");
+            rootNode.AddChild(existingNode);
 
-            var existingNode = IDependencyNodeFactory.FromJson(nodeJson);
             var mockProvider = new IProjectDependenciesSubTreeProviderMock();
+            mockProvider.RootNode = rootNode;
             mockProvider.AddTestDependencyNodes(new[] { existingNode });
+
             var mockProjectContextProvider = IDependenciesGraphProjectContextProviderFactory.Implement(projectPath, mockProvider);
 
             var mockGraphContext = IGraphContextFactory.Implement(CancellationToken.None,
@@ -247,30 +269,38 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             var projectPath = @"c:\myproject\project.csproj";
             var nodeIdString = @"file:///[MyProvider;MyNodeItemSpec]";
-
-            var nodeJson = @"
+            var rootNode = IDependencyNodeFactory.FromJson(@"
+{
+    ""Id"": {
+        ""ProviderType"": ""MyProvider"",
+        ""ItemSpec"": ""MyRootNode""
+    }
+}");
+            var existingNode = IDependencyNodeFactory.FromJson(@"
 {
     ""Id"": {
         ""ProviderType"": ""MyProvider"",
         ""ItemSpec"": ""MyNodeItemSpec""
     }
-}";
-            var childNodeJson = @"
+}");
+            var existingChildNode = IDependencyNodeFactory.FromJson(@"
 {
     ""Id"": {
         ""ProviderType"": ""MyProvider"",
         ""ItemSpec"": ""MyChildNodeItemSpec""
     }
-}";
-
-            var existingNode = IDependencyNodeFactory.FromJson(nodeJson);
-            var existingChildNode = IDependencyNodeFactory.FromJson(childNodeJson);
+}");
+            rootNode.AddChild(existingNode);
             existingNode.Children.Add(existingChildNode);
 
-            var inputNode = IGraphContextFactory.CreateNode(projectPath, nodeIdString, null);
+            var mockVsHierarchyItem = IVsHierarchyItemFactory.Implement(text: "MyNodeItemSpec");
+            var inputNode = IGraphContextFactory.CreateNode(projectPath, 
+                                                            nodeIdString,
+                                                            hierarchyItem:mockVsHierarchyItem);
             var outputNodes = new HashSet<GraphNode>();
 
             var mockProvider = new IProjectDependenciesSubTreeProviderMock();
+            mockProvider.RootNode = rootNode;
             mockProvider.AddTestDependencyNodes(new[] { existingNode });
 
             var mockProjectContextProvider = IDependenciesGraphProjectContextProviderFactory.Implement(projectPath, mockProvider);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProviderTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             var projectPath = @"c:\myproject\project.csproj";
             var nodeIdString = @"file:///[MyProvider;MyNodeItemSpec]";
-            var mockVsHierarchyItem = IVsHierarchyItemFactory.Implement(text: "MyNodeItemSpec");
+            var mockVsHierarchyItem = IVsHierarchyItemFactory.ImplementTextProperty(text: "MyNodeItemSpec");
             var inputNode = IGraphContextFactory.CreateNode(projectPath, 
                                                             nodeIdString, 
                                                             hierarchyItem: mockVsHierarchyItem);
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var projectPath = @"c:\myproject\project.csproj";
             var nodeIdString = @"file:///[MyProvider;MyNodeItemSpec]";
 
-            var mockVsHierarchyItem = IVsHierarchyItemFactory.Implement(text: "MyNodeItemSpec");
+            var mockVsHierarchyItem = IVsHierarchyItemFactory.ImplementTextProperty(text: "MyNodeItemSpec");
             var inputNode = IGraphContextFactory.CreateNode(projectPath, 
                                                             nodeIdString, 
                                                             hierarchyItem: mockVsHierarchyItem);
@@ -293,7 +293,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             rootNode.AddChild(existingNode);
             existingNode.Children.Add(existingChildNode);
 
-            var mockVsHierarchyItem = IVsHierarchyItemFactory.Implement(text: "MyNodeItemSpec");
+            var mockVsHierarchyItem = IVsHierarchyItemFactory.ImplementTextProperty(text: "MyNodeItemSpec");
             var inputNode = IGraphContextFactory.CreateNode(projectPath, 
                                                             nodeIdString,
                                                             hierarchyItem:mockVsHierarchyItem);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyNodeTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyNodeTests.cs
@@ -563,7 +563,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                             ? DependencyNode.PackageNodePriority
                             : DependencyNode.UnresolvedReferenceNodePriority;
 
-            var caption = "MyCaption";
+            var name = "MyName";
+            var caption = "MyCaption (xxx)";
             var id = DependencyNodeId.FromString(
                         "file:///[MyProviderType;c:\\MyItemSpec.dll;MyItemType;MyUniqueToken]");
             var properties = new Dictionary<string, string>().ToImmutableDictionary();
@@ -571,6 +572,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             // Act
             var node = new PackageDependencyNode(id,
+                                                 name,
                                                  caption,
                                                  myFlags,
                                                  properties,
@@ -580,6 +582,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(expectedIcon, node.Icon);
             Assert.Equal(resolved, node.Resolved);
             Assert.Equal(priority, node.Priority);
+            Assert.Equal(name, node.Name);
             Assert.Equal(caption, node.Caption);
             Assert.Equal(node.Alias, node.Caption);
             Assert.Equal(properties, node.Properties);
@@ -592,8 +595,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             var id = DependencyNodeId.FromString("file:///[MyProviderType]");
 
+            Assert.Throws<ArgumentNullException>("name", () => {
+                new PackageDependencyNode(id, null, null, ProjectTreeFlags.Empty);
+            });
+
             Assert.Throws<ArgumentNullException>("caption", () => {
-                new PackageDependencyNode(id, null, ProjectTreeFlags.Empty);
+                new PackageDependencyNode(id, "somename", null, ProjectTreeFlags.Empty);
             });
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyNodeTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyNodeTests.cs
@@ -53,8 +53,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             // Assert
             var expectedFlags = resolved
-                ? DependencyNode.GenericResolvedDependencyFlags.Union(myFlags)
-                : DependencyNode.GenericUnresolvedDependencyFlags.Union(myFlags);
+                ? DependencyNode.ResolvedDependencyFlags.Union(myFlags)
+                : DependencyNode.UnresolvedDependencyFlags.Union(myFlags);
 
             Assert.True(node.Flags.Contains(expectedFlags));
             Assert.Equal(resolved, node.Resolved);
@@ -556,9 +556,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 : KnownMonikers.ReferenceWarning;
 
             var defaultFlags = (resolved
-                ? DependencyNode.ResolvedDependencyFlags
-                : DependencyNode.UnresolvedDependencyFlags)
-                .Add(ProjectTreeFlags.Common.ResolvedReference);
+                ? DependencyNode.GenericResolvedDependencyFlags
+                : DependencyNode.GenericUnresolvedDependencyFlags);
 
             var priority = resolved
                             ? DependencyNode.PackageNodePriority

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyNodeTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyNodeTests.cs
@@ -138,10 +138,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var id = DependencyNodeId.FromString(
                         "file:///[MyProviderType;c:\\MyItemSpec.dll;MyItemType;MyUniqueToken]");
             var properties = new Dictionary<string, string>().ToImmutableDictionary();
+            var defaultFlags = DependencyNode.GenericResolvedDependencyFlags;
+            var myFlags = ProjectTreeFlags.Create("MyFlag");
 
             // Act
             var node = new AssemblyDependencyNode(id,
-                                                  ProjectTreeFlags.Empty,
+                                                  myFlags,
                                                   priority,
                                                   properties,
                                                   resolved: true,
@@ -151,11 +153,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(KnownMonikers.Reference, node.Icon);
             Assert.Equal(true, node.Resolved);
             Assert.Equal(expectedCaption, node.Caption);
+            Assert.Equal(expectedCaption, node.Name);
 
             // Just to double-check that these properties are still set as sexpected
             Assert.Equal(priority, node.Priority);
             Assert.Equal(properties, node.Properties);
             Assert.Equal(node.Icon, node.ExpandedIcon);
+            Assert.True(node.Flags.Contains(defaultFlags.Union(myFlags)));
         }
 
         [Theory]
@@ -169,10 +173,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var id = DependencyNodeId.FromString(
                         "file:///[MyProviderType;c:\\MyItemSpec.dll;MyItemType;MyUniqueToken]");
             var properties = new Dictionary<string, string>().ToImmutableDictionary();
+            var defaultFlags = DependencyNode.GenericUnresolvedDependencyFlags;
+            var myFlags = ProjectTreeFlags.Create("MyFlag");
 
             // Act
             var node = new AssemblyDependencyNode(id,
-                                                  ProjectTreeFlags.Empty,
+                                                  myFlags,
                                                   priority,
                                                   properties,
                                                   resolved: false,
@@ -182,11 +188,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(KnownMonikers.ReferenceWarning, node.Icon);
             Assert.Equal(false, node.Resolved);
             Assert.Equal("MyItemSpec.dll", node.Caption);
+            Assert.Equal("MyItemSpec.dll", node.Name);
 
             // Just to double-check that these properties are still set as sexpected
             Assert.Equal(priority, node.Priority);
             Assert.Equal(properties, node.Properties);
             Assert.Equal(node.Icon, node.ExpandedIcon);
+            Assert.True(node.Flags.Contains(defaultFlags.Union(myFlags)));
         }
 
         [Theory]
@@ -202,10 +210,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var id = DependencyNodeId.FromString(
                         $"file:///[AnalyzerDependency;{itemSpec};Analyzer;MyUniqueToken]");
             var properties = new Dictionary<string, string>().ToImmutableDictionary();
+            var defaultFlags = (resolved
+                ? DependencyNode.GenericResolvedDependencyFlags
+                : DependencyNode.GenericUnresolvedDependencyFlags);
+            var myFlags = ProjectTreeFlags.Create("MyFlag");
 
             // Act
             var node = new AnalyzerDependencyNode(id,
-                                                  ProjectTreeFlags.Empty,
+                                                  myFlags,
                                                   priority,
                                                   properties,
                                                   resolved: resolved);
@@ -214,11 +226,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(resolved? KnownMonikers.CodeInformation : KnownMonikers.ReferenceWarning, node.Icon);
             Assert.Equal(resolved, node.Resolved);
             Assert.Equal(expectedCaption, node.Caption);
+            Assert.Equal(expectedCaption, node.Name);
 
             // Just to double-check that these properties are still set as sexpected
             Assert.Equal(priority, node.Priority);
             Assert.Equal(properties, node.Properties);
             Assert.Equal(node.Icon, node.ExpandedIcon);
+            Assert.True(node.Flags.Contains(defaultFlags.Union(myFlags)));
         }
 
         [Theory]
@@ -234,10 +248,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var id = DependencyNodeId.FromString(
                         "file:///[MyProviderType;c:\\MyItemSpec.dll;MyItemType;MyUniqueToken]");
             var properties = new Dictionary<string, string>().ToImmutableDictionary();
+            var defaultFlags = (resolved
+                ? DependencyNode.GenericResolvedDependencyFlags
+                : DependencyNode.GenericUnresolvedDependencyFlags);
+            var myFlags = ProjectTreeFlags.Create("MyFlag");
 
             // Act
             var node = new ComDependencyNode(id,
-                                             ProjectTreeFlags.Empty,
+                                             myFlags,
                                              priority,
                                              properties,
                                              resolved: resolved);
@@ -246,11 +264,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(expectedIcon, node.Icon);
             Assert.Equal(resolved, node.Resolved);
             Assert.Equal(expectedCaption, node.Caption);
+            Assert.Equal(expectedCaption, node.Name);
 
             // Just to double-check that these properties are still set as sexpected
             Assert.Equal(priority, node.Priority);
             Assert.Equal(properties, node.Properties);
             Assert.Equal(node.Icon, node.ExpandedIcon);
+            Assert.True(node.Flags.Contains(defaultFlags.Union(myFlags)));
         }
 
         [Theory]
@@ -266,10 +286,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var id = DependencyNodeId.FromString(
                         "file:///[MyProviderType;c:\\MyItemSpec.dll;MyItemType;MyUniqueToken]");
             var properties = new Dictionary<string, string>().ToImmutableDictionary();
+            var defaultFlags = (resolved
+                ? DependencyNode.GenericResolvedDependencyFlags
+                : DependencyNode.GenericUnresolvedDependencyFlags);
+            var myFlags = ProjectTreeFlags.Create("MyFlag");
 
             // Act
             var node = new SdkDependencyNode(id,
-                                             ProjectTreeFlags.Empty,
+                                             myFlags,
                                              priority,
                                              properties,
                                              resolved: resolved);
@@ -278,11 +302,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(expectedIcon, node.Icon);
             Assert.Equal(resolved, node.Resolved);
             Assert.Equal("c:\\MyItemSpec.dll", node.Caption);
+            Assert.Equal("c:\\MyItemSpec.dll", node.Name);
 
             // Just to double-check that these properties are still set as sexpected
             Assert.Equal(priority, node.Priority);
             Assert.Equal(properties, node.Properties);
             Assert.Equal(node.Icon, node.ExpandedIcon);
+            Assert.True(node.Flags.Contains(defaultFlags.Union(myFlags)));
         }
 
         [Fact]
@@ -308,10 +334,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var id = DependencyNodeId.FromString(
                         "file:///[MyProviderType;c:\\MyItemSpec.dll;MyItemType;MyUniqueToken]");
             var properties = new Dictionary<string, string>().ToImmutableDictionary();
+            var defaultFlags = (resolved
+                ? DependencyNode.GenericResolvedDependencyFlags
+                : DependencyNode.GenericUnresolvedDependencyFlags);
+            var myFlags = ProjectTreeFlags.Create("MyFlag");
 
             // Act
             var node = new SharedProjectDependencyNode(id,
-                                                       ProjectTreeFlags.Empty,
+                                                       myFlags,
                                                        priority,
                                                        properties,
                                                        resolved: resolved);
@@ -320,11 +350,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(expectedIcon, node.Icon);
             Assert.Equal(resolved, node.Resolved);
             Assert.Equal("MyItemSpec", node.Caption);
+            Assert.Equal("MyItemSpec", node.Name);
 
             // Just to double-check that these properties are still set as sexpected
             Assert.Equal(priority, node.Priority);
             Assert.Equal(properties, node.Properties);
             Assert.Equal(node.Icon, node.ExpandedIcon);
+            Assert.True(node.Flags.Contains(defaultFlags.Union(myFlags)));
         }
 
         [Fact]
@@ -350,10 +382,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var id = DependencyNodeId.FromString(
                         "file:///[MyProviderType;c:\\MyItemSpec.dll;MyItemType;MyUniqueToken]");
             var properties = new Dictionary<string, string>().ToImmutableDictionary();
+            var defaultFlags = (resolved
+                ? DependencyNode.GenericResolvedDependencyFlags
+                : DependencyNode.GenericUnresolvedDependencyFlags);
+            var myFlags = ProjectTreeFlags.Create("MyFlag");
 
             // Act
             var node = new ProjectDependencyNode(id,
-                                                 ProjectTreeFlags.Empty,
+                                                 myFlags,
                                                  priority,
                                                  properties,
                                                  resolved: resolved);
@@ -362,11 +398,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(expectedIcon, node.Icon);
             Assert.Equal(resolved, node.Resolved);
             Assert.Equal("MyItemSpec", node.Caption);
+            Assert.Equal("MyItemSpec", node.Name);
 
             // Just to double-check that these properties are still set as sexpected
             Assert.Equal(priority, node.Priority);
             Assert.Equal(properties, node.Properties);
             Assert.Equal(node.Icon, node.ExpandedIcon);
+            Assert.True(node.Flags.Contains(defaultFlags.Union(myFlags)));
         }
 
         [Fact]
@@ -407,6 +445,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(KnownMonikers.QuestionMark, node.Icon);
             Assert.Equal(resolved, node.Resolved);
             Assert.Equal(caption, node.Caption);
+            Assert.Equal(caption, node.Name);
             Assert.Equal(properties, node.Properties);
             Assert.Equal(node.Icon, node.ExpandedIcon);
             Assert.True(node.Flags.Contains(defaultFlags.Union(myFlags)));
@@ -434,6 +473,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(KnownMonikers.Library, node.Icon);
             Assert.Equal(true, node.Resolved);
             Assert.Equal(caption, node.Caption);
+            Assert.Equal(caption, node.Name);
             Assert.Equal(properties, node.Properties);
             Assert.Equal(node.Icon, node.ExpandedIcon);
             Assert.True(node.Flags.Contains(defaultFlags.Union(myFlags)));
@@ -476,6 +516,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(resolved, node.Resolved);
             Assert.Equal(priority, node.Priority);
             Assert.Equal(caption, node.Caption);
+            Assert.Equal(caption, node.Name);
             Assert.Equal(node.Alias, node.Caption);
             Assert.Equal(properties, node.Properties);
             Assert.Equal(node.Icon, node.ExpandedIcon);
@@ -529,6 +570,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(resolved, node.Resolved);
             Assert.Equal(priority, node.Priority);
             Assert.Equal(caption, node.Caption);
+            Assert.Equal(caption, node.Name);
             Assert.Equal(node.Alias, node.Caption);
             Assert.Equal(properties, node.Properties);
             Assert.Equal(node.Icon, node.ExpandedIcon);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -212,6 +212,7 @@
     <Compile Include="ProjectSystem\VS\Utilities\NameValuePair.cs" />
     <Compile Include="ProjectSystem\VS\Utilities\ObservableList.cs" />
     <Compile Include="ProjectSystem\VS\Utilities\ObservableListExtensions.cs" />
+    <Compile Include="ProjectSystem\VS\Utilities\ManagedPathHelper.cs" />
     <Compile Include="ProjectSystem\VS\Utilities\UnitTestHelper.cs" />
     <Compile Include="ProjectSystem\VS\Utilities\UIThreadHelper.cs" />
     <Compile Include="ProjectSystem\VS\UI\VsShellUtilitiesHelper.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IProjectTreeExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IProjectTreeExtensions.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
-using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.Shell;
 
@@ -77,44 +76,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             return FindNodeHelper(tree, itemPath, child => child.FilePath);
         }
-
-        /// <summary>
-        /// Finds direct child of IProjectTree by it's path constructed with projectPath 
-        /// and either itemspec or caption.
-        /// </summary>
-        /// <param name="tree"></param>
-        /// <param name="projectFolder"></param>
-        /// <param name="itemSpec"></param>
-        /// <param name="caption"></param>
-        /// <returns></returns>
-        public static IProjectTree FindNodeByPath(this IProjectTree tree, 
-                                                  string projectFolder, 
-                                                  string itemSpec, 
-                                                  string caption)
-        {
-            var treeNode = SafeFindNodeByPath(tree, projectFolder, itemSpec);
-            if (treeNode == null)
-            {
-                treeNode = SafeFindNodeByPath(tree, projectFolder, caption);
-            }
-
-            return treeNode;
-        }
-
-        private static IProjectTree SafeFindNodeByPath(IProjectTree tree, string projectFolder, string relativePath)
-        {
-            try
-            {
-                var nodeFullFilePath = Path.GetFullPath(Path.Combine(projectFolder, relativePath));
-                return FindNodeHelper(tree, nodeFullFilePath, child => child.FilePath);
-
-            }
-            catch (ArgumentException)
-            {
-                var nodeFullFilePath = Path.Combine(projectFolder, relativePath);
-                return FindNodeHelper(tree, nodeFullFilePath, child => child.FilePath);
-            }
-        }        
 
         /// <summary>
         /// Finds direct child of IProjectTree by it's name

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IProjectTreeExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IProjectTreeExtensions.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.Shell;
 
@@ -78,14 +79,52 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         }
 
         /// <summary>
+        /// Finds direct child of IProjectTree by it's path constructed with projectPath 
+        /// and either itemspec or caption.
+        /// </summary>
+        /// <param name="tree"></param>
+        /// <param name="projectFolder"></param>
+        /// <param name="itemSpec"></param>
+        /// <param name="caption"></param>
+        /// <returns></returns>
+        public static IProjectTree FindNodeByPath(this IProjectTree tree, 
+                                                  string projectFolder, 
+                                                  string itemSpec, 
+                                                  string caption)
+        {
+            var treeNode = SafeFindNodeByPath(tree, projectFolder, itemSpec);
+            if (treeNode == null)
+            {
+                treeNode = SafeFindNodeByPath(tree, projectFolder, caption);
+            }
+
+            return treeNode;
+        }
+
+        private static IProjectTree SafeFindNodeByPath(IProjectTree tree, string projectFolder, string relativePath)
+        {
+            try
+            {
+                var nodeFullFilePath = Path.GetFullPath(Path.Combine(projectFolder, relativePath));
+                return FindNodeHelper(tree, nodeFullFilePath, child => child.FilePath);
+
+            }
+            catch (ArgumentException)
+            {
+                var nodeFullFilePath = Path.Combine(projectFolder, relativePath);
+                return FindNodeHelper(tree, nodeFullFilePath, child => child.FilePath);
+            }
+        }        
+
+        /// <summary>
         /// Finds direct child of IProjectTree by it's name
         /// </summary>
         /// <param name="tree"></param>
-        /// <param name="itemName"></param>
+        /// <param name="caption"></param>
         /// <returns></returns>
-        public static IProjectTree FindNodeByName(this IProjectTree tree, string itemName)
+        public static IProjectTree FindNodeByCaption(this IProjectTree tree, string caption)
         {
-            return FindNodeHelper(tree, itemName, child => child.Caption);
+            return FindNodeHelper(tree, caption, child => child.Caption);
         }
 
         private static IProjectTree FindNodeHelper(this IProjectTree tree, string itemToFind,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AnalyzerDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AnalyzerDependencyNode.cs
@@ -32,8 +32,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             }
 
             Priority = AnalyzerNodePriority;
-
             ExpandedIcon = Icon;
+
+            Flags = (resolved ? GenericResolvedDependencyFlags : GenericUnresolvedDependencyFlags)
+                        .Union(flags);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AssemblyDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AssemblyDependencyNode.cs
@@ -43,8 +43,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             }
 
             Priority = FrameworkAssemblyNodePriority;
-
             ExpandedIcon = Icon;
+
+            Flags = (resolved ? GenericResolvedDependencyFlags : GenericUnresolvedDependencyFlags)
+                        .Union(flags);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ComDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ComDependencyNode.cs
@@ -34,6 +34,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             Priority = ComNodePriority;
             ExpandedIcon = Icon;
+
+            Flags = (resolved ? GenericResolvedDependencyFlags : GenericUnresolvedDependencyFlags)
+                        .Union(flags);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProvider.cs
@@ -16,6 +16,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 using Task = System.Threading.Tasks.Task;
+using System.IO;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
@@ -221,7 +222,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     continue;
                 }
 
-                var (node, subTreeProvider) = await GetDependencyNodeInfo(graphContext, inputGraphNode, projectPath)
+                var (node, subTreeProvider) = await GetDependencyNodeInfoAsync(graphContext, inputGraphNode, projectPath)
                                                         .ConfigureAwait(false);
                 if (node == null || subTreeProvider == null)
                 {
@@ -269,7 +270,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     continue;
                 }
 
-                var (node, subTreeProvider) = await GetDependencyNodeInfo(graphContext, inputGraphNode, projectPath)
+                var (node, subTreeProvider) = await GetDependencyNodeInfoAsync(graphContext, inputGraphNode, projectPath)
                                                         .ConfigureAwait(false);
                 if (node == null || subTreeProvider == null)
                 {
@@ -311,9 +312,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     for (int i = 0; i < nodeChildren.Length; ++i)
                     {
                         var childNodeToAdd = nodeChildren[i];
-                        var childSubTreeProvider = childrenSubTreeProviders == null 
-                                                    ? subTreeProvider 
-                                                    : childrenSubTreeProviders[i];
+                        var childSubTreeProvider = childrenSubTreeProviders?[i];
 
                         // start tracking changes if needed
                         if (graphContext.TrackChanges)
@@ -390,10 +389,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                             }
 
                             // add provider's root node to display matching nodes                                                         
-                            var topLevelGraphNode = AddGraphNode(graphContext,
+                            var topLevelGraphNode = AddTopLevelGraphNode(graphContext,
                                                                  projectContext.ProjectFilePath,
                                                                  subTreeProvider,
-                                                                 parentNode: null,
                                                                  nodeInfo: refreshedTopLevelNode);
 
                             // now recursively add graph nodes for provider nodes that match search criteria under 
@@ -430,19 +428,40 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// able to discover IDependencyNode form the scratch.
         /// </summary>
         private async Task<(IDependencyNode node, IProjectDependenciesSubTreeProvider subTreeProvider)> 
-            GetDependencyNodeInfo(IGraphContext graphContext, GraphNode inputGraphNode, string projectPath)
+            GetDependencyNodeInfoAsync(IGraphContext graphContext, GraphNode inputGraphNode, string projectPath)
         {
             IDependencyNode node = null;
             IProjectDependenciesSubTreeProvider subTreeProvider = null;
 
+            // check if node is toplevel or lowerlevel hierarchy
             node = inputGraphNode.GetValue<IDependencyNode>(DependenciesGraphSchema.DependencyNodeProperty);
             if (node == null)
             {
-                // All graph nodes generated here will have this unique node id, root node will have it equal to null
-                var nodeIdString = GetPartialValueFromGraphNodeId(inputGraphNode.Id, CodeGraphNodeIdName.File);
-                var nodeId = DependencyNodeId.FromString(nodeIdString);
+                // this is a top level dependency node or unsupported node like some source file node
+                var hierarchyItem = inputGraphNode.GetValue<IVsHierarchyItem>(HierarchyGraphNodeProperties.HierarchyItem);
+                if (hierarchyItem == null)
+                {
+                    // unknown node
+                    return (node, subTreeProvider);
+                }
+
+                // now check node file path if it is a DependencyNodeId 
+                var nodeFilePath = GetPartialValueFromGraphNodeId(inputGraphNode.Id, CodeGraphNodeIdName.File);
+                var nodeId = DependencyNodeId.FromString(nodeFilePath);
                 if (nodeId == null)
                 {
+                    // check parent node - it will be a IProjectTree node which can have file path to be 
+                    // in our DependencyNodeId format. If it is a top level dependency, it's parent will 
+                    // be provider root node: Dependencies\NuGet\<top level dependency>. In this sample
+                    // parent for <top level dependency> will be NuGet node, which will be not IProjectItemTree,
+                    // but IProjecTree and thus has FilePath containing actual DependencyNodeId. 
+                    var parentFilePath = hierarchyItem.Parent.CanonicalName;
+                    nodeId = DependencyNodeId.FromString(parentFilePath);
+                }
+
+                if (nodeId == null)
+                {
+                    // unknown node
                     return (node, subTreeProvider);
                 }
 
@@ -450,27 +469,31 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                                                 inputGraphNode,
                                                                 projectPath,
                                                                 nodeId).ConfigureAwait(false);
+
                 if (subTreeProvider == null)
                 {
                     return (node, subTreeProvider);
                 }
 
-                node = subTreeProvider.GetDependencyNode(nodeId);
+                // now get real DependencyNodeId - find the actual node in the provider's top 
+                // level node. Note: nodeId above we need only to get correct sub tree provider, but
+                // it would not contain our top level node's ItemSpec, ItemType etc. We need to get it here.
+                var caption = hierarchyItem.Text;
+                node = subTreeProvider.RootNode.Children.Where(x => x.Caption.Equals(caption, StringComparison.OrdinalIgnoreCase))
+                                                 .FirstOrDefault();
                 if (node == null)
                 {
+                    // node is not ours or does node xist anymore
                     return (node, subTreeProvider);
                 }
             }
             else
             {
+                // this is lower level graph node that is created by this provider, just get it's subTreeProvider
                 subTreeProvider = await GetSubTreeProviderAsync(graphContext,
                                                                 inputGraphNode,
                                                                 projectPath,
                                                                 node.Id).ConfigureAwait(false);
-                if (subTreeProvider == null)
-                {
-                    return (node, subTreeProvider);
-                }
             }
 
             return (node, subTreeProvider);
@@ -670,6 +693,42 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             return GraphNodeId.GetNested(partialValues.ToArray());
         }
 
+        private GraphNodeId GetTopLevelGraphNodeId(string projectPath, IDependencyNode nodeInfo)
+        {
+            var partialValues = new List<GraphNodeId>();
+            partialValues.Add(GraphNodeId.GetPartial(CodeGraphNodeIdName.Assembly,
+                                                     new Uri(projectPath, UriKind.RelativeOrAbsolute)));
+            if (nodeInfo.Flags.Contains(DependencyNode.GenericDependencyFlags))
+            {
+                var projectFolder = Path.GetDirectoryName(projectPath)?.ToLowerInvariant();
+                if (nodeInfo.Flags.Contains(DependencyNode.CustomItemSpec))
+                {
+                    partialValues.Add(GraphNodeId.GetPartial(CodeGraphNodeIdName.File,
+                                                         new Uri(Path.Combine(projectFolder, nodeInfo.Caption.ToLowerInvariant()),
+                                                           UriKind.RelativeOrAbsolute)));
+                }
+                else
+                {
+                    var fullItemSpecPath = Path.GetFullPath(
+                                            Path.Combine(projectFolder,
+                                                         nodeInfo.Id.ItemSpec?.ToLowerInvariant()));
+                    if (!string.IsNullOrEmpty(fullItemSpecPath))
+                    {
+                        partialValues.Add(GraphNodeId.GetPartial(CodeGraphNodeIdName.File,
+                                                             new Uri(fullItemSpecPath, UriKind.RelativeOrAbsolute)));
+                    }
+                }
+            }
+            else
+            {
+                partialValues.Add(GraphNodeId.GetPartial(CodeGraphNodeIdName.File,
+                                                         new Uri(nodeInfo.Id.ToString().ToLowerInvariant(),
+                                                           UriKind.RelativeOrAbsolute)));
+            }
+
+            return GraphNodeId.GetNested(partialValues.ToArray());
+        }
+
         private GraphNode AddGraphNode(IGraphContext graphContext,
                                        string projectPath,
                                        IProjectDependenciesSubTreeProvider subTreeProvider,
@@ -677,19 +736,40 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                        IDependencyNode nodeInfo)
         {
             var newNodeId = GetGraphNodeId(projectPath, nodeInfo);
-            var newNode = graphContext.Graph.Nodes.GetOrCreate(newNodeId, nodeInfo.Caption, null);
+
+            return DoAddGraphNode(newNodeId, graphContext, projectPath, subTreeProvider, parentNode, nodeInfo);
+        }
+
+        private GraphNode AddTopLevelGraphNode(IGraphContext graphContext,
+                                               string projectPath,
+                                               IProjectDependenciesSubTreeProvider subTreeProvider,
+                                               IDependencyNode nodeInfo)
+        {
+            var newNodeId = GetTopLevelGraphNodeId(projectPath, nodeInfo);
+
+            return DoAddGraphNode(newNodeId, graphContext, projectPath, subTreeProvider, null, nodeInfo);
+        }
+
+        private GraphNode DoAddGraphNode(GraphNodeId graphNodeId,
+                                         IGraphContext graphContext,
+                                         string projectPath,
+                                         IProjectDependenciesSubTreeProvider subTreeProvider,
+                                         GraphNode parentNode,
+                                         IDependencyNode nodeInfo)
+        {
+            var newNode = graphContext.Graph.Nodes.GetOrCreate(graphNodeId, nodeInfo.Caption, null);
 
             newNode.SetValue(DgmlNodeProperties.Icon, GetIconStringName(nodeInfo.Icon));
             newNode.SetValue(DependenciesGraphSchema.DependencyNodeProperty, nodeInfo);
             // priority sets correct order among peers
-            newNode.SetValue(CodeNodeProperties.SourceLocation, 
+            newNode.SetValue(CodeNodeProperties.SourceLocation,
                              new SourceLocation(projectPath, new Position(nodeInfo.Priority, 0)));
             newNode.SetValue(DependenciesGraphSchema.ProviderProperty, subTreeProvider);
 
-            newNode.AddCategory(DependenciesGraphSchema.CategoryDependency);
+            //newNode.AddCategory(DependenciesGraphSchema.CategoryDependency);
 
             graphContext.OutputNodes.Add(newNode);
-
+            
             if (parentNode != null)
             {
                 graphContext.Graph.Links.GetOrCreate(parentNode, newNode, /*label*/ null, CodeLinkCategories.Contains);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProvider.cs
@@ -312,7 +312,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     for (int i = 0; i < nodeChildren.Length; ++i)
                     {
                         var childNodeToAdd = nodeChildren[i];
-                        var childSubTreeProvider = childrenSubTreeProviders?[i];
+                        var childSubTreeProvider = childrenSubTreeProviders?[i] ?? subTreeProvider;
 
                         // start tracking changes if needed
                         if (graphContext.TrackChanges)
@@ -483,7 +483,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                                  .FirstOrDefault();
                 if (node == null)
                 {
-                    // node is not ours or does node xist anymore
+                    // node is not ours or does node exist anymore
                     return (node, subTreeProvider);
                 }
             }
@@ -703,9 +703,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 var projectFolder = Path.GetDirectoryName(projectPath)?.ToLowerInvariant();
                 if (nodeInfo.Flags.Contains(DependencyNode.CustomItemSpec))
                 {
-                    partialValues.Add(GraphNodeId.GetPartial(CodeGraphNodeIdName.File,
-                                                         new Uri(Path.Combine(projectFolder, nodeInfo.Caption.ToLowerInvariant()),
-                                                           UriKind.RelativeOrAbsolute)));
+                    var name = DependencyNode.GetName(nodeInfo);
+                    if (name != null)
+                    {
+                        partialValues.Add(GraphNodeId.GetPartial(
+                            CodeGraphNodeIdName.File,
+                            new Uri(Path.Combine(projectFolder, name.ToLowerInvariant()),
+                            UriKind.RelativeOrAbsolute)));
+                    }
                 }
                 else
                 {
@@ -766,7 +771,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                              new SourceLocation(projectPath, new Position(nodeInfo.Priority, 0)));
             newNode.SetValue(DependenciesGraphSchema.ProviderProperty, subTreeProvider);
 
-            //newNode.AddCategory(DependenciesGraphSchema.CategoryDependency);
+            newNode.AddCategory(DependenciesGraphSchema.CategoryDependency);
 
             graphContext.OutputNodes.Add(newNode);
             

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -15,6 +15,7 @@ using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.References;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using Task = System.Threading.Tasks.Task;
@@ -179,14 +180,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     }
 
                     var nodeItemContext = node.BrowseObjectProperties.Context;
-                    var itemName = nodeItemContext.ItemName;
-                    if (PackageReference.SchemaName.Equals(nodeItemContext.ItemType))
-                    {
-                        // for packages captions always contain versions, but actual project items don't
-                        itemName = ExtractNameFromCaption(itemName);
-                    }
-
-                    var unresolvedReferenceItem = project.GetItemsByEvaluatedInclude(itemName)
+                    var unresolvedReferenceItem = project.GetItemsByEvaluatedInclude(nodeItemContext.ItemName)
                         .FirstOrDefault(item => string.Equals(item.ItemType, 
                                                               nodeItemContext.ItemType, 
                                                               StringComparison.OrdinalIgnoreCase));
@@ -226,17 +220,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     }
                 }
             }
-        }
-
-        private string ExtractNameFromCaption(string caption)
-        {
-            var index = caption?.IndexOf(' ');
-            if (index.HasValue && index.Value >= 0)
-            {
-                return caption.Substring(0, index.Value);
-            }
-
-            return caption;
         }
 
         /// <summary>
@@ -416,15 +399,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                                        .Add(Folder.FullPathProperty, string.Empty);
 
             // For generic node types we do set correct, known item types, however for custom nodes
-            // provided by third party extensions we can not guaranty that item type will be known. 
+            // provided by third party extensions we can not guarantee that item type will be known. 
             // Thus always set predefined itemType for all custom nodes.
             // TODO: generate specific xaml rule for generic Dependency nodes
             var itemType = isGenericNodeType ? nodeInfo.Id.ItemType : Folder.SchemaName;
             
             // when itemSpec is not in valid absolute path format, property page does not show 
-            // item name correctly.
+            // item name correctly. Use real Name for the node here instead of caption, since caption
+            // can have other info liek version in it.
             var itemSpec = nodeInfo.Flags.Contains(DependencyNode.CustomItemSpec)
-                    ? nodeInfo.Caption
+                    ? DependencyNode.GetName(nodeInfo)
                     : nodeInfo.Id.ItemSpec;
             var itemContext = ProjectPropertiesContext.GetContext(UnconfiguredProject, itemType, itemSpec);
             var configuredProjectExports = GetActiveConfiguredProjectExports(ActiveConfiguredProject);
@@ -524,8 +508,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Requires.NotNullOrEmpty(subTreeProvider.RootNode.Caption, nameof(subTreeProvider.RootNode.Caption));
             Requires.NotNullOrEmpty(subTreeProvider.ProviderType, nameof(subTreeProvider.ProviderType));
 
-            var projectPath = Path.GetDirectoryName(UnconfiguredProject.FullPath);
-
+            var projectFolder = Path.GetDirectoryName(UnconfiguredProject.FullPath);
             var providerRootTreeNode = GetSubTreeRootNode(dependenciesNode,
                                                           subTreeProvider.RootNode.Flags);
             if (subTreeProvider.RootNode.HasChildren || subTreeProvider.ShouldBeVisibleWhenEmpty)
@@ -554,9 +537,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                             return dependenciesNode;
                         }
 
-                        var treeNode = providerRootTreeNode.FindNodeByPath(projectPath,
-                                                                           removedItem.Id.ItemSpec,
-                                                                           removedItem.Caption);
+                        var treeNode = FindProjectTreeNode(providerRootTreeNode, removedItem, projectFolder);
                         if (treeNode != null)
                         {
                             providerRootTreeNode = treeNode.Remove();
@@ -570,9 +551,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                             return dependenciesNode;
                         }
 
-                        var treeNode = providerRootTreeNode.FindNodeByPath(projectPath, 
-                                                                           updatedItem.Id.ItemSpec, 
-                                                                           updatedItem.Caption);
+                        var treeNode = FindProjectTreeNode(providerRootTreeNode, updatedItem, projectFolder);
                         if (treeNode != null)
                         {
 
@@ -605,9 +584,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                             return dependenciesNode;
                         }
 
-                        var treeNode = providerRootTreeNode.FindNodeByPath(projectPath, 
-                                                                           addedItem.Id.ItemSpec, 
-                                                                           addedItem.Caption);
+                        var treeNode = FindProjectTreeNode(providerRootTreeNode, addedItem, projectFolder);
                         if (treeNode == null)
                         {
                             treeNode = CreateProjectItemTreeNode(providerRootTreeNode, addedItem, catalogs);
@@ -637,6 +614,42 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             return dependenciesNode;
         }
 
+        /// <summary>
+        /// Finds IProjectTree node in the top level children of a given parent IProjectTree node.
+        /// Depending on the type of IDependencyNode search method is different:
+        ///     - if dependency node has custom ItemSpec, we only can find it by caption.
+        ///     - if dependency node has normal ItemSpec, we first try to find it by path and then
+        ///       by caption if path was not found (since unresolved and resolved items can have 
+        ///       different items specs).
+        /// </summary>
+        private IProjectTree FindProjectTreeNode(IProjectTree parentNode, IDependencyNode nodeInfo, string projectPath)
+        {
+            IProjectTree treeNode = null;
+            if (nodeInfo.Flags.Contains(DependencyNode.CustomItemSpec))
+            {
+                treeNode = parentNode.FindNodeByCaption(nodeInfo.Caption);
+            }
+            else
+            {
+                var itemSpec = nodeInfo.Id.ItemSpec;
+                if (!ManagedPathHelper.IsRooted(itemSpec))
+                {
+                    itemSpec = ManagedPathHelper.TryMakeRooted(projectPath, itemSpec);
+                }
+
+                if (!string.IsNullOrEmpty(itemSpec))
+                {
+                    treeNode = parentNode.FindNodeByPath(itemSpec);
+                }
+
+                if (treeNode == null)
+                {
+                    treeNode = parentNode.FindNodeByCaption(nodeInfo.Caption);
+                }
+            }
+
+            return treeNode;
+        }
 
         /// <summary>
         /// Finds the resolved reference item for a given unresolved reference.
@@ -808,7 +821,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                             unresolvedContext.ItemName);
             }
         }
-       
+
         /// <summary>
         /// Gets an IRule to attach to a project item so that browse object properties will be displayed.
         /// </summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -383,7 +383,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                                            IProjectCatalogSnapshot catalogs)
         {
             var isGenericNodeType = nodeInfo.Flags.Contains(DependencyNode.GenericDependencyFlags);
-
             var properties = nodeInfo.Properties ??
                     ImmutableDictionary<string, string>.Empty
                                                        .Add(Folder.IdentityProperty, nodeInfo.Caption)
@@ -393,6 +392,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             // provided by third party extensions we can not guarantee that item type will be known. 
             // Thus always set predefined itemType for all custom nodes.
             // TODO: generate specific xaml rule for generic Dependency nodes
+            // tracking issue: https://github.com/dotnet/roslyn-project-system/issues/1102
             var itemType = isGenericNodeType ? nodeInfo.Id.ItemType : Folder.SchemaName;
             
             // when itemSpec is not in valid absolute path format, property page does not show 
@@ -499,7 +499,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Requires.NotNullOrEmpty(subTreeProvider.RootNode.Caption, nameof(subTreeProvider.RootNode.Caption));
             Requires.NotNullOrEmpty(subTreeProvider.ProviderType, nameof(subTreeProvider.ProviderType));
 
-            var projectFolder = Path.GetDirectoryName(UnconfiguredProject.FullPath);
+            var projectFolder = Path.GetDirectoryName(UnconfiguredProject.FullPath);                                    
             var providerRootTreeNode = GetSubTreeRootNode(dependenciesNode,
                                                           subTreeProvider.RootNode.Flags);
             if (subTreeProvider.RootNode.HasChildren || subTreeProvider.ShouldBeVisibleWhenEmpty)
@@ -613,7 +613,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         ///       by caption if path was not found (since unresolved and resolved items can have 
         ///       different items specs).
         /// </summary>
-        private IProjectTree FindProjectTreeNode(IProjectTree parentNode, IDependencyNode nodeInfo, string projectPath)
+        private IProjectTree FindProjectTreeNode(IProjectTree parentNode, 
+                                                 IDependencyNode nodeInfo, 
+                                                 string projectFolder)
         {
             IProjectTree treeNode = null;
             if (nodeInfo.Flags.Contains(DependencyNode.CustomItemSpec))
@@ -625,7 +627,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 var itemSpec = nodeInfo.Id.ItemSpec;
                 if (!ManagedPathHelper.IsRooted(itemSpec))
                 {
-                    itemSpec = ManagedPathHelper.TryMakeRooted(projectPath, itemSpec);
+                    itemSpec = ManagedPathHelper.TryMakeRooted(projectFolder, itemSpec);
                 }
 
                 if (!string.IsNullOrEmpty(itemSpec))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -239,15 +239,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 return null;
             }
 
-            // Note: all dependency nodes file path starts with file:///, but FindByPath is called eventually 
-            // from ParseCanonicalName, which in turn called from progression's SourceFileToHierarchyItem where
-            // LocalPath of the Uri is passed, not full Uri during search. Thus here we need to append file:/// 
-            // if it is not there.
-            //if (!path.StartsWith("file:///"))
-            //{
-            //    path = "file:///" + path.Trim('/');
-            //}
-
             var node = dependenciesNode.FindNodeByPath(path);
             if (node == null)
             {
@@ -406,7 +397,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             
             // when itemSpec is not in valid absolute path format, property page does not show 
             // item name correctly. Use real Name for the node here instead of caption, since caption
-            // can have other info liek version in it.
+            // can have other info like version in it.
             var itemSpec = nodeInfo.Flags.Contains(DependencyNode.CustomItemSpec)
                     ? DependencyNode.GetName(nodeInfo)
                     : nodeInfo.Id.ItemSpec;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
@@ -104,6 +104,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             Id = id;
             Caption = Id.ItemSpec ?? string.Empty;
+            Name = Caption;
             Priority = priority;
             Properties = properties;
             Resolved = resolved;
@@ -125,6 +126,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// </summary>
         public string Caption { get; set; }
 
+        /// <summary>
+        /// Actual formal name of the node. In most cases it will be equal to Caption,
+        /// however in some cases caption would have name + version or something else.
+        /// So to allow tree provider store formal name we need this property too. 
+        /// It is a hack now and we should make it public and move to IDependencyNode when
+        /// we get a chance and it is safe to do a breaking change.
+        /// </summary>
+        internal string Name { get; set; }
+
+        /// <summary>
+        /// This is temporary until we can add Name to IDependencyNode to protect us from custom 
+        /// implementations of IDependencyNode which don't have Name yet.
+        /// </summary>
+        internal static string GetName(IDependencyNode node)
+        {
+            Requires.NotNull(node, nameof(node));
+
+            if (node is DependencyNode dependencyNode)
+            {
+                return dependencyNode.Name;
+            }
+            else
+            {
+                return node.Caption;
+            }
+        }
         /// <summary>
         /// Unique name constructed in the form Caption (ItemSpec).
         /// Is used to dedupe dependency nodes when they have same caption but different 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
@@ -132,6 +132,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// So to allow tree provider store formal name we need this property too. 
         /// It is a hack now and we should make it public and move to IDependencyNode when
         /// we get a chance and it is safe to do a breaking change.
+        /// Tracking with https://github.com/dotnet/roslyn-project-system/issues/1101
         /// </summary>
         internal string Name { get; set; }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
@@ -104,7 +104,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             Id = id;
             Caption = Id.ItemSpec ?? string.Empty;
-            Name = Caption;
             Priority = priority;
             Properties = properties;
             Resolved = resolved;
@@ -134,7 +133,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// we get a chance and it is safe to do a breaking change.
         /// Tracking with https://github.com/dotnet/roslyn-project-system/issues/1101
         /// </summary>
-        internal string Name { get; set; }
+        private string _name;
+        internal string Name {
+            get
+            {
+                return _name ?? Caption;
+            }
+            set
+            {
+                _name = value;
+            }
+        }
 
         /// <summary>
         /// This is temporary until we can add Name to IDependencyNode to protect us from custom 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
@@ -108,8 +108,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Properties = properties;
             Resolved = resolved;
             Flags = Resolved
-                        ? GenericResolvedDependencyFlags.Union(flags)
-                        : GenericUnresolvedDependencyFlags.Union(flags);
+                        ? ResolvedDependencyFlags.Union(flags)
+                        : UnresolvedDependencyFlags.Union(flags);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/NuGetDependenciesSubTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/NuGetDependenciesSubTreeProvider.cs
@@ -117,6 +117,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 case DependencyType.Package:
                     dependencyNode = new PackageDependencyNode(
                                              id,
+                                             name: dependencyMetadata.Name,
                                              caption: dependencyMetadata.FriendlyName,
                                              flags: NuGetSubTreeNodeFlags,
                                              properties: dependencyMetadata.Properties,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageDependencyNode.cs
@@ -23,9 +23,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                             ? PackageNodePriority 
                             : UnresolvedReferenceNodePriority;
 
-            Flags = (resolved ? ResolvedDependencyFlags : UnresolvedDependencyFlags)
-                        .Add(ProjectTreeFlags.Common.ResolvedReference)
+            Flags = (resolved ? GenericResolvedDependencyFlags : GenericUnresolvedDependencyFlags)
                         .Union(flags);
+
         }
 
         public override string Alias

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/PackageDependencyNode.cs
@@ -8,14 +8,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     internal class PackageDependencyNode : DependencyNode
     {
         public PackageDependencyNode(DependencyNodeId id,
+                                     string name,
                                      string caption,
                                      ProjectTreeFlags flags,
                                      IImmutableDictionary<string, string> properties = null,
                                      bool resolved = true)
             : base(id, flags, 0, properties, resolved)
         {
+            Requires.NotNullOrEmpty(name, nameof(name));
             Requires.NotNullOrEmpty(caption, nameof(caption));
 
+            Name = name;
             Caption = caption;
             Icon = resolved ? KnownMonikers.PackageReference : KnownMonikers.ReferenceWarning;
             ExpandedIcon = Icon;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ProjectDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ProjectDependencyNode.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             ExpandedIcon = Icon;
 
-            Flags = (resolved ? ResolvedDependencyFlags : GenericUnresolvedDependencyFlags)
+            Flags = (resolved ? GenericResolvedDependencyFlags : GenericUnresolvedDependencyFlags)
                         .Union(flags);
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SdkDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SdkDependencyNode.cs
@@ -32,6 +32,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             Priority = SdkNodePriority;
             ExpandedIcon = Icon;
+
+            Flags = (resolved ? GenericResolvedDependencyFlags : GenericUnresolvedDependencyFlags)
+                        .Union(flags);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SharedProjectDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SharedProjectDependencyNode.cs
@@ -29,6 +29,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             }
 
             ExpandedIcon = Icon;
+            Flags = (resolved ? GenericResolvedDependencyFlags : GenericUnresolvedDependencyFlags)
+                        .Union(flags);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SubTreeRootDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SubTreeRootDependencyNode.cs
@@ -6,6 +6,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
     internal class SubTreeRootDependencyNode : DependencyNode
     {
+        private static readonly ProjectTreeFlags SubTreeRootNodeFlags
+                = ProjectTreeFlags.Create("SubTreeRootNode");
+
         public SubTreeRootDependencyNode(string providerType,
                                          string caption,
                                          ProjectTreeFlags flags,
@@ -21,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Caption = caption;
             Icon = icon;
             ExpandedIcon = expandedIcon ?? Icon;
-            Flags = flags.Add(ProjectTreeFlags.Common.NonFileSystemProjectItem.ToString());
+            Flags = flags.Add(SubTreeRootNodeFlags.ToString());
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SubTreeRootDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SubTreeRootDependencyNode.cs
@@ -21,6 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Caption = caption;
             Icon = icon;
             ExpandedIcon = expandedIcon ?? Icon;
+            Flags = flags.Add(ProjectTreeFlags.Common.NonFileSystemProjectItem.ToString());
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/ManagedPathHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/ManagedPathHelper.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
     internal static class ManagedPathHelper
     {
         /// <summary>
-        /// Tests a path to see if it is absolute or not.  More reliable that Path.IsPathRooted.
+        /// Tests a path to see if it is absolute or not. More reliable than Path.IsPathRooted.
         /// </summary>
         /// <param name="path"></param>
         /// <returns></returns>
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
 
             try
             {
-                return PathHelper.MakeRooted(basePath, path);
+                return PathHelper.MakeRooted(PathHelper.EnsureTrailingSlash(basePath), path);
             }
             catch (ArgumentException)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/ManagedPathHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/ManagedPathHelper.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
+{
+    /// <summary>
+    /// Helpful Path operations that are repeating in several places.
+    /// We need to ask to make these API public in CPS's PathHelper.
+    /// </summary>
+    internal static class ManagedPathHelper
+    {
+        /// <summary>
+        /// Tests a path to see if it is absolute or not.  More reliable that Path.IsPathRooted.
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        public static bool IsRooted(string path)
+        {
+            Requires.NotNullOrEmpty(path, nameof(path));
+            // We don't use System.IO.Path.IsPathRooted because it doesn't support
+            // URIs, and because it returns true for paths like "\dir\file", which is
+            // relative to whatever drive we're talking about.
+            return Uri.TryCreate(path, UriKind.Absolute, out var result);
+        }
+
+        /// <summary>
+        /// Makes the specified path absolute if possible, otherwise return an empty string.
+        /// </summary>
+        /// <param name="basePath">The path used as the root if <paramref name="path"/> is relative.</param>
+        /// <param name="path">An absolute or relative path.</param>
+        /// <returns>An absolute path, or the empty string if <paramref name="path"/> invalid.</returns>
+        public static string TryMakeRooted(string basePath, string path)
+        {
+            Requires.NotNullOrEmpty(basePath, nameof(basePath));
+            Requires.NotNullOrEmpty(path, nameof(path));
+
+            try
+            {
+                return PathHelper.MakeRooted(basePath, path);
+            }
+            catch (ArgumentException)
+            {
+                return string.Empty;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- support automation (VSLangProj.References) by switching to IProjectItemTree instead of IProjectTree. This is needed since CPS uses IProjectItemTree nodes with Reference flag to implement VSLangProj.References. (Note: this still would need some matching CPS changes to make sure we work OK for regular references (assemblies and projects) and packages (for packages CPS needs to listen for package xaml rules and add e new reference type). Note: i reuse a Folder xaml type for custom dependency nodes (implemented outside of managed project system), however we might want to create a separate BrowseObject xaml rule "GenericDependency" to be precise and add there standard set of properties.
- organize dependency nodes flags: all generic (implemented by us nodes) will have CPS's Reference flags to allow CPS default commands behavior and our own Dependencies flags to allow to figure out if nodes are ours in the future. All custom nodes implemented outside of managed project system, will have only Dependencies flags to avoid CPS logic be executed for them - they are not References in old meaning of them.
- fixes issue #398 and does not show View In ObjectBrowser for dependencies sub nodes. Properties is still showing up though
fixes #864 and #708 to support Remove menu command and delete key for all standard top level dependencies (custom ones like web bower, should implement their own delete command)
- fixes #403 to show View in Object Browser command for standard dependencies, however projects are not displayed in the Browser (still investigating why - could be CPS) and also need to hide this command for packages, (this is also pending).

	TODO:
- projects are not displayed in the Browser (still investigating why - could be CPS) and also need to hide this command for packages, (this is also pending).
- Properties is still showing up for Dependencies sub nodes. If it is controlled by some CPS command handler will override it, if by IVsUIHierarchy implementation would need CPS change.
- see if we want to create a separate BrowseObject xaml rule "GenericDependency" for custom dependency nodes and add there standard set of properties.