### PR TITLE
Strip the xml header

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/MSBuildXmlAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/MSBuildXmlAccessor.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
                 // encoded as UTF-8. This will mess up the project file encoding, so we strip it here to prevent that case.
                 // Note that if the user adds the header manually it will still be stripped, so we need to find a better
                 // long term solution for this.
-                if (xmlString.StartsWith("<?xml"))
+                if (xmlString.StartsWith("<?xml", StringComparison.Ordinal))
                 {
                     xmlString = xmlString.Substring(xmlString.IndexOf(Environment.NewLine) + Environment.NewLine.Length);
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/MSBuildXmlAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/MSBuildXmlAccessor.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.Threading.Tasks;
@@ -29,7 +30,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
                 var stringWriter = new StringWriter();
                 var projectXml = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
                 projectXml.Save(stringWriter);
-                return stringWriter.ToString();
+                var xmlString = stringWriter.ToString();
+                // Remove the xml prelude to deal with https://github.com/dotnet/roslyn-project-system/issues/1168 until
+                // we have a better solution. The XML returned here has a utf-16 header, even if the project file is
+                // encoded as UTF-8. This will mess up the project file encoding, so we strip it here to prevent that case.
+                // Note that if the user adds the header manually it will still be stripped, so we need to find a better
+                // long term solution for this.
+                if (xmlString.StartsWith("<?xml"))
+                {
+                    xmlString = xmlString.Substring(xmlString.IndexOf(Environment.NewLine) + Environment.NewLine.Length);
+                }
+                return xmlString;
             }
         }
 


### PR DESCRIPTION
**Customer scenario**

When the user edits the project file in VS, a UTF-16 xml header is added to the file, although there isn't one on disk. When the project is saved, MSBuild will change the format of the file based on this header, so future saves will be UTF-16 instead of UTF-8, causing issues with VCS.

**Bugs this fixes:**

Temporary workaround for https://github.com/dotnet/roslyn-project-system/issues/1168.

**Workarounds, if any**

Edit the project file with an external editor, not inside VS.

**Risk**

Relatively low. It checks to see if the project file has an XML header, and strips it if it exists. If the user manually put in the header it will strip that as well, so this cannot be the permanent fix.

**Performance impact**

Minor. We're doing a string comparison on the first 5 characters and a substring if that returns true, which should be relatively low impact.

**Is this a regression from a previous update?**

Not sure. The header has existed for a while, but bug reports only recently started coming in.

**Root cause analysis:**

We've known about not being able to get the true xml that MSBuild saves to disk for a while, this is another manifestation of that issue.

**How was the bug found?**

Customer reported.

Tagging @srivatsn @dotnet/project-system for review.