### PR TITLE
Remove warnings around duplicate imports in modern vsixes

### DIFF
--- a/src/VsixV3/EditorsPackage/Microsoft.VisualStudio.Editors.vsmanproj
+++ b/src/VsixV3/EditorsPackage/Microsoft.VisualStudio.Editors.vsmanproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
-  <Import Project="..\..\..\build\Targets\VSL.Versions.targets" />
 
   <PropertyGroup>
     <FinalizeManifest>true</FinalizeManifest>

--- a/src/VsixV3/ProjectSystemPackage/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles.swixproj
+++ b/src/VsixV3/ProjectSystemPackage/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles.swixproj
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
-  <Import Project="..\..\..\build\Targets\VSL.Versions.targets" />
 
   <PropertyGroup>
     <OutputArchitecture>neutral</OutputArchitecture>

--- a/src/VsixV3/ProjectSystemPackage/Microsoft.VisualStudio.ProjectSystem.Managed.vsmanproj
+++ b/src/VsixV3/ProjectSystemPackage/Microsoft.VisualStudio.ProjectSystem.Managed.vsmanproj
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
-  <Import Project="..\..\..\build\Targets\VSL.Versions.targets" />
 
   <PropertyGroup>
     <FinalizeManifest>true</FinalizeManifest>


### PR DESCRIPTION
VSManProj and SwixProj were both import VSL.Versions, even though ProducesNoOutput was already. Remove the import.