### PR TITLE
Import VSL.Settings.targets instead of ProducesNoOuput.targets/VSL.Version.targets

### DIFF
--- a/src/VsixV3/EditorsPackage/Microsoft.VisualStudio.Editors.vsmanproj
+++ b/src/VsixV3/EditorsPackage/Microsoft.VisualStudio.Editors.vsmanproj
@@ -5,8 +5,7 @@
     <UseVisualStudioVersion>true</UseVisualStudioVersion>
   </PropertyGroup>
 
-  <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
-  <Import Project="..\..\..\build\Targets\VSL.Versions.targets" />
+  <Import Project="..\..\..\build\Targets\VSL.Settings.targets" />
 
   <PropertyGroup>
     <FinalizeManifest>true</FinalizeManifest>

--- a/src/VsixV3/ProjectSystemPackage/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles.swixproj
+++ b/src/VsixV3/ProjectSystemPackage/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles.swixproj
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
-  <Import Project="..\..\..\build\Targets\VSL.Versions.targets" />
+  <Import Project="..\..\..\build\Targets\VSL.Settings.targets" />
 
   <PropertyGroup>
     <OutputArchitecture>neutral</OutputArchitecture>

--- a/src/VsixV3/ProjectSystemPackage/Microsoft.VisualStudio.ProjectSystem.Managed.vsmanproj
+++ b/src/VsixV3/ProjectSystemPackage/Microsoft.VisualStudio.ProjectSystem.Managed.vsmanproj
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
-  <Import Project="..\..\..\build\Targets\VSL.Versions.targets" />
+  <Import Project="..\..\..\build\Targets\VSL.Settings.targets" />
 
   <PropertyGroup>
     <FinalizeManifest>true</FinalizeManifest>


### PR DESCRIPTION
vsmanproj/swixproj projects were importing ProductsNoOutput for what appears to be just because it's provides an output path. This broke when the output path changed in #ebdfe8a. These projects shouldn't be importing that project - it's for projects that produce no output.

This fixes the current build break.