### PR TITLE
Stop building intermediates building into the source tree

### DIFF
--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -145,7 +145,7 @@
 
   <PropertyGroup>
     <OutDir Condition="'$(OutDir)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\bin\$(Configuration)'))\</OutDir>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\bin\obj\$(MSBuildProjectName)'))\</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\bin\obj\$(MSBuildProjectName)'))\</BaseIntermediateOutputPath>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
MSBuild made a change where they started setting BaseIntermediateOutputPath (https://github.com/Microsoft/msbuild/issues/1525) in props instead of targets, this caused us to think that an individual project had set the base intermediate path and respect it. This caused us to output them into the default location (obj in the project directory).

Stop respecting a project's ability to override the intermediate path and hence, not inheriting the one from props - no one was doing it anyway.