### PR TITLE
Generate satellites for editors vsix

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
+++ b/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
@@ -156,7 +156,15 @@
       <DependentUpon>ApplicationDesignerView.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="ApplicationDesigner\ApplicationDesignerView.*.resx">
+      <DependentUpon>ApplicationDesignerView.vb</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="ApplicationDesigner\SpecialFileCustomView.resx">
+      <DependentUpon>SpecialFileCustomView.vb</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="ApplicationDesigner\SpecialFileCustomView.*.resx">
       <DependentUpon>SpecialFileCustomView.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
@@ -164,7 +172,15 @@
       <DependentUpon>PropPageDesignerView.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="PropPageDesigner\PropPageDesignerView.*.resx">
+      <DependentUpon>PropPageDesignerView.vb</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="PropPages\PropPageHostDialog.resx">
+      <DependentUpon>PropPageHostDialog.vb</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\PropPageHostDialog.*.resx">
       <DependentUpon>PropPageHostDialog.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
@@ -179,9 +195,16 @@
       <LastGenOutput>Designer.Designer.vb</LastGenOutput>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="Resources\Designer.*.resx">
+      <LogicalName>Microsoft.VisualStudio.AppDesigner.%(Filename).resources</LogicalName>
+      <DependentUpon>Designer.resx</DependentUpon>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="DesignerFramework\ErrorControl.resx">
+      <DependentUpon>ErrorControl.vb</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="DesignerFramework\ErrorControl.*.resx">
       <DependentUpon>ErrorControl.vb</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Resources\ApplicationDesigner\OverflowImage.png">

--- a/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
+++ b/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
@@ -49,7 +49,15 @@
     <EmbeddedResource Include="AddImportsDialogs\AddImports.resx">
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="AddImportsDialogs\AddImports.*.resx">
+      <SubType>Designer</SubType>
+      <DependentUpon>AddImports.resx</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="AddImportsDialogs\AutoAddImportsCollisionDialog.resx">
+      <DependentUpon>AutoAddImportsCollisionDialog.vb</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="AddImportsDialogs\AutoAddImportsCollisionDialog.*.resx">
       <DependentUpon>AutoAddImportsCollisionDialog.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
@@ -57,10 +65,21 @@
       <DependentUpon>AutoAddImportsExtensionCollisionDialog.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="AddImportsDialogs\AutoAddImportsExtensionCollisionDialog.*.resx">
+      <DependentUpon>AutoAddImportsExtensionCollisionDialog.vb</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="DesignerFramework\ErrorControl.resx">
       <DependentUpon>ErrorControl.vb</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="DesignerFramework\ErrorControl.*.resx">
+      <DependentUpon>ErrorControl.vb</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="MyExtensibility\AddMyExtensionsDialog.resx">
+      <DependentUpon>AddMyExtensionsDialog.vb</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="MyExtensibility\AddMyExtensionsDialog.*.resx">
       <DependentUpon>AddMyExtensionsDialog.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
@@ -68,11 +87,24 @@
       <DependentUpon>AssemblyOptionDialog.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="MyExtensibility\AssemblyOptionDialog.*.resx">
+      <DependentUpon>AssemblyOptionDialog.vb</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="MyExtensibility\MyExtensibilityPropPage.resx">
       <DependentUpon>MyExtensibilityPropPage.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="MyExtensibility\MyExtensibilityPropPage.*.resx">
+      <DependentUpon>MyExtensibilityPropPage.vb</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="Package\EditorToolsOptionsPanel.resx">
+      <DependentUpon>EditorToolsOptionsPanel.vb</DependentUpon>
+      <LogicalName>Microsoft.VisualStudio.Editors.Package.EditorToolsOptionsPanel.resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Package\EditorToolsOptionsPanel.*.resx">
       <DependentUpon>EditorToolsOptionsPanel.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.Package.EditorToolsOptionsPanel.resources</LogicalName>
       <SubType>Designer</SubType>
@@ -82,9 +114,19 @@
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.AdvancedServicesDialog.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\AdvancedServicesDialog.*.resx">
+      <DependentUpon>AdvancedServicesDialog.vb</DependentUpon>
+      <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="PropPages\AdvBuildSettingsPropPage.resx">
       <DependentUpon>AdvBuildSettingsPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.AdvBuildSettingsPropPage.resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\AdvBuildSettingsPropPage.*.resx">
+      <DependentUpon>AdvBuildSettingsPropPage.vb</DependentUpon>
+      <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\AdvCompilerSettingsPropPage.resx">
@@ -92,12 +134,26 @@
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.AdvCompilerSettingsPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\AdvCompilerSettingsPropPage.*.resx">
+      <DependentUpon>AdvCompilerSettingsPropPage.vb</DependentUpon>
+      <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="PropPages\ApplicationPropPage.resx">
       <DependentUpon>ApplicationPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.ApplicationPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\ApplicationPropPage.*.resx">
+      <DependentUpon>ApplicationPropPage.vb</DependentUpon>
+      <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="PropPages\ApplicationPropPageBase.resx">
+      <DependentUpon>ApplicationPropPageBase.vb</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\ApplicationPropPageBase.*.resx">
       <DependentUpon>ApplicationPropPageBase.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
@@ -105,11 +161,23 @@
       <DependentUpon>ApplicationPropPageVBBase.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\ApplicationPropPageVBBase.*.resx">
+      <DependentUpon>ApplicationPropPageVBBase.vb</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="PropPages\ApplicationPropPageVBWinForms.resx">
       <DependentUpon>ApplicationPropPageVBWinForms.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\ApplicationPropPageVBWinForms.*.resx">
+      <DependentUpon>ApplicationPropPageVBWinForms.vb</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="PropPages\PackagePropPage.resx">
+      <DependentUpon>PackagePropPage.vb</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\PackagePropPage.*.resx">
       <DependentUpon>PackagePropPage.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
@@ -118,9 +186,19 @@
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.AssemblyInfoPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\AssemblyInfoPropPage.*.resx">
+      <DependentUpon>AssemblyInfoPropPage.vb</DependentUpon>
+      <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="PropPages\BuildEventCommandLineDialog.resx">
       <DependentUpon>BuildEventCommandLineDialog.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.BuildEventCommandLineDialog.resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\BuildEventCommandLineDialog.*.resx">
+      <DependentUpon>BuildEventCommandLineDialog.vb</DependentUpon>
+      <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\BuildEventsPropPage.resx">
@@ -128,9 +206,19 @@
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.BuildEventsPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\BuildEventsPropPage.*.resx">
+      <DependentUpon>BuildEventsPropPage.vb</DependentUpon>
+      <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="PropPages\BuildPropPage.resx">
       <DependentUpon>BuildPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.BuildPropPage.resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\BuildPropPage.*.resx">
+      <DependentUpon>BuildPropPage.vb</DependentUpon>
+      <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\CompilePropPage2.resx">
@@ -138,9 +226,19 @@
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.CompilePropPage2.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\CompilePropPage2.*.resx">
+      <DependentUpon>CompilePropPage2.vb</DependentUpon>
+      <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="PropPages\CSharpApplicationPropPage.resx">
       <DependentUpon>CSharpApplicationPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.CSharpApplicationPropPage.resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\CSharpApplicationPropPage.*.resx">
+      <DependentUpon>CSharpApplicationPropPage.vb</DependentUpon>
+      <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\DebugPropPage.resx">
@@ -148,9 +246,19 @@
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.DebugPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\DebugPropPage.*.resx">
+      <DependentUpon>DebugPropPage.vb</DependentUpon>
+      <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="PropPages\ReferencePathsPropPage.resx">
       <DependentUpon>ReferencePathsPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.ReferencePathsPropPage.resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\ReferencePathsPropPage.*.resx">
+      <DependentUpon>ReferencePathsPropPage.vb</DependentUpon>
+      <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\ReferencePropPage.resx">
@@ -158,14 +266,29 @@
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.ReferencePropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\ReferencePropPage.*.resx">
+      <DependentUpon>ReferencePropPage.vb</DependentUpon>
+      <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="PropPages\ServicesAuthenticationForm.resx">
       <DependentUpon>ServicesAuthenticationForm.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.ServicesAuthenticationForm.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\ServicesAuthenticationForm.*.resx">
+      <DependentUpon>ServicesAuthenticationForm.vb</DependentUpon>
+      <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="PropPages\ServicesPropPage.resx">
       <DependentUpon>ServicesPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.ServicesPropPage.resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\ServicesPropPage.*.resx">
+      <DependentUpon>ServicesPropPage.vb</DependentUpon>
+      <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="PropPages\Strings.resx">
@@ -174,12 +297,24 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Strings.Designer.vb</LastGenOutput>
     </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\Strings.*.resx">
+      <DependentUpon>Strings.resx</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="PropPages\UnusedReferencePropPage.resx">
       <DependentUpon>UnusedReferencePropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.UnusedReferencePropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\UnusedReferencePropPage.*.resx">
+      <DependentUpon>UnusedReferencePropPage.vb</DependentUpon>
+      <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="PropPages\WPF\AppDotXamlErrorControl.resx">
+      <DependentUpon>AppDotXamlErrorControl.vb</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\WPF\AppDotXamlErrorControl.*.resx">
       <DependentUpon>AppDotXamlErrorControl.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
@@ -187,7 +322,16 @@
       <DependentUpon>ApplicationPropPageVBWPF.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="PropPages\WPF\ApplicationPropPageVBWPF.*.resx">
+      <DependentUpon>ApplicationPropPageVBWPF.vb</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="ResourceEditor\DialogQueryName.resx">
+      <DependentUpon>DialogQueryName.vb</DependentUpon>
+      <LogicalName>Microsoft.VisualStudio.Editors.ResourceEditor.DialogQueryName.resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="ResourceEditor\DialogQueryName.*.resx">
       <DependentUpon>DialogQueryName.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.ResourceEditor.DialogQueryName.resources</LogicalName>
       <SubType>Designer</SubType>
@@ -197,6 +341,11 @@
       <LogicalName>Microsoft.VisualStudio.Editors.ResourceEditor.OpenFileWarningDialog.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="ResourceEditor\OpenFileWarningDialog.*.resx">
+      <DependentUpon>OpenFileWarningDialog.vb</DependentUpon>
+      <LogicalName>Microsoft.VisualStudio.Editors.ResourceEditor.%(Filename).resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="Resources\Designer.resx">
       <LogicalName>Microsoft.VisualStudio.Editors.Designer.resources</LogicalName>
       <SubType>Designer</SubType>
@@ -204,11 +353,17 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Designer.Designer.vb</LastGenOutput>
     </EmbeddedResource>
+    <EmbeddedResource Include="Resources\Designer.*.resx">
+      <LogicalName>Microsoft.VisualStudio.Editors.%(Filename).resources</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="Resources\MyExtensibilityRes.resx">
       <SubType>Designer</SubType>
       <CustomToolNamespace>My.Resources</CustomToolNamespace>
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>MyExtensibilityRes.Designer.vb</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\MyExtensibilityRes.*.resx">
+      <DependentUpon>MyExtensibilityRes.resx</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Resources\ResourceEditor\BlankBmp.bmp">
       <LogicalName>Microsoft.VisualStudio.Editors.ResourceEditor.BlankBmp</LogicalName>
@@ -239,9 +394,19 @@
       <LogicalName>Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsDesignerView.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="SettingsDesigner\SettingsDesignerView.*.resx">
+      <DependentUpon>SettingsDesignerView.vb</DependentUpon>
+      <LogicalName>Microsoft.VisualStudio.Editors.SettingsDesigner.%(Filename).resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="SettingsDesigner\TypeEditorHostControl.resx">
       <DependentUpon>TypeEditorHostControl.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.SettingsDesigner.TypeEditorHostControl.resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="SettingsDesigner\TypeEditorHostControl.*.resx">
+      <DependentUpon>TypeEditorHostControl.vb</DependentUpon>
+      <LogicalName>Microsoft.VisualStudio.Editors.SettingsDesigner.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="SettingsDesigner\TypePickerDialog.resx">
@@ -249,7 +414,16 @@
       <LogicalName>Microsoft.VisualStudio.Editors.SettingsDesigner.TypePickerDialog.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="SettingsDesigner\TypePickerDialog.*.resx">
+      <DependentUpon>TypePickerDialog.vb</DependentUpon>
+      <LogicalName>Microsoft.VisualStudio.Editors.SettingsDesigner.%(Filename).resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="XmlToSchema\InputXmlForm.resx">
+      <DependentUpon>InputXmlForm.vb</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="XmlToSchema\InputXmlForm.*.resx">
       <DependentUpon>InputXmlForm.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
@@ -257,7 +431,15 @@
       <DependentUpon>PasteXmlDialog.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="XmlToSchema\PasteXmlDialog.*.resx">
+      <DependentUpon>PasteXmlDialog.vb</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="XmlToSchema\WebUrlDialog.resx">
+      <DependentUpon>WebUrlDialog.vb</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="XmlToSchema\WebUrlDialog.*.resx">
       <DependentUpon>WebUrlDialog.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>


### PR DESCRIPTION
New package property page showing up nicely:

![image](https://cloud.githubusercontent.com/assets/75470/21735470/f0319dba-d41e-11e6-8f76-1d0bd335fc36.png)

Also spot checked translation of other pages line up with previous VS versions (for French at least).

@srivatsn @dotnet/project-system 

@jinujoseph This is the change that needs the temporary editors satellite change in VSO undone. Ideally, we could add the insertion of this and my other two loc PRs to that PR and test that PR build in English and Loc.