### PR TITLE
Added swr registration for .xproj files

### DIFF
--- a/src/VsixV3/ProjectSystemPackage/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles.swixproj
+++ b/src/VsixV3/ProjectSystemPackage/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles.swixproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <Package Include="Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles.swr" />
+    <Package Include="ext.xproj.swr" />
   </ItemGroup>
 
   <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildVersion)\build\MicroBuild.Core.targets" />

--- a/src/VsixV3/ProjectSystemPackage/ext.xproj.swr
+++ b/src/VsixV3/ProjectSystemPackage/ext.xproj.swr
@@ -1,0 +1,15 @@
+use vs
+
+vs.fileAssociations
+  vs.fileAssociation extension=".xproj"
+                     progId="VisualStudio.xproj.[InstanceId]"
+                     contentType="text/plain"
+                     defaultProgramRegistrationPath=$(VSDefaultProgramPath)
+
+vs.progIds
+  vs.progId id="VisualStudio.xproj.[InstanceId]"
+            displayName="ASP.NET 5 (XPROJ)"
+            path="[InstallDir]\Common7\IDE\devenv.exe"
+            defaultIconPath="[InstallDir]\VC#\VCSPackages\csproj.dll"
+            defaultIconPosition=0
+            alwaysShowExtension=true


### PR DESCRIPTION
I've copied the extension registration format from csproj, https://devdiv.visualstudio.com/DevDiv/_git/VS.ref_archive?path=%2Fsrc%2FSetupPackages%2FCoreIde%2FCommunity%2Fres%2FFileAssociations%2Fext.csproj.swr&version=GBmaster&_a=contents, adjusting for the existing icon and present for xproj. Tagging @dotnet/project-system @basoundr for review. /cc @jinujoseph.

**Customer scenario**

When attempting to open an xproj from the file explorer, the file icon is correct, but double-clicking results in a "no program installed" popup.

**Bugs this fixes:**

Fixes https://github.com/dotnet/roslyn-project-system/issues/1143.

**Workarounds, if any**

Open the solution file, or open from inside VS.

**Risk**

Low. There are no code changes here, only registering a file handler.

**Performance impact**

None. No code changes.

**Is this a regression from a previous update?**

No. No one has ever attempted to double-click an xproj with vs2017 at this point.

**How was the bug found?**

Internal validation.