### PR TITLE
Remove Reload workaround and use official API

### DIFF
--- a/src/Dependencies/MSBuild/project.json
+++ b/src/Dependencies/MSBuild/project.json
@@ -1,11 +1,11 @@
 {
   "supports": { },
   "dependencies": {
-     "Microsoft.Build": "15.1.262-preview5",
-	 "Microsoft.Build.Framework": "15.1.262-preview5",
-	 "Microsoft.Build.Utilities.Core": "15.1.262-preview5",
-	 "Microsoft.Build.Tasks.Core": "15.1.262-preview5",
-	 "Microsoft.Build.Engine": "15.1.262-preview5",
+    "Microsoft.Build": "15.1.0-preview-000516-03",
+    "Microsoft.Build.Framework": "15.1.0-preview-000516-03",
+    "Microsoft.Build.Utilities.Core": "15.1.0-preview-000516-03",
+    "Microsoft.Build.Tasks.Core": "15.1.0-preview-000516-03",
+    "Microsoft.Build.Engine": "15.1.0-preview-000516-03"
   },
   "frameworks": {
     ".NETFramework,Version=v4.6": { }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Reload/ReloadableProject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Reload/ReloadableProject.cs
@@ -97,32 +97,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 }
                 else
                 {
-                    // What we need to do is load the one on disk. This accomplishes two things: 1) verifies that at least the msbuild is OK. If it isn't
-                    // we want to let the normal solution reload occur so that the user sees the failure, and 2) it allows us to clear the current project
-                    // and do a deep copy from the newly loaded one to the original - replacing its contents. Note that the Open call is cached so that if
-                    // the project is already in a collection, it will just return the cached one. For this reason, and the fact we don't want the project to
-                    // appear in the global project collection, the file is opened in a new collection which we will discard when done.
                     try
                     {
-                        ProjectCollection thisCollection = new ProjectCollection();
-                        var newProject = ProjectRootElement.Open(_projectVsServices.Project.FullPath, thisCollection);
-
-                        // First copy to a temp project, so that any failures will not corrupt the users project.
-                        ProjectRootElement.Create().DeepCopyFrom(newProject);
-
-                        msbuildProject.RemoveAllChildren();
-                        msbuildProject.DeepCopyFrom(newProject);
-
-                        // There isn't a way to clear the dirty flag on the project xml, so to work around that the project is saved
-                        // to a StringWriter. 
-                        var tw = new StringWriter();
-                        msbuildProject.Save(tw);
-
-                        thisCollection.UnloadAllProjects();
+                        // This reloads the project off disk and handles if the new XML is invalid
+                        msbuildProject.Reload();
                     }
                     catch (Microsoft.Build.Exceptions.InvalidProjectFileException)
                     {
-                        // Indicate we weren't able to complete the action. We want to do a normal reload 
+                        // Indicate we weren't able to complete the action. We want to do a normal reload
                         return ProjectReloadResult.ReloadFailed;
                     }
                     catch (Exception ex)

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -7,6 +7,7 @@
     <clear />  
     <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="myget.org roslyn-master-nightly" value="https://dotnet.myget.org/F/roslyn-master-nightly/api/v3/index.json" />
+    <add key="myget.org msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
     <add key="myget.org nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
     <add key="dotnet.myget.org roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />


### PR DESCRIPTION
Consumes the new msbuild feature: [https://github.com/Microsoft/msbuild/pull/1507](https://github.com/Microsoft/msbuild/pull/1507)