### PR TITLE
Sign Satellite Assemblies and add them to the VSIX from the Final out…

### DIFF
--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -502,6 +502,36 @@
     </FilesToSign>
   </ItemGroup>
 
+  <Target Name="IncludeResourcesDllForSigning" AfterTargets="CopyFilesToOutputDirectory"> 
+    <ItemGroup> 
+      <!-- Handle the resources dll if there are any --> 
+      <FilesToSign Condition="'$(ShouldSignBuild)' == 'true' AND '$(NonShipping)' != 'true' AND '$(ProjectSystemLayer)' != 'Dependency'" Include="$(OutDir)\**\$(AssemblyName).resources.dll"> 
+          <Authenticode>Microsoft</Authenticode> 
+          <StrongName>$(StrongNameCertificateFriendlyId)</StrongName> 
+      </FilesToSign> 
+    </ItemGroup> 
+  </Target>
+
+  <!-- This target is similar to SatelliteDllsProjectOutputGroup except it includes path from the final output path rather than intermediate output path -->
+  <Target Name="SatelliteDllsProjectOutputGroupWithFinalOutputPath" 
+        Returns="@(SatelliteDllsProjectOutputGroupWithFinalOutputPathOutput)" 
+        DependsOnTargets="$(SatelliteDllsProjectOutputGroupDependsOn)"> 
+
+    <ItemGroup> 
+      <SatelliteDllsProjectOutputGroupWithFinalOutputPathItem Include="$(OutputPath)%(EmbeddedResource.Culture)\$(TargetName).resources.dll" 
+                                                         Condition="'%(WithCulture)' == 'true'"> 
+        <TargetPath>%(EmbeddedResource.Culture)\$(TargetName).resources.dll</TargetPath> 
+      </SatelliteDllsProjectOutputGroupWithFinalOutputPathItem> 
+    </ItemGroup> 
+
+    <!-- Convert intermediate items into final items; this way we can get the full path for each item. --> 
+    <ItemGroup> 
+      <SatelliteDllsProjectOutputGroupWithFinalOutputPathOutput Include="@(SatelliteDllsProjectOutputGroupWithFinalOutputPathItem->'%(FullPath)')"> 
+        <OriginalItemSpec>%(SatelliteDllsProjectOutputGroupWithFinalOutputPathItem.Identity)</OriginalItemSpec> 
+      </SatelliteDllsProjectOutputGroupWithFinalOutputPathOutput> 
+    </ItemGroup> 
+  </Target> 
+
   <!-- ====================================================================================
 
   Copying vsixmanifest to a separate folder

--- a/src/ProjectSystemSetup/ProjectSystemSetup.csproj
+++ b/src/ProjectSystemSetup/ProjectSystemSetup.csproj
@@ -43,7 +43,7 @@
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp.VS\Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj">
       <Project>{765ef6eb-9f36-4d68-8c3d-9e11cd49e0bc}</Project>
       <Name>Microsoft.VisualStudio.ProjectSystem.CSharp.VS</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3bPkgdefProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroupWithFinalOutputPath%3bPkgdefProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
       <Private>True</Private>
@@ -51,7 +51,7 @@
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp\Microsoft.VisualStudio.ProjectSystem.CSharp.csproj">
       <Project>{7d150b7b-ce02-4cd4-8ec9-6a7c18727a36}</Project>
       <Name>Microsoft.VisualStudio.ProjectSystem.CSharp</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bSatelliteDllsProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bSatelliteDllsProjectOutputGroupWithFinalOutputPath%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
       <Private>True</Private>
@@ -60,14 +60,14 @@
       <Project>{1c5666ea-24a4-4ec2-b8fb-faedf6b14697}</Project>
       <Name>Microsoft.VisualStudio.ProjectSystem.Managed.VS</Name>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bSatelliteDllsProjectOutputGroup%3bBuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3bPkgdefProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bSatelliteDllsProjectOutputGroupWithFinalOutputPath%3bBuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bPkgdefProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
       <Private>True</Private>
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj">
       <Project>{6c6a41ce-72c5-4d77-8208-d01693f9bc88}</Project>
       <Name>Microsoft.VisualStudio.ProjectSystem.Managed</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bSatelliteDllsProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bSatelliteDllsProjectOutputGroupWithFinalOutputPath%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
       <Private>True</Private>
@@ -76,14 +76,14 @@
       <Project>{15dcb34c-b628-49b8-b472-bba65a0ab6a5}</Project>
       <Name>Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS</Name>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3bPkgdefProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroupWithFinalOutputPath%3bPkgdefProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
       <Private>True</Private>
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.VisualBasic\Microsoft.VisualStudio.ProjectSystem.VisualBasic.csproj">
       <Project>{04aa393a-48c2-424d-985c-77385a962019}</Project>
       <Name>Microsoft.VisualStudio.ProjectSystem.VisualBasic</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bSatelliteDllsProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bSatelliteDllsProjectOutputGroupWithFinalOutputPath%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
       <Private>True</Private>


### PR DESCRIPTION
…put path rather than the intermediate path

Previously, the VSIX project was using the target SatelliteDllsProjectOutputGroup to include the satellite assemblies to the VSIX. But the assemblies in the intermediate path are not signed and hence the VSIX gets constructed with unsigned assemblies.

With this change we pick the assemblies from the final output path where the satellites assemblies are signed.

**Customer scenario**

All the satellite assemblies wont be signed

**Bugs this fixes:** 

[VSO link](https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=364946&triage=true)

**Workarounds, if any**

There are no workarounds

**Risk**

Low risk. This only affects the resources dll

**Performance impact**

None

**Is this a regression from a previous update?**

The resources dlls are new for the project system. 

**How was the bug found?**

VS Sign Verification process

@srivatsn @nguerrera @dotnet/project-system for review