### PR TITLE
Restore based on a design time build instead of evaluation to get PackageReferences

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         private readonly ActiveConfiguredProjectsProvider _activeConfiguredProjectsProvider;
         private readonly IActiveConfiguredProjectSubscriptionService _activeConfiguredProjectSubscriptionService;
         private readonly IActiveProjectConfigurationRefreshService _activeProjectConfigurationRefreshService;
-        private IDisposable _evaluationSubscriptionLink;
+        private IDisposable _designTimeBuildSubscriptionLink;
         private IDisposable _targetFrameworkSubscriptionLink;
 
         private const int perfPackageRestoreEnd = 7343;
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         private static ImmutableHashSet<string> _targetFrameworkWatchedRules = Empty.OrdinalIgnoreCaseStringSet
             .Add(NuGetRestore.SchemaName);
 
-        private static ImmutableHashSet<string> _evaluationWatchedRules = Empty.OrdinalIgnoreCaseStringSet
+        private static ImmutableHashSet<string> _designTimeBuildWatchedRules = Empty.OrdinalIgnoreCaseStringSet
             .Add(NuGetRestore.SchemaName)
             .Add(ProjectReference.SchemaName)
             .Add(PackageReference.SchemaName)
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 
         protected override Task DisposeCoreAsync(bool initialized)
         {
-            _evaluationSubscriptionLink?.Dispose();
+            _designTimeBuildSubscriptionLink?.Dispose();
             _targetFrameworkSubscriptionLink?.Dispose();
             return Task.CompletedTask;
         }
@@ -98,7 +98,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             // active configuration should be updated before resetting subscriptions
             await RefreshActiveConfigurationAsync().ConfigureAwait(false);
 
-            _evaluationSubscriptionLink?.Dispose();
+            _designTimeBuildSubscriptionLink?.Dispose();
 
             var currentProjects = await _activeConfiguredProjectsProvider.GetActiveConfiguredProjectsAsync().ConfigureAwait(false);
 
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             {
                 var sourceLinkOptions = new StandardRuleDataflowLinkOptions
                 {
-                    RuleNames = _evaluationWatchedRules,
+                    RuleNames = _designTimeBuildWatchedRules,
                     PropagateCompletion = true
                 };
 
@@ -117,7 +117,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 
                 var targetLinkOptions = new DataflowLinkOptions { PropagateCompletion = true };
 
-                _evaluationSubscriptionLink = ProjectDataSources.SyncLinkTo(sourceBlocks.ToImmutableList(), target, targetLinkOptions);
+                _designTimeBuildSubscriptionLink = ProjectDataSources.SyncLinkTo(sourceBlocks.ToImmutableList(), target, targetLinkOptions);
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
@@ -111,7 +111,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
                 };
 
                 var sourceBlocks = currentProjects.Select(
-                    cp => cp.Services.ProjectSubscription.ProjectRuleSource.SourceBlock.SyncLinkOptions<IProjectValueVersions>(sourceLinkOptions));
+                    cp => cp.Services.ProjectSubscription.JointRuleSource.SourceBlock.SyncLinkOptions<IProjectValueVersions>(sourceLinkOptions));
 
                 var target = new ActionBlock<Tuple<ImmutableList<IProjectValueVersions>, TIdentityDictionary>>(ProjectPropertyChangedAsync);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
@@ -9,7 +9,7 @@
     
     <Rule.DataSource>
         <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False"
-                    SourceType="TargetResults" MSBuildTarget="ResolvePackageReferencesDesignTime" />
+                    SourceType="TargetResults" MSBuildTarget="CollectPackageReferences" />
     </Rule.DataSource>
     
     <StringProperty Name="Description" 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
@@ -8,7 +8,8 @@
     xmlns="http://schemas.microsoft.com/build/2009/properties">
     
     <Rule.DataSource>
-        <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" />
+        <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False"
+                    SourceType="TargetResults" MSBuildTarget="ResolvePackageReferencesDesignTime" />
     </Rule.DataSource>
     
     <StringProperty Name="Description" 

--- a/src/Targets/Microsoft.Managed.DesignTime.targets
+++ b/src/Targets/Microsoft.Managed.DesignTime.targets
@@ -199,7 +199,9 @@
        once the actual targets are available after package restore-->
   <Target Name="ResolvePackageDependenciesDesignTime" />
 
-  <Target Name="ResolvePackageReferencesDesignTime" Returns="@(PackageReference)" />
+  <!-- This target is used to collect the PackageReferences in the project. This target can be overriden to add\remove packagereferences before they are
+       sent to NuGet to be restored.-->
+  <Target Name="CollectPackageReferences" Returns="@(PackageReference)" />
 
   <!-- Validates that the correct properties have been set for design-time compiles  -->
   <Target Name="_CheckCompileDesignTimePrerequisite">

--- a/src/Targets/Microsoft.Managed.DesignTime.targets
+++ b/src/Targets/Microsoft.Managed.DesignTime.targets
@@ -199,6 +199,8 @@
        once the actual targets are available after package restore-->
   <Target Name="ResolvePackageDependenciesDesignTime" />
 
+  <Target Name="ResolvePackageReferencesDesignTime" Returns="@(PackageReference)" />
+
   <!-- Validates that the correct properties have been set for design-time compiles  -->
   <Target Name="_CheckCompileDesignTimePrerequisite">
 


### PR DESCRIPTION
This is needed to get https://github.com/dotnet/sdk/pull/633 to work in VS.

See https://github.com/dotnet/sdk/pull/633 for the escrow template.

@davkean @natidea @basoundr @dotnet/project-system 