### PR TITLE
Fix "System cannot be referenced" in Error List

### DIFF
--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -1,6 +1,15 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Choose>
+    <When Condition="'$(ProjectSystemLayer)' == 'Toolset'">
+      <PropertyGroup>
+        <IncludeCoreFrameworkReferences>false</IncludeCoreFrameworkReferences>
+        <IncludeHostAgnosticReferences>false</IncludeHostAgnosticReferences>
+        <IncludeVisualStudioReferences>false</IncludeVisualStudioReferences>
+        <IncludeVisualStudioDesignerReferences>false</IncludeVisualStudioDesignerReferences>
+        <IncludeCPSReferences>false</IncludeCPSReferences>
+      </PropertyGroup>
+    </When>
     <When Condition="'$(ProjectSystemLayer)' == 'Dependency'">
       <PropertyGroup>
         <!-- 
@@ -8,7 +17,7 @@
              MSBuild outputing MSB3277 when it finds conflicts between PLIB "old-style" assemblies and desktop
              assemblies, which have the same name but different keys/versions.
          -->
-        
+
         <IncludeCoreFrameworkReferences>true</IncludeCoreFrameworkReferences>
         <IncludeHostAgnosticReferences>false</IncludeHostAgnosticReferences>
         <IncludeVisualStudioReferences>false</IncludeVisualStudioReferences>
@@ -52,22 +61,22 @@
       </PropertyGroup>
     </When>
   </Choose>
-  
+
   <!-- Don't be tempted to move this to conditional ItemGroup or <References> csproj/msvbprj do not like this-->
   <Choose>
     <When Condition="'$(IncludeCoreFrameworkReferences)' == 'true'">
       <ItemGroup>
-      
+
         <!-- Framework -->
         <Reference Include="System" />
         <Reference Include="System.Core" />
         <Reference Include="System.Xml" />
-        <Reference Include="System.Xml.Linq" />    
-      
+        <Reference Include="System.Xml.Linq" />
+
       </ItemGroup>
     </When>
   </Choose>
-      
+
   <Choose>
     <When Condition="'$(IncludeHostAgnosticReferences)' == 'true'">
       <ItemGroup>
@@ -139,7 +148,7 @@
         <Reference Include="Microsoft.VisualStudio.ComponentModelHost">
           <HintPath>$(DevEnvDir)\PublicAssemblies\Microsoft.VisualStudio.ComponentModelHost.dll</HintPath>
         </Reference>
-	<!--
+        <!--
 		Microsoft.VisualStudio.Diagnostics.PerformanceProvider.dll is needed by GraphProvider unit tests.
 		if it is not provided here, tests fail to load this assembly at runtime.
 	-->

--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <!-- During Restore the props/targets won't be present-->
-  <ImportGroup Condition="'$(ProjectSystemLayer)' != 'Dependency' AND '$(NonShipping)' != 'true' AND Exists('$(MicroBuildPackageDirectory)')">
+  <ImportGroup Condition="'$(ProjectSystemLayer)' != 'Dependency' AND '$(ProjectSystemLayer)' != 'Toolset' AND '$(NonShipping)' != 'true' AND Exists('$(MicroBuildPackageDirectory)')">
     <Import Project="$(MicroBuildPackageDirectory)\build\MicroBuild.Core.props" />
     <Import Project="$(MicroBuildPackageDirectory)\build\MicroBuild.Core.targets" />
   </ImportGroup>

--- a/src/Dependencies/Toolset/Toolset.csproj
+++ b/src/Dependencies/Toolset/Toolset.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{4D52C1E5-6F4B-4CDE-8149-AC374F018245}</ProjectGuid>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <ProjectSystemLayer>Dependency</ProjectSystemLayer>
+    <ProjectSystemLayer>Toolset</ProjectSystemLayer>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="project.json" />


### PR DESCRIPTION
After #7a8718d, a warning was introduced in the Error List when opening the ProjectSystem.sln around "System not being able to referenced". This occured due to the way the legacy NuGet build task adds/removes framework assemblies for project.json. It does it during design-time builds which confuses csproj, and results it spitting out a warning. This was occuring to the toolset project only due to the unneeded framework assemblies coming from the analyzers references (https://github.com/dotnet/roslyn-analyzers/issues/1092).

Adding a new dependency type as a workaround of this issue.