### PR TITLE
Add the resources final output path to the VSIX

### DIFF
--- a/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
+++ b/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
@@ -45,7 +45,7 @@
     <ProjectReference Include="..\Microsoft.VisualStudio.AppDesigner\Microsoft.VisualStudio.AppDesigner.vbproj">
       <Project>{19725d6f-4690-412b-934a-fc48d752b802}</Project>
       <Name>Microsoft.VisualStudio.AppDesigner</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroupWithFinalOutputPath%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
       <Private>True</Private>
       <Ngen>true</Ngen>
@@ -55,7 +55,7 @@
     <ProjectReference Include="..\Microsoft.VisualStudio.Editors\Microsoft.VisualStudio.Editors.vbproj">
       <Project>{CD6E5D00-7B0B-442D-9F5D-EAEC1A71838A}</Project>
       <Name>Microsoft.VisualStudio.Editors</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3bPkgdefProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroupWithFinalOutputPath%3bPkgdefProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
       <Private>True</Private>
       <Ngen>true</Ngen>


### PR DESCRIPTION
Change the target SatelliteDllsProjectOutputGroup to SatelliteDllsProjectOutputGroupWithFinalOutputPath, which will include the resources from the final output path rather than the intermediate path and hence will include the signed satellite assemblies

**Customer scenario**

All the satellite assemblies wont be signed for the MS.VS.Editors.dll and MS.VS.AppDesigner.dll
either VSO or GitHub links)

**Bugs this fixes:**

[VSO Link](https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=366133&triage=true)

**Workarounds, if any**

There are no workarounds

**Risk**

Low risk. This only affects the resources dll

**Performance impact**

None

**Is this a regression from a previous update?**

The resources dlls are new for the Editors and AppDesigner

**How was the bug found?**

VS Sign Verification Process

@srivatsn @nguerrera @dotnet/project-system for review