### PR TITLE
Always build vsman projects

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -107,8 +107,8 @@
     <Error Text="There were test failures, for full log see %(HtmlTestFile.FullPath)" Condition="$(ExitCode) != 0" />
 
   </Target>
-
-  <Target Name="Build" DependsOnTargets="RestorePackages;BuildSolution;BuildNuGetPackages;BuildModernVsixPackages;Test" />
-  <Target Name="Rebuild" DependsOnTargets="RestorePackages;RebuildSolution;RebuildNuGetPackages;BuildModernVsixPackages;Test" />
+ 
+  <Target Name="Build" DependsOnTargets="RestorePackages;BuildSolution;BuildNuGetPackages;Test" />
+  <Target Name="Rebuild" DependsOnTargets="RestorePackages;RebuildSolution;RebuildNuGetPackages;Test" />
 
 </Project>

--- a/build/build.proj
+++ b/build/build.proj
@@ -108,7 +108,7 @@
 
   </Target>
 
-  <Target Name="Build" DependsOnTargets="RestorePackages;BuildSolution;BuildNuGetPackages;Test" />
-  <Target Name="Rebuild" DependsOnTargets="RestorePackages;RebuildSolution;RebuildNuGetPackages;Test" />
+  <Target Name="Build" DependsOnTargets="RestorePackages;BuildSolution;BuildNuGetPackages;BuildModernVsixPackages;Test" />
+  <Target Name="Rebuild" DependsOnTargets="RestorePackages;RebuildSolution;RebuildNuGetPackages;BuildModernVsixPackages;Test" />
 
 </Project>

--- a/build/build.proj
+++ b/build/build.proj
@@ -83,7 +83,7 @@
 
     <MSBuild Projects="@(VsManProjectFile)"
              Targets="Rebuild"
-             Condition="'$(RunningInMicroBuild)' == 'true'"
+             
              />
   </Target>
 

--- a/src/Dependencies/Toolset/project.json
+++ b/src/Dependencies/Toolset/project.json
@@ -1,7 +1,12 @@
 {
   "supports": { },
   "dependencies": {
+    "MicroBuild.Core.Sentinel": "1.0.0",
     "MicroBuild.Core": "0.2.0",
+    "MicroBuild.Plugins.SwixBuild": {
+      "version": "1.0.101",
+      "exclude": "build"
+    },
     "Microsoft.Net.Compilers": {
       "version": "2.0.0-rc2-61102-09",
       "exclude": "build"
@@ -16,6 +21,6 @@
     }
   },
   "frameworks": {
-    ".NETPortable,Version=v4.5,Profile=Profile7": { }
+    ".NETPortable,Version=v4.5,Profile=Profile7": { "imports": "net461" }
   }
 }

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -8,6 +8,7 @@
     <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="myget.org roslyn-master-nightly" value="https://dotnet.myget.org/F/roslyn-master-nightly/api/v3/index.json" />
     <add key="myget.org nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
+    <add key="dotnet.myget.org roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 


### PR DESCRIPTION
VSMan projects were limited to only building inside MicroBuild, which lead to issues being caught after things had merged.

This is going to fail until the build break is fixed due to https://github.com/dotnet/roslyn-project-system/pull/1107.

Fixes: #1111 