### PR TITLE
Bump up the version of our assemblies from 2.0.0.XXX to 2.0.1.XXX

### DIFF
--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -1,7 +1,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <RoslynSemanticVersion Condition="'$(RoslynSemanticVersion)' == '' AND '$(UseVisualStudioVersion)' == 'true'">15.0.0</RoslynSemanticVersion>
-    <RoslynSemanticVersion Condition="'$(RoslynSemanticVersion)' == ''">2.0.0</RoslynSemanticVersion>
+    <RoslynSemanticVersion Condition="'$(RoslynSemanticVersion)' == '' AND '$(UseVisualStudioVersion)' == 'true'">15.0.1</RoslynSemanticVersion>
+    <RoslynSemanticVersion Condition="'$(RoslynSemanticVersion)' == ''">2.0.1</RoslynSemanticVersion>
     <MicroBuildVersion>0.2.0</MicroBuildVersion>
     <BuildNumber Condition="'$(BuildNumber)' == ''">$(BUILD_BUILDNUMBER)</BuildNumber>
 
@@ -61,7 +61,7 @@
 
   <!-- NuGet version -->
   <PropertyGroup>
-    <VSSemanticVersion>15.0.0</VSSemanticVersion>
+    <VSSemanticVersion>15.0.1</VSSemanticVersion>
 
     <RoslynNuGetPreReleaseVersion>$(RoslynSemanticVersion)-rc</RoslynNuGetPreReleaseVersion>
     <RoslynNuGetPerBuildPreReleaseVersion Condition="'$(BuildNumberFiveDigitDateStamp)' != '' AND '$(BuildNumberBuildOfTheDayPadded)' != ''">$(RoslynNuGetPreReleaseVersion)-$(BuildNumberFiveDigitDateStamp.Trim())-$(BuildNumberBuildOfTheDayPadded.Trim())</RoslynNuGetPerBuildPreReleaseVersion>


### PR DESCRIPTION
**Customer scenario**

Post RC.2 we fixed our versioning to use the correct revision field, but this causes RC.2 version to be treated as higher then our latest version. This causes the VS upgrade from RC.2 to RC.3 to not upgrade our Project System and Editor assemblies. To workaround this, we are bumping up Build portion of the version from 0 to 1.

**Bugs this fixes:**

https://github.com/dotnet/roslyn-project-system/issues/1187

**Workarounds, if any**

Users need to do a clean install of RC.3 or manually uninstall and install the VSIXes.

**Risk**

Minimal, we are just upgrading the version

**Performance impact**

None

**Is this a regression from a previous update?**

**Root cause analysis:**

We didn't test this upgrade path.

**How was the bug found?**

Dogfooding