### PR TITLE
Delete global.json

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests.csproj
@@ -42,6 +42,10 @@
       <Project>{c7ec63f8-f96a-4a8f-b879-d572516746b4}</Project>
       <Name>Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj">
+      <Project>{469b50e9-fe67-459e-8afa-44cbe523dbf6}</Project>
+      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS\Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj">
       <Project>{1c5666ea-24a4-4ec2-b8fb-faedf6b14697}</Project>
       <Name>Microsoft.VisualStudio.ProjectSystem.Managed.VS</Name>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
@@ -5,14 +5,14 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Flavor;
 using Microsoft.VisualStudio.Shell.Interop;
 using Newtonsoft.Json;
 using Xunit;
-using Microsoft.VisualStudio.Shell.Flavor;
-using System.Reflection;
-using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
@@ -53,8 +53,8 @@ namespace Microsoft.VisualStudio.Packaging
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            _factory = new MigrateXprojProjectFactory(new ProcessRunner(), new Win32FileSystem());
-            _factory.SetSite(this);
+            _factory = new MigrateXprojProjectFactory(new ProcessRunner(), new Win32FileSystem(), ServiceProvider.GlobalProvider);
+            _factory.SetSite(new ServiceProviderToOleServiceProviderAdapter(ServiceProvider.GlobalProvider));
             RegisterProjectFactory(_factory);
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/FuncWithOut.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/FuncWithOut.cs
@@ -6,4 +6,5 @@ namespace Microsoft
     public delegate TResult FuncWithOut<in T1, TOut, TResult>(T1 arg1, out TOut result);
     public delegate TResult FuncWithOut<in T1, TOut1, TOut2, TResult>(T1 arg1, out TOut1 result1, out TOut2 result2);
     public delegate TResult FuncWithOut<in T1, in T2, TOut1, TOut2, TResult>(T1 arg1, T2 arg2, out TOut1 result1, out TOut2 result2);
+    public delegate TResult FuncWithOutThreeArgs<TOut1, TOut2, TOut3, TResult>(out TOut1 result1, out TOut2 result2, out TOut3 result3);
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Moq/ReturnsExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Moq/ReturnsExtensions.cs
@@ -40,6 +40,12 @@ namespace Moq
             return Returns(valueFunction, (object)action);
         }
 
+        public static IReturnsThrows<TMock, TReturn> Returns<TMock, TReturn, TOut1, TOut2, TOut3, TResult>(this IReturns<TMock, TReturn> valueFunction, FuncWithOutThreeArgs<TOut1, TOut2, TOut3, TResult> action)
+            where TMock : class
+        {
+            return Returns(valueFunction, (object)action);
+        }
+
         private static IReturnsThrows<TMock, TReturn> Returns<TMock, TReturn>(IReturns<TMock, TReturn> valueFunction, object action)
             where TMock : class
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -110,7 +110,7 @@
     <Compile Include="Mocks\IVsLanguageServiceBuildErrorReporter2Factory.cs" />
     <Compile Include="Mocks\IVsWindowFrameFactory.cs" />
     <Compile Include="Mocks\IVsHierarchyFactory.cs" />
-    <Compile Include="Mocks\IVsProjectFactory.cs" />
+    <Compile Include="Mocks\IVsProject_Factory.cs" />
     <Compile Include="Mocks\ProjectFactory.cs" />
     <Compile Include="Mocks\SolutionFactory.cs" />
     <Compile Include="Mocks\VSProjectFactory.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsProject_Factory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsProject_Factory.cs
@@ -5,7 +5,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.Shell.Interop
 {
-    internal static class IVsProjectFactory
+    internal static class IVsProject_Factory
     {
         public static void ImplementOpenItemWithSpecific(this IVsProject4 project, Guid editorType, Guid logicalView, int hr)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsProject_Factory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsProject_Factory.cs
@@ -5,6 +5,8 @@ using Moq;
 
 namespace Microsoft.VisualStudio.Shell.Interop
 {
+    // Named with an _ instead of IVsProjectFactory to avoid collisions with the actual IVsProjectFactory
+    // class.
     internal static class IVsProject_Factory
     {
         public static void ImplementOpenItemWithSpecific(this IVsProject4 project, Guid editorType, Guid logicalView, int hr)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsSolutionFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsSolutionFactory.cs
@@ -6,6 +6,16 @@ namespace Microsoft.VisualStudio.Shell.Interop
 {
     internal static class IVsSolutionFactory
     {
+        public static IVsSolution CreateWithSolutionDirectory(FuncWithOutThreeArgs<string, string, string, int> func)
+        {
+            var mock = new Mock<IVsSolution>();
+            string directory;
+            string solutionFile;
+            string userSettings;
+            mock.Setup(x => x.GetSolutionInfo(out directory, out solutionFile, out userSettings)).Returns(func);
+            return mock.Object;
+        }
+
         public static IVsSolution CreateWithAdviseUnadviseSolutionEvents(uint adviseCookie)
         {
             var mock = new Mock<IVsSolution>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -228,6 +228,7 @@
     <Compile Include="Shell\HierarchyId.cs" />
     <Compile Include="Shell\Interop\VsProjectExtensions.cs" />
     <Compile Include="Shell\Interop\VsHierarchyExtensions.cs" />
+    <Compile Include="Shell\ServiceProviderToOleServiceProviderAdapter.cs" />
     <Compile Include="Threading\Tasks\VsTaskScheduler.cs" />
     <Compile Include="VSResources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/ServiceProviderToOleServiceProviderAdapter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/ServiceProviderToOleServiceProviderAdapter.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.VisualStudio.ProjectSystem.VS;
+using System;
+using System.Runtime.InteropServices;
+using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
+
+namespace Microsoft.VisualStudio.Shell
+{
+    // Adapts an IServiceProvider to an OLE IServiceProvider
+    internal class ServiceProviderToOleServiceProviderAdapter : IOleServiceProvider
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public ServiceProviderToOleServiceProviderAdapter(IServiceProvider serviceProvider)
+        {
+            Requires.NotNull(serviceProvider, "serviceProvider");
+
+            _serviceProvider = serviceProvider;
+        }
+
+        public object ComServices { get; private set; }
+
+        public int QueryService(ref Guid guidService, ref Guid riid, out IntPtr ppvObject)
+        {
+            ppvObject = IntPtr.Zero;
+
+            object service;
+            if (!TryGetService(guidService, out service))
+            {
+                return HResult.NoInterface;
+            }
+
+            return GetComInterfaceForObject(service, riid, out ppvObject);
+        }
+
+        private bool TryGetService(Guid riid, out object service)
+        {
+            service = null;
+
+            Type serviceType = Type.GetTypeFromCLSID(riid, throwOnError: true); // Should only throw on OOM according to MSDN
+
+            service = _serviceProvider.GetService(serviceType);
+            if (service == null)
+                return false;
+
+            return true;
+        }
+
+        private static HResult GetComInterfaceForObject(object instance, Guid iid, out IntPtr ppvObject)
+        {
+            Requires.NotNull(instance, "instance");
+
+            IntPtr unknown = Marshal.GetIUnknownForObject(instance);
+            if (iid.Equals(VSConstants.IID_IUnknown))
+            {
+                ppvObject = unknown;
+                return HResult.OK;
+            }
+
+            HResult result = Marshal.QueryInterface(unknown, ref iid, out ppvObject);
+
+            // Don't leak the IUnknown
+            Marshal.Release(unknown);
+
+            return result;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/ServiceProviderToOleServiceProviderAdapter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/ServiceProviderToOleServiceProviderAdapter.cs
@@ -1,6 +1,8 @@
-﻿using Microsoft.VisualStudio.ProjectSystem.VS;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System;
 using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.ProjectSystem.VS;
 using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 
 namespace Microsoft.VisualStudio.Shell

--- a/src/ProjectSystem.sln
+++ b/src/ProjectSystem.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26030.0
+VisualStudioVersion = 15.0.26116.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeployTestDependencies", "DeployTestDependencies\DeployTestDependencies.csproj", "{37BA82E6-9ABD-4ACA-AA26-2DFD39A359A5}"
 EndProject


### PR DESCRIPTION
**Customer scenario**

When the user had a global.json specifying a lower version of the cli, it will be used instead of version installed with VS and cause issues with migration and during build. We need to emulate the behavior of the CLI here, which is to delete the global.json from the solution directory and run migration from the solution directory to prevent any global.json files from the project directories from applying.

**Bugs this fixes:**

Fixes https://github.com/dotnet/roslyn-project-system/issues/1184

**Workarounds, if any**

Having the user manually delete their global.json. This is a bad experience and doesn't match what the CLI does.

**Risk**

This should have low impact on other components, beyond potentially confusing the user. We only look in the solution directory for the global.json, so if the user has a global.json in an upper directory the bug will still exist. Additionally, we aren't removing the global.json from the solution, so the user will have a broken link to a solution item.

**Performance impact**

Relatively low. The only thing that may take time is if a user has a heavily nested project, as I need to find the root backup directory can can only do that via an iterative algorithm that works up the path.

**Is this a regression from a previous update?**

No. This is a new bug.

**How was the bug found?**

MVP testing.

Tagging @dotnet/project-system for review.