### PR TITLE
Get a not-implemented popup when you attempt to rename a resource in RESX

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ProjectContextCodeModelProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ProjectContextCodeModelProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.ComponentModel.Composition;
 using EnvDTE;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
@@ -59,7 +60,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             {
                 await _threadingService.SwitchToUIThread();
 
-                return _codeModelFactory.GetFileCodeModel(projectContext, fileItem);
+                try
+                {
+                    return _codeModelFactory.GetFileCodeModel(projectContext, fileItem);
+                }
+                catch (NotImplementedException)
+                {   // Isn't a file that Roslyn knows about
+                }
+
+                return null;
             });
         }
     }


### PR DESCRIPTION
**Customer scenario**

Customers get the following dialog when attempting to add a new resource or rename a resource within the Resource Designer:

```
---------------------------
Microsoft Visual Studio
---------------------------
The method or operation is not implemented.
---------------------------
OK   
---------------------------
```

**Bugs this fixes:**

https://github.com/dotnet/roslyn-project-system/issues/752

**Workarounds, if any**

Click OK on the dialog.

**Risk**

Low

**Performance impact**

None

**Is this a regression from a previous update?**

No

**Root cause analysis:**

There were lots of blockers that prevented the Resource Designer from working, now that we started peeling the onion - we're finding more issues.

**How was the bug found?**

Ad hoc.

**Dev Notes**

Old legacy project system returns null when you ask for the FileCodeModel for a project item that the language service doesn't know about. We're mimic'ing this behavior.

Underneath if Roslyn returns E_NOTIMPL, it returns null. Ironically, if Roslyn just return S_OK and null, it would still work and we could the avoid the exception. I looked into that - but the Code Model lookup is pretty convoluted and used in a few places. I looked into fixing it - but would need to worry about breaking legacy project system and the VisualStudioWorkspace which has API for retrieving CodeModel items. I opt'd for a targeted fix.