### PR TITLE
Stop building unused dependencies dlls to output 

### DIFF
--- a/build/Targets/ProducesNoOutput.Settings.targets
+++ b/build/Targets/ProducesNoOutput.Settings.targets
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
- <!-- Return this back when up-to-date bug is fixed (projects are being build everytime) -->
-  <!--<Import Project="Settings.targets" />-->
   <Import Project="VSL.Settings.targets" />
 
   <PropertyGroup>
@@ -12,7 +10,7 @@
 
   <PropertyGroup Condition="'$(IsDeployment)' == 'false'">
     <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
-    <OutputPath>bin</OutputPath>
+    <OutDir>bin\Unused</OutDir>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/build/Targets/ProducesNoOutput.Settings.targets
+++ b/build/Targets/ProducesNoOutput.Settings.targets
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Import Project="VSL.Settings.targets" />
-
   <PropertyGroup>
     <IsDeployment Condition="'$(IsDeployment)' == ''">false</IsDeployment>
     <IsPortable Condition="'$(IsPortable)' == ''">true</IsPortable>
@@ -10,8 +8,10 @@
 
   <PropertyGroup Condition="'$(IsDeployment)' == 'false'">
     <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
-    <OutDir>bin\Unused</OutDir>
+    <OutDir>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\bin\obj\Unused\$(Configuration)'))\</OutDir>
   </PropertyGroup>
+  
+  <Import Project="VSL.Settings.targets" />
 
   <PropertyGroup>
     <!-- Return this back when up-to-date bug is fixed (projects are being build everytime) -->
@@ -23,12 +23,12 @@
   <PropertyGroup Condition="'$(IsPortable)' == 'true'">
     <TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>    
+    <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsPortable)' != 'true'">
     <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
-  
+
 </Project>

--- a/src/Dependencies/xUnit.net/xUnit.net.csproj
+++ b/src/Dependencies/xUnit.net/xUnit.net.csproj
@@ -5,7 +5,6 @@
     <ProjectGuid>{8635CB8F-D210-41ED-B4FF-71502CDB475C}</ProjectGuid>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectSystemLayer>Dependency</ProjectSystemLayer>
-    <OutDir>$(OutDir)Tests\</OutDir>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="project.json" />


### PR DESCRIPTION
The dependency projects product an output solely to make csproj's up-to-date check happy. Stop deploying them the output directory.