### PR TITLE
Fix build warnings around conflicting versions

### DIFF
--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -3,6 +3,13 @@
   <Choose>
     <When Condition="'$(ProjectSystemLayer)' == 'Dependency'">
       <PropertyGroup>
+        <!-- 
+             We reference the core framework from Dependency projects to make these primary refs, and prevent
+             MSBuild outputing MSB3277 when it finds conflicts between PLIB "old-style" assemblies and desktop
+             assemblies, which have the same name but different keys/versions.
+         -->
+        
+        <IncludeCoreFrameworkReferences>true</IncludeCoreFrameworkReferences>
         <IncludeHostAgnosticReferences>false</IncludeHostAgnosticReferences>
         <IncludeVisualStudioReferences>false</IncludeVisualStudioReferences>
         <IncludeVisualStudioDesignerReferences>false</IncludeVisualStudioDesignerReferences>
@@ -11,6 +18,7 @@
     </When>
     <When Condition="'$(ProjectSystemLayer)' == 'HostAgnostic'">
       <PropertyGroup>
+        <IncludeCoreFrameworkReferences>true</IncludeCoreFrameworkReferences>
         <IncludeHostAgnosticReferences>true</IncludeHostAgnosticReferences>
         <IncludeVisualStudioReferences>false</IncludeVisualStudioReferences>
         <IncludeVisualStudioDesignerReferences>false</IncludeVisualStudioDesignerReferences>
@@ -19,6 +27,7 @@
     </When>
     <When Condition="'$(ProjectSystemLayer)' == 'VisualStudio'">
       <PropertyGroup>
+        <IncludeCoreFrameworkReferences>true</IncludeCoreFrameworkReferences>
         <IncludeHostAgnosticReferences>true</IncludeHostAgnosticReferences>
         <IncludeVisualStudioReferences>true</IncludeVisualStudioReferences>
         <IncludeVisualStudioDesignerReferences>false</IncludeVisualStudioDesignerReferences>
@@ -27,6 +36,7 @@
     </When>
     <When Condition="'$(ProjectSystemLayer)' == 'VisualStudioDesigner'">
       <PropertyGroup>
+        <IncludeCoreFrameworkReferences>true</IncludeCoreFrameworkReferences>
         <IncludeHostAgnosticReferences>true</IncludeHostAgnosticReferences>
         <IncludeVisualStudioReferences>true</IncludeVisualStudioReferences>
         <IncludeVisualStudioDesignerReferences>true</IncludeVisualStudioDesignerReferences>
@@ -42,19 +52,29 @@
       </PropertyGroup>
     </When>
   </Choose>
-
+  
   <!-- Don't be tempted to move this to conditional ItemGroup or <References> csproj/msvbprj do not like this-->
+  <Choose>
+    <When Condition="'$(IncludeCoreFrameworkReferences)' == 'true'">
+      <ItemGroup>
+      
+        <!-- Framework -->
+        <Reference Include="System" />
+        <Reference Include="System.Core" />
+        <Reference Include="System.Xml" />
+        <Reference Include="System.Xml.Linq" />    
+      
+      </ItemGroup>
+    </When>
+  </Choose>
+      
   <Choose>
     <When Condition="'$(IncludeHostAgnosticReferences)' == 'true'">
       <ItemGroup>
 
         <!-- Framework -->
-        <Reference Include="System" />
         <Reference Include="System.ComponentModel.Composition" />
-        <Reference Include="System.Core" />
         <Reference Include="System.Xaml" />
-        <Reference Include="System.Xml" />
-        <Reference Include="System.Xml.Linq" />
 
         <!-- NuGet Dependencies -->
         <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\src\Dependencies\Roslyn\Roslyn.csproj">

--- a/src/Dependencies/VisualStudio/VisualStudio.csproj
+++ b/src/Dependencies/VisualStudio/VisualStudio.csproj
@@ -12,5 +12,11 @@
   <ItemGroup>
     <Content Include="project.json" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Json.net\Json.net.csproj">
+      <Project>{ca374af1-c983-4019-8fd0-01fa510c6e56}</Project>
+      <Name>Json.net</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Imports.targets" />
 </Project>


### PR DESCRIPTION
- Fix conflict warning around JSON.NET
   - MSBuild was outputting a warning around JSON.NET because our VS dependencies had conflicting dependencies on JSON.NET, and it couldn't figure out which one to pick. Force it to version use 8.0, which means that MSBuild will favor it.

- Fix conflict warning around System.dll
   - MSBuild was outputting a warning around System because our nuget dependencies had conflicting dependencies on System.dll between portable and full framework, and it couldn't figure out which one to pick. Force our dependencies to reference the core assemblies from the framework, causing them to become primary and win over the portable versions.

Fixes: #892