### PR TITLE
Clean up build warnings

### DIFF
--- a/src/Dependencies/CPS/CPS.csproj
+++ b/src/Dependencies/CPS/CPS.csproj
@@ -12,5 +12,11 @@
   <ItemGroup>
     <Content Include="project.json" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Immutable\Immutable.csproj">
+      <Project>{dcda908d-ef5e-494b-addc-c26f5fd610ca}</Project>
+      <Name>Immutable</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Imports.targets" />
 </Project>

--- a/src/Dependencies/Immutable/project.json
+++ b/src/Dependencies/Immutable/project.json
@@ -1,7 +1,7 @@
 {
   "supports": {},
   "dependencies": {
-    "System.Collections.Immutable": "1.1.36"
+    "System.Collections.Immutable": "1.3.1"
   },
   "frameworks": {
     ".NETPortable,Version=v4.5,Profile=Profile7": {}


### PR DESCRIPTION
PR https://github.com/dotnet/roslyn-project-system/pull/1140, upgraded our MSBuild dependency which resulted in 20 build warnings due to us depending on a lower version of System.Collections.Immutable than our dependencies.

