### PR TITLE
Adds a new implementation of IVsDesignTimeAssemblyResolution

### DIFF
--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -6,6 +6,7 @@
         <IncludeHostAgnosticReferences>false</IncludeHostAgnosticReferences>
         <IncludeVisualStudioReferences>false</IncludeVisualStudioReferences>
         <IncludeVisualStudioDesignerReferences>false</IncludeVisualStudioDesignerReferences>
+        <IncludeVisualStudioVsLangProjReferences>false</IncludeVisualStudioVsLangProjReferences>
         <IncludeCPSReferences>false</IncludeCPSReferences>
       </PropertyGroup>
     </When>
@@ -14,6 +15,7 @@
         <IncludeHostAgnosticReferences>true</IncludeHostAgnosticReferences>
         <IncludeVisualStudioReferences>false</IncludeVisualStudioReferences>
         <IncludeVisualStudioDesignerReferences>false</IncludeVisualStudioDesignerReferences>
+        <IncludeVisualStudioVsLangProjReferences>false</IncludeVisualStudioVsLangProjReferences>
         <IncludeCPSReferences>true</IncludeCPSReferences>
       </PropertyGroup>
     </When>
@@ -22,6 +24,7 @@
         <IncludeHostAgnosticReferences>true</IncludeHostAgnosticReferences>
         <IncludeVisualStudioReferences>true</IncludeVisualStudioReferences>
         <IncludeVisualStudioDesignerReferences>false</IncludeVisualStudioDesignerReferences>
+        <IncludeVisualStudioVsLangProjReferences>true</IncludeVisualStudioVsLangProjReferences>
         <IncludeCPSReferences>true</IncludeCPSReferences>
       </PropertyGroup>
     </When>
@@ -30,6 +33,7 @@
         <IncludeHostAgnosticReferences>true</IncludeHostAgnosticReferences>
         <IncludeVisualStudioReferences>true</IncludeVisualStudioReferences>
         <IncludeVisualStudioDesignerReferences>true</IncludeVisualStudioDesignerReferences>
+        <IncludeVisualStudioVsLangProjReferences>true</IncludeVisualStudioVsLangProjReferences>
         <IncludeCPSReferences>false</IncludeCPSReferences>
       </PropertyGroup>
     </When>
@@ -138,23 +142,9 @@
   </Choose>
 
   <Choose>
-    <When Condition="'$(IncludeVisualStudioDesignerReferences)' == 'true'">
+    <When Condition="'$(IncludeVisualStudioVsLangProjReferences)' == 'true'">
 
       <ItemGroup>
-        <!-- Framework -->
-        <Reference Include="CustomMarshalers" />
-        <Reference Include="System.Configuration" />
-        <Reference Include="System.Data" />
-        <Reference Include="System.Design" />
-        <Reference Include="System.Drawing" />
-        <Reference Include="System.Web.ApplicationServices" />
-        <Reference Include="System.Web.Extensions" />
-        <Reference Include="System.Windows.Forms" />
-        <Reference Include="PresentationFramework" />
-        <Reference Include="PresentationCore" />
-        <Reference Include="WindowsBase" />
-
-        <!-- Visual Studio -->
         <Reference Include="VSLangProj">
           <HintPath>$(DevEnvDir)\PublicAssemblies\VSLangProj.dll</HintPath>
         </Reference>
@@ -174,6 +164,28 @@
           <HintPath>$(DevEnvDir)\PublicAssemblies\VSLangProj110.dll</HintPath>
           <EmbedInteropTypes>true</EmbedInteropTypes>
         </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+
+  <Choose>
+    <When Condition="'$(IncludeVisualStudioDesignerReferences)' == 'true'">
+
+      <ItemGroup>
+        <!-- Framework -->
+        <Reference Include="CustomMarshalers" />
+        <Reference Include="System.Configuration" />
+        <Reference Include="System.Data" />
+        <Reference Include="System.Design" />
+        <Reference Include="System.Drawing" />
+        <Reference Include="System.Web.ApplicationServices" />
+        <Reference Include="System.Web.Extensions" />
+        <Reference Include="System.Windows.Forms" />
+        <Reference Include="PresentationFramework" />
+        <Reference Include="PresentationCore" />
+        <Reference Include="WindowsBase" />
+
+        <!-- Visual Studio -->
         <Reference Include="VsWebSite.Interop">
           <HintPath>$(DevEnvDir)\PublicAssemblies\VsWebSite.Interop.dll</HintPath>
         </Reference>

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorDesignerLoader.vb
@@ -118,11 +118,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     Try
                         mtSvr = New MultiTargetService(VsHierarchy, ProjectItemid, isGlobalDTAR:=False)
                     Catch ex As ArgumentException
-                        ' Can happen if there is no supported TargetFrameworkMoniker
+                        ' Failed to follow a type forward
                         mtSvr = Nothing
                     Catch ex As InvalidOperationException
-                        ' Can also happen if there is no supported TargetFrameworkMoniker, in a .NETCore project
-                        ' TODO: fix MultiTargetService to work for .NET Core apps. Tracked by https://github.com/dotnet/roslyn-project-system/issues/686
+                        ' Could not resolve mscorlib or System.Runtime
                         mtSvr = Nothing
                     End Try
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Mocks\IVsSolutionFactory.cs" />
     <Compile Include="Mocks\IVsFileChangeExFactory.cs" />
     <Compile Include="Mocks\IVsStartupProjectsListServiceFactory.cs" />
+    <Compile Include="Mocks\Reference3Factory.cs" />
     <Compile Include="Mocks\RegistrationContextFactory.cs" />
     <Compile Include="Mocks\IVsAddProjectItemDlgFactory.cs" />
     <Compile Include="Mocks\SVsServiceProviderFactory.cs" />
@@ -111,6 +112,7 @@
     <Compile Include="Mocks\IVsProjectFactory.cs" />
     <Compile Include="Mocks\ProjectFactory.cs" />
     <Compile Include="Mocks\SolutionFactory.cs" />
+    <Compile Include="Mocks\VSProjectFactory.cs" />
     <Compile Include="ProjectSystem\VS\Build\LanguageServiceErrorListProviderTests.cs" />
     <Compile Include="ProjectSystem\VS\CreateFileFromTemplateServiceTests.cs" />
     <Compile Include="ProjectSystem\VS\Debug\ConsoleDebugLaunchProviderTests.cs" />
@@ -143,6 +145,7 @@
     <Compile Include="ProjectSystem\VS\PropertyPages\PropertyPageControlTests.cs" />
     <Compile Include="ProjectSystem\VS\PropertyPages\PropertyPageTests.cs" />
     <Compile Include="ProjectSystem\VS\PropertyPages\TestPropertyProviders.cs" />
+    <Compile Include="ProjectSystem\VS\References\DesignTimeAssemblyResolutionTests.cs" />
     <Compile Include="ProjectSystem\VS\References\ReferenceContextProviderTests.cs" />
     <Compile Include="ProjectSystem\VS\Reload\ReloadableProjectTests.cs" />
     <Compile Include="ProjectSystem\VS\Reload\ProjectReloadManagerTests.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ProjectFactory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using EnvDTE80;
 using Moq;
 
@@ -10,6 +11,15 @@ namespace EnvDTE
         public static Project Create()
         {
             return Mock.Of<Project>();
+        }
+
+        public static Project ImplementObject(Func<object> action)
+        {
+            var mock = new Mock<Project>();
+            mock.SetupGet(p => p.Object)
+                .Returns(action);
+
+            return mock.Object;
         }
 
         public static Project CreateWithSolution(Solution2 solution)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/Reference3Factory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/Reference3Factory.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+using VSLangProj;
+
+namespace VSLangProj80
+{
+    internal static class Reference3Factory
+    {
+        public static Reference3 CreateComReference()
+        {
+            var mock = new Mock<Reference3>();
+            mock.SetupGet(r => r.Type)
+                .Returns(prjReferenceType.prjReferenceTypeActiveX);
+
+            return mock.Object;
+        }
+
+        public static Reference3 CreateAssemblyReference(string name, string version, string path = null)
+        {
+            var mock = new Mock<Reference3>();
+            mock.SetupGet(r => r.Name)
+                .Returns(name);
+
+            mock.SetupGet(r => r.Version)
+                .Returns(version);
+
+            mock.SetupGet(r => r.Path)
+                .Returns(path);
+
+            mock.SetupGet(r => r.Resolved)
+                .Returns(path != null);
+
+            mock.SetupGet(r => r.Type)
+                .Returns(prjReferenceType.prjReferenceTypeAssembly);
+
+            return mock.Object;            
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/VSProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/VSProjectFactory.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using EnvDTE;
+using Moq;
+
+namespace VSLangProj
+{
+    internal static class VSProjectFactory
+    {
+        public static VSProject ImplementReferences(IEnumerable<Reference> references)
+        {
+            var vsProjectReferences = new VSProjectReferences(references);
+
+            var mock = new Mock<VSProject>();
+            mock.SetupGet(p => p.References)
+                .Returns(vsProjectReferences);
+
+            return mock.Object;
+        }
+
+        private class VSProjectReferences : References
+        {
+            private readonly IEnumerable<Reference> _references;
+
+            public VSProjectReferences(IEnumerable<Reference> references)
+            {
+                _references = references;
+            }
+
+            public Reference Item(object index)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IEnumerator GetEnumerator()
+            {
+                return _references.GetEnumerator();
+            }
+
+            public Reference Find(string bstrIdentity)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Reference Add(string bstrPath)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Reference AddActiveX(string bstrTypeLibGuid, int lMajorVer = 0, int lMinorVer = 0, int lLocaleId = 0, string bstrWrapperTool = "")
+            {
+                throw new NotImplementedException();
+            }
+
+            public Reference AddProject(Project pProject)
+            {
+                throw new NotImplementedException();
+            }
+
+            public DTE DTE
+            {
+                get
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            public object Parent
+            {
+                get
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            public Project ContainingProject
+            {
+                get
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            public int Count
+            {
+                get
+                {
+                    throw new NotImplementedException();
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/References/DesignTimeAssemblyResolutionTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/References/DesignTimeAssemblyResolutionTests.cs
@@ -1,0 +1,235 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using EnvDTE;
+using Microsoft.VisualStudio.Shell.Interop;
+using VSLangProj;
+using VSLangProj80;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.References
+{
+    public class DesignTimeAssemblyResolutionTests
+    {
+        [Fact]
+        public void GetTargetFramework_WhenUnderlyingGetPropertyReturnsHResult_ReturnsHResult()
+        {
+            var hierarchy = IVsHierarchyFactory.ImplementGetProperty(VSConstants.E_INVALIDARG);
+            var resolution = CreateInstance(hierarchy);
+
+            var result = resolution.GetTargetFramework(out string _);
+
+            Assert.Equal(result, VSConstants.E_INVALIDARG);
+        }
+
+        [Fact]
+        public void GetTargetFramework_WhenUnderlyingGetPropertyReturnsHResult_SetsTargetFrameworkToNull()
+        {
+            var hierarchy = IVsHierarchyFactory.ImplementGetProperty(VSConstants.E_INVALIDARG);
+            var resolution = CreateInstance(hierarchy);
+
+            resolution.GetTargetFramework(out string result);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetTargetFramework_WhenUnderlyingGetPropertyReturnsDISP_E_MEMBERNOTFOUND_ReturnsOK()
+        {
+            var hierarchy = IVsHierarchyFactory.ImplementGetProperty(VSConstants.DISP_E_MEMBERNOTFOUND);
+            var resolution = CreateInstance(hierarchy);
+
+            var result = resolution.GetTargetFramework(out string _);
+
+            Assert.Equal(VSConstants.S_OK, result);
+        }
+
+        [Fact]
+        public void GetTargetFramework_WhenUnderlyingGetPropertyReturnsDISP_E_MEMBERNOTFOUND_SetsTargetFrameworkToNull()
+        {
+            var hierarchy = IVsHierarchyFactory.ImplementGetProperty(VSConstants.DISP_E_MEMBERNOTFOUND);
+            var resolution = CreateInstance(hierarchy);
+
+            resolution.GetTargetFramework(out string result);
+
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("  ")]
+        [InlineData(".NETFramework, Version=v4.5")]
+        [InlineData(".NETFramework, Version=v4.5, Profile=Client")]
+        public void GetTargetFramework_WhenUnderlyingGetPropertyReturnsValue_SetsTargetFramework(string input)
+        {
+            var hierarchy = IVsHierarchyFactory.ImplementGetProperty(input);
+            var resolution = CreateInstance(hierarchy);
+
+            var hr = resolution.GetTargetFramework(out string result);
+
+            Assert.Equal(input, result);
+            Assert.Equal(VSConstants.S_OK, hr);
+        }
+
+        [Fact]
+        public void ResolveAssemblyPathInTargetFx_NullAsAssemblySpecs_ReturnsE_INVALIDARG()
+        {
+            var resolution = CreateInstance();
+
+            var result = resolution.ResolveAssemblyPathInTargetFx((string[])null, 1, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
+
+            Assert.Equal(VSConstants.E_INVALIDARG, result);
+            Assert.Equal(0u, resolvedAssemblyPaths);
+        }
+
+        [Fact]
+        public void ResolveAssemblyPathInTargetFx_ZeroAsAssembliesToResolve_ReturnsE_INVALIDARG()
+        {
+            var resolution = CreateInstance();
+
+            var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { "mscorlib" }, 0, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
+
+            Assert.Equal(VSConstants.E_INVALIDARG, result);
+            Assert.Equal(0u, resolvedAssemblyPaths);
+        }
+
+        [Fact]
+        public void ResolveAssemblyPathInTargetFx_NullAsResolvedAssemblyPaths_ReturnsE_INVALIDARG()
+        {
+            var resolution = CreateInstance();
+
+            var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { "mscorlib" }, 1, (VsResolvedAssemblyPath[])null, out uint resolvedAssemblyPaths);
+
+            Assert.Equal(VSConstants.E_INVALIDARG, result);
+            Assert.Equal(0u, resolvedAssemblyPaths);
+        }
+
+        [Fact]
+        public void ResolveAssemblyPathInTargetFx_MoreAssemblySpecsThanAssembliesToResolve_ReturnsE_INVALIDARG()
+        {
+            var resolution = CreateInstance();
+
+            var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { "mscorlib", "System" }, 1, new VsResolvedAssemblyPath[2], out uint resolvedAssemblyPaths);
+
+            Assert.Equal(VSConstants.E_INVALIDARG, result);
+            Assert.Equal(0u, resolvedAssemblyPaths);
+        }
+
+        [Fact]
+        public void ResolveAssemblyPathInTargetFx_MoreAssemblySpecsThanResolvedAssemblyPaths_ReturnsE_INVALIDARG()
+        {
+            var resolution = CreateInstance();
+
+            var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { "mscorlib", "System" }, 2, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
+
+            Assert.Equal(VSConstants.E_INVALIDARG, result);
+            Assert.Equal(0u, resolvedAssemblyPaths);
+        }
+
+
+        [Fact]
+        public void ResolveAssemblyPathInTargetFx_MoreAssembliesToResolveThanAssemblySpecs_ReturnsE_INVALIDARG()
+        {
+            var resolution = CreateInstance();
+
+            var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { "mscorlib" }, 2, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
+
+            Assert.Equal(VSConstants.E_INVALIDARG, result);
+            Assert.Equal(0u, resolvedAssemblyPaths);
+        }
+
+        [Fact]
+        public void ResolveAssemblyPathInTargetFx_MoreResolvedAssemblyPathsThanAssemblySpecs_ReturnsE_INVALIDARG()
+        {
+            var resolution = CreateInstance();
+
+            var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { "mscorlib" }, 1, new VsResolvedAssemblyPath[2], out uint resolvedAssemblyPaths);
+
+            Assert.Equal(VSConstants.E_INVALIDARG, result);
+            Assert.Equal(0u, resolvedAssemblyPaths);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("System, Bar")]
+        [InlineData("System, Version=NotAVersion")]
+        [InlineData("System, PublicKeyToken=ABC")]
+        public void ResolveAssemblyPathInTargetFx_InvalidNameAsAssemblySpec_ReturnsE_INVALIDARG(string input)
+        {
+            var resolution = CreateInstance();
+
+            var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { input }, 1, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
+
+            Assert.Equal(VSConstants.E_INVALIDARG, result);
+            Assert.Equal(0u, resolvedAssemblyPaths);
+        }
+
+        [Theory]    // Input                                                                        // Name             // Version          // Path
+        [InlineData("System",                                                                       "System",           "",                 @"C:\System.dll")]
+        [InlineData("System",                                                                       "System",           "1",                @"C:\System.dll")]
+        [InlineData("System",                                                                       "System",           "1.0",              @"C:\System.dll")]
+        [InlineData("System",                                                                       "System",           "1.0.0",            @"C:\System.dll")]
+        [InlineData("System",                                                                       "System",           "1.0.0.0",          @"C:\System.dll")]
+        [InlineData("System.Foo",                                                                   "System.Foo",       "1.0.0.0",          @"C:\System.Foo.dll")]
+        [InlineData("System, Version=1.0.0.0",                                                      "System",           "1.0.0.0",          @"C:\System.dll")]
+        [InlineData("System, Version=1.0.0.0",                                                      "System",           "2.0.0.0",          @"C:\System.dll")]      // We let a later version satisfy an earlier version
+        [InlineData("System, Version=1.0",                                                          "System",           "2.0.0.0",          @"C:\System.dll")]
+        [InlineData("System, Version=1.0",                                                          "System",           "2.0.0.0",          @"C:\System.dll")]
+        [InlineData("System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",    "System",           "4.0.0.0",          @"C:\System.dll")]
+        public void ResolveAssemblyPathInTargetFx_NameThatMatches_ReturnsResolvedPaths(string input, string name, string version, string path)
+        {
+            var reference = Reference3Factory.CreateAssemblyReference(name, version, path);
+
+            var resolution = CreateInstance(reference);
+
+            var resolvedPaths = new VsResolvedAssemblyPath[1];
+            var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { input }, 1, resolvedPaths, out uint resolvedAssemblyPaths);
+
+            Assert.Equal(VSConstants.S_OK, result);
+            Assert.Equal(1u, resolvedAssemblyPaths);
+            Assert.Equal(input, resolvedPaths[0].bstrOrigAssemblySpec);
+            Assert.Equal(path, resolvedPaths[0].bstrResolvedAssemblyPath);
+        }
+
+        [Theory]    // Input                                                                        // Name             // Version          // Path
+        [InlineData("System",                                                                       "System.Core",      "",                 @"C:\System.Core.dll")]
+        [InlineData("System",                                                                       "system",           "",                 @"C:\System.dll")]
+        [InlineData("system",                                                                       "System",           "",                 @"C:\System.dll")]
+        [InlineData("encyclopædia",                                                                 "encyclopaedia",    "",                 @"C:\System.dll")]
+        [InlineData("System, Version=1.0.0.0",                                                      "System",           "",                 @"C:\System.dll")]
+        [InlineData("System, Version=2.0.0.0",                                                      "System",           "1.0.0.0",          @"C:\System.dll")]
+        public void ResolveAssemblyPathInTargetFx_NameThatDoesNotMatch_SetsResolvedAssemblysToZero(string input, string name, string version, string path)
+        {
+            var reference = Reference3Factory.CreateAssemblyReference(name, version, path);
+
+            var resolution = CreateInstance(reference);
+
+            var resolvedPaths = new VsResolvedAssemblyPath[1];
+            var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { input }, 1, resolvedPaths, out uint resolvedAssemblyPaths);
+
+            Assert.Equal(VSConstants.S_OK, result);
+            Assert.Equal(0u, resolvedAssemblyPaths);
+            Assert.Null(resolvedPaths[0].bstrOrigAssemblySpec);
+            Assert.Null(resolvedPaths[0].bstrResolvedAssemblyPath);
+        }
+
+        private static DesignTimeAssemblyResolution CreateInstance(params Reference[] references)
+        {
+            VSProject vsProject = VSProjectFactory.ImplementReferences(references);
+            Project project = ProjectFactory.ImplementObject(() => vsProject);
+            IVsHierarchy hierarchy = IVsHierarchyFactory.ImplementGetProperty(project);
+
+            return CreateInstance(hierarchy);
+        }
+
+        private static DesignTimeAssemblyResolution CreateInstance(IVsHierarchy hierarchy = null)
+        {
+            hierarchy = hierarchy ?? IVsHierarchyFactory.Create();
+
+            IUnconfiguredProjectVsServices projectVsServices = IUnconfiguredProjectVsServicesFactory.Implement(() => hierarchy);
+
+            return new DesignTimeAssemblyResolution(projectVsServices);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/References/DesignTimeAssemblyResolutionTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/References/DesignTimeAssemblyResolutionTests.cs
@@ -195,7 +195,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         [Theory]    // Input                                                                        // Name             // Version          // Path
         [InlineData("System",                                                                       "System.Core",      "",                 @"C:\System.Core.dll")]
         [InlineData("System",                                                                       "system",           "",                 @"C:\System.dll")]
-        [InlineData("system",                                                                       "System",           "",                 @"C:\System.dll")]
         [InlineData("encyclopædia",                                                                 "encyclopaedia",    "",                 @"C:\System.dll")]
         [InlineData("System, Version=1.0.0.0",                                                      "System",           "",                 @"C:\System.dll")]
         [InlineData("System, Version=2.0.0.0",                                                      "System",           "1.0.0.0",          @"C:\System.dll")]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -125,6 +125,8 @@
     <Compile Include="ProjectSystem\VS\References\AssemblyReferenceContextProvider.cs" />
     <Compile Include="ProjectSystem\VS\References\BaseReferenceContextProvider.cs" />
     <Compile Include="ProjectSystem\VS\References\ComReferencesProviderContext.cs" />
+    <Compile Include="ProjectSystem\VS\References\DesignTimeAssemblyResolution.cs" />
+    <Compile Include="ProjectSystem\VS\References\DesignTimeAssemblyResolution.ResolvedReference.cs" />
     <Compile Include="ProjectSystem\VS\References\ProjectReferencesProviderContext.cs" />
     <Compile Include="ProjectSystem\VS\References\SharedProjectReferencesProviderContext.cs" />
     <Compile Include="ProjectSystem\VS\References\WinRTReferencesProviderContext.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.ResolvedReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.ResolvedReference.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.References
+{
+    internal partial class DesignTimeAssemblyResolution
+    {
+        private struct ResolvedReference
+        {
+            public ResolvedReference(string resolvedPath, Version version)
+            {
+                Assumes.NotNull(resolvedPath);
+
+                ResolvedPath = resolvedPath;
+                Version = version;
+            }
+
+            public string ResolvedPath
+            {
+                get;
+
+            }
+
+            public Version Version
+            {
+                get;
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.ResolvedReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.ResolvedReference.cs
@@ -19,7 +19,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             public string ResolvedPath
             {
                 get;
-
             }
 
             public Version Version

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
     /// <summary>
     ///     Provides an implementation of <see cref="IVsDesignTimeAssemblyResolution"/> that sits over the top of VSLangProj.References.
     /// </summary>
-    [ExportProjectNodeComService(typeof(IVsDesignTimeAssemblyResolution))]  // Need to override CPS's version, which it implements on the project node as IVsDesignTimeAssemblyResolution
+    [Export]
     [ExportVsProfferedProjectService(typeof(SVsDesignTimeAssemblyResolution))]
     [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
     [Order(1)] // Before CPS's version
@@ -43,6 +43,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             Requires.NotNull(projectVsServices, nameof(projectVsServices));
 
             _projectVsServices = projectVsServices;
+        }
+
+        // BUG (https://devdiv.visualstudio.com/DevDiv/_workitems?id=367916): VS MEF rejects a part marked 
+        // with two Export/Metadata attributes where one is AllowMultiple=false
+        [ExportProjectNodeComService(typeof(IVsDesignTimeAssemblyResolution))]  // Need to override CPS's version, which it implements on the project node as IVsDesignTimeAssemblyResolution
+        [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
+        [Order(1)] // Before CPS's version
+        public IVsDesignTimeAssemblyResolution ComService
+        {
+            get { return this; }
         }
 
         public int GetTargetFramework(out string ppTargetFramework)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
@@ -1,0 +1,178 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using EnvDTE;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using VSLangProj;
+using VSLangProj80;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.References
+{
+    /// <summary>
+    ///     Provides an implementation of <see cref="IVsDesignTimeAssemblyResolution"/> that sits over the top of VSLangProj.References.
+    /// </summary>
+    [Export(ExportContractNames.VsTypes.ProjectNodeComExtension)]  // Need to override CPS's version, which it implements on the project node as IVsDesignTimeAssemblyResolution
+    [ComServiceIid(typeof(IVsDesignTimeAssemblyResolution))]
+    [ExportVsProfferedProjectService(typeof(SVsDesignTimeAssemblyResolution))]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
+    [Order(1)] // Before CPS's version
+    internal partial class DesignTimeAssemblyResolution : IVsDesignTimeAssemblyResolution
+    {
+        // NOTE: Unlike the legacy project system, this implementation does resolve only "framework" assemblies. In .NET Core and other project types, framework assemblies
+        // are not treated specially - they just come through as normal references from packages. We also do not have a static registration of what assemblies would make up 
+        // a framework, so we assume that what the project is referencing represents the "framework" of accessible types. This is the same as what the legacy project system
+        // does under the UWP flavor (when the DTARUseReferencesFromProject MSBuild property is set).
+        // 
+        // This implmementation will work for .NET Core based projects, but we might run into unexpected behavior when bringing up legacy projects where designers/components
+        // expect to ask for/use types that are not currently referenced by the project. We should revisit at that time.
+        //
+        // Ideally this would sit on a simple wrapper over the top of project subscription service, however, CPS's internal ReferencesHostBridge, which populates VSLangProj.References,
+        // already does the work to listen to the project subscription for reference adds/removes/changes and makes sure to publish the results in sync with the solution tree.
+        // We just use its results.
+        private readonly IUnconfiguredProjectVsServices _projectVsServices;
+
+        [ImportingConstructor]
+        public DesignTimeAssemblyResolution(IUnconfiguredProjectVsServices projectVsServices)
+        {
+            Requires.NotNull(projectVsServices, nameof(projectVsServices));
+
+            _projectVsServices = projectVsServices;
+        }
+
+        public int GetTargetFramework(out string ppTargetFramework)
+        {
+            return _projectVsServices.VsHierarchy.GetProperty(VsHierarchyPropID.TargetFrameworkMoniker, defaultValue: null, result: out ppTargetFramework);
+        }
+
+        public int ResolveAssemblyPathInTargetFx(string[] prgAssemblySpecs, uint cAssembliesToResolve, VsResolvedAssemblyPath[] prgResolvedAssemblyPaths, out uint pcResolvedAssemblyPaths)
+        {
+            if (prgAssemblySpecs == null || cAssembliesToResolve == 0 || prgResolvedAssemblyPaths == null || cAssembliesToResolve != prgAssemblySpecs.Length || cAssembliesToResolve != prgResolvedAssemblyPaths.Length)
+            {
+                pcResolvedAssemblyPaths = 0;
+                return VSConstants.E_INVALIDARG;
+            }
+
+            if (!TryParseAssemblyNames(prgAssemblySpecs, out AssemblyName[] assemblyNames))
+            {
+                pcResolvedAssemblyPaths = 0;
+                return VSConstants.E_INVALIDARG;
+            }
+
+            pcResolvedAssemblyPaths = ResolveReferences(prgAssemblySpecs, assemblyNames, prgResolvedAssemblyPaths);
+            return VSConstants.S_OK;
+        }
+
+        private uint ResolveReferences(string[] originalNames, AssemblyName[] assemblyName, [In, Out]VsResolvedAssemblyPath[] assemblyPaths)
+        {
+            Assumes.True(originalNames.Length == assemblyName.Length && originalNames.Length == assemblyPaths.Length);
+
+            uint resolvedReferencesCount = 0;
+            IDictionary<string, ResolvedReference> references = GetAllResolvedReferences();
+
+            for (int i = 0; i < assemblyName.Length; i++)
+            {
+                string resolvedPath = FindResolvedAssemblyPath(references, assemblyName[i]);
+                if (resolvedPath != null)
+                {
+                    assemblyPaths[resolvedReferencesCount] = new VsResolvedAssemblyPath() {
+                            bstrOrigAssemblySpec = originalNames[i],    // Note we use the original name, not the parsed name, as they could be different
+                            bstrResolvedAssemblyPath = resolvedPath
+                    };
+
+                    resolvedReferencesCount++;
+                }
+            }
+
+            return resolvedReferencesCount;
+        }
+
+        private string FindResolvedAssemblyPath(IDictionary<string, ResolvedReference> references, AssemblyName assemblyName)
+        {
+            // NOTE: We mimic the behavior of the legacy project system when in "DTARUseReferencesFromProject" mode, it matches 
+            // only on version, and only against currently referenced assemblies, nothing more. 
+            //
+            // See ResolveAssemblyReference in vs\env\vscore\package\MSBuild\ToolLocationHelperShim.cs
+            //
+            // 
+            if (references.TryGetValue(assemblyName.Name, out ResolvedReference reference))
+            {
+                // If the caller didn't specify a version, than they only want to match on name
+                if (assemblyName.Version == null)
+                    return reference.ResolvedPath;
+
+                // If the reference is the same or higher than the requested version, then we consider it a match
+                if (reference.Version != null && reference.Version >= assemblyName.Version)
+                    return reference.ResolvedPath;
+            }
+
+            return null;
+        }
+
+        private IDictionary<string, ResolvedReference> GetAllResolvedReferences()
+        {
+            var resolvedReferences = new Dictionary<string, ResolvedReference>(StringComparer.Ordinal);
+
+            VSProject project = GetVSProject();
+            foreach (Reference3 reference in project.References.OfType<Reference3>())
+            {
+                // We only want resolved assembly references
+                if (reference.Type != prjReferenceType.prjReferenceTypeAssembly && !reference.Resolved)
+                    continue;
+
+                resolvedReferences[reference.Name] = new ResolvedReference(reference.Path, TryParseVersionOrNull(reference.Version));
+            }
+
+            return resolvedReferences;
+        }
+
+        private VSProject GetVSProject()
+        {
+            Project project = _projectVsServices.VsHierarchy.GetProperty<Project>(VsHierarchyPropID.ExtObject);
+            if (project == null)
+                return null;
+
+            return project.Object as VSProject;
+        }
+
+        private bool TryParseAssemblyNames(string[] assemblyNames, out AssemblyName[] result)
+        {
+            result = new AssemblyName[assemblyNames.Length];
+
+            for (int i = 0; i < assemblyNames.Length; i++)
+            {
+                string assemblyName = assemblyNames[i];
+
+                if (string.IsNullOrEmpty(assemblyName))
+                    return false;
+
+                try
+                {
+                    result[i] = new AssemblyName(assemblyName);
+                }
+                catch (FileLoadException)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private Version TryParseVersionOrNull(string version)
+        {
+            if (Version.TryParse(version, out Version result))
+            {
+                return result;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
@@ -18,8 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
     /// <summary>
     ///     Provides an implementation of <see cref="IVsDesignTimeAssemblyResolution"/> that sits over the top of VSLangProj.References.
     /// </summary>
-    [Export(ExportContractNames.VsTypes.ProjectNodeComExtension)]  // Need to override CPS's version, which it implements on the project node as IVsDesignTimeAssemblyResolution
-    [ComServiceIid(typeof(IVsDesignTimeAssemblyResolution))]
+    [ExportProjectNodeComService(typeof(IVsDesignTimeAssemblyResolution))]  // Need to override CPS's version, which it implements on the project node as IVsDesignTimeAssemblyResolution
     [ExportVsProfferedProjectService(typeof(SVsDesignTimeAssemblyResolution))]
     [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
     [Order(1)] // Before CPS's version

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
@@ -119,13 +119,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             var resolvedReferences = new Dictionary<string, ResolvedReference>(StringComparer.Ordinal);
 
             VSProject project = GetVSProject();
-            foreach (Reference3 reference in project.References.OfType<Reference3>())
+            if (project != null)
             {
-                // We only want resolved assembly references
-                if (reference.Type != prjReferenceType.prjReferenceTypeAssembly && !reference.Resolved)
-                    continue;
+                foreach (Reference3 reference in project.References.OfType<Reference3>())
+                {
+                    // We only want resolved assembly references
+                    if (reference.Type != prjReferenceType.prjReferenceTypeAssembly && !reference.Resolved)
+                        continue;
 
-                resolvedReferences[reference.Name] = new ResolvedReference(reference.Path, TryParseVersionOrNull(reference.Version));
+                    resolvedReferences[reference.Name] = new ResolvedReference(reference.Path, TryParseVersionOrNull(reference.Version));
+                }
             }
 
             return resolvedReferences;


### PR DESCRIPTION
New implementation of IVsDesignTimeAssemblyResolution that overrides CPS's version, it can be accessed via:

- By casting the hierarchy to IVsDesignTimeAssemblyResolution (no one in the tree that I can find uses this, but this is solely to override CPS's version)
- By looking up SVSDesignTimeAssemblyResolution via IVsProject.GetItemContext(any id).

This will enable us (along with a VSTypeResolutionChange and CPS change), enable to resolve the following issues:

#1076
#660
#747