### PR TITLE
Enable "Run Code Analysis" commands to run FxCop for managed projects

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Menus.vsct
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Menus.vsct
@@ -98,4 +98,8 @@
     </GuidSymbol>
   </Symbols>
 
+  <UsedCommands>
+    <UsedCommand guid="guidVSStd2K" id="ECMD_RUNFXCOPSEL" />
+    <UsedCommand guid="guidVSStd2K" id="ECMD_RUNFXCOPPROJCTX" />
+  </UsedCommands>
 </CommandTable>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -49,6 +49,9 @@
     <Compile Include="ProjectSystem\VS\Editor\TempFileTextBufferManager.cs" />
     <Compile Include="ProjectSystem\VS\EditAndContinue\EditAndContinueProvider.cs" />
     <Compile Include="ProjectSystem\VS\ExportProjectNodeComServiceAttribute.cs" />
+    <Compile Include="ProjectSystem\VS\Input\Commands\AbstractRunCodeAnalysisCommand.cs" />
+    <Compile Include="ProjectSystem\VS\Input\Commands\RunCodeAnalysisTopLevelBuildMenuCommand.cs" />
+    <Compile Include="ProjectSystem\VS\Input\Commands\RunCodeAnalysisProjectContextMenuCommand.cs" />
     <Compile Include="ProjectSystem\VS\Input\Commands\GenerateNuGetPackageTopLevelBuildMenuCommand.cs" />
     <Compile Include="ProjectSystem\VS\Input\Commands\GenerateNuGetPackageProjectContextMenuCommand.cs" />
     <Compile Include="ProjectSystem\VS\Input\Commands\AbstractGenerateNuGetPackageCommand.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
@@ -21,6 +21,11 @@ namespace Microsoft.VisualStudio.Packaging
                                                   ProjectCapability.HandlesOwnReload + "; " +
                                                   ProjectCapability.OpenProjectFile;
 
+        public const long RunCodeAnalysisTopLevelBuildMenuCmdId = 0x066f;
+        public const long RunCodeAnalysisProjectContextMenuCmdId = 0x0670;
+        public const string CodeAnalysisPackageGuid = "B20604B0-72BC-4953-BB92-95BF26D30CFA";
+        public const string VSStd2KCommandSet = "1496A755-94DE-11D0-8C3F-00C04FC2AAE2";
+
         public ManagedProjectSystemPackage()
         {
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractRunCodeAnalysisCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractRunCodeAnalysisCommand.cs
@@ -2,54 +2,109 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Packaging;
 using Microsoft.VisualStudio.ProjectSystem.Build;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using IOleCommandTarget = Microsoft.VisualStudio.OLE.Interop.IOleCommandTarget;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 {
-    internal abstract class AbstractGenerateNuGetPackageCommand : AbstractSingleNodeProjectCommand, IVsUpdateSolutionEvents, IDisposable
+    internal abstract class AbstractRunCodeAnalysisCommand : AbstractSingleNodeProjectCommand, IVsUpdateSolutionEvents, IDisposable
     {
         private readonly IProjectThreadingService _threadingService;
         private readonly IServiceProvider _serviceProvider;
-        private readonly GeneratePackageOnBuildPropertyProvider _generatePackageOnBuildPropertyProvider;
+        private readonly RunCodeAnalysisBuildPropertyProvider _runCodeAnalysisBuildPropertyProvider;
+
         private IVsSolutionBuildManager2 _buildManager;
         private uint _solutionEventsCookie;
+        private IVsShell _vsShell;
+        private bool? _isCodeAnalysisPackageInstalled;
+        private bool _codeAnalysisPackageLoadAttempted;
+        private IOleCommandTarget _codeAnalysisCommandTarget;
 
-        protected AbstractGenerateNuGetPackageCommand(
+        protected AbstractRunCodeAnalysisCommand(
             UnconfiguredProject unconfiguredProject,
             IProjectThreadingService threadingService,
             SVsServiceProvider serviceProvider,
-            GeneratePackageOnBuildPropertyProvider generatePackageOnBuildPropertyProvider)
+            RunCodeAnalysisBuildPropertyProvider runCodeAnalysisBuildPropertyProvider)
         {
             Requires.NotNull(unconfiguredProject, nameof(unconfiguredProject));
             Requires.NotNull(threadingService, nameof(threadingService));
             Requires.NotNull(serviceProvider, nameof(serviceProvider));
-            Requires.NotNull(generatePackageOnBuildPropertyProvider, nameof(generatePackageOnBuildPropertyProvider));
+            Requires.NotNull(serviceProvider, nameof(runCodeAnalysisBuildPropertyProvider));
 
             UnconfiguredProject = unconfiguredProject;
             _threadingService = threadingService;
             _serviceProvider = serviceProvider;
-            _generatePackageOnBuildPropertyProvider = generatePackageOnBuildPropertyProvider;            
+            _runCodeAnalysisBuildPropertyProvider = runCodeAnalysisBuildPropertyProvider;
         }
 
         protected UnconfiguredProject UnconfiguredProject { get; }
 
         protected abstract string GetCommandText();
         protected abstract bool ShouldHandle(IProjectTree node);
+        protected abstract long CommandId { get; }
 
         protected async override Task<CommandStatusResult> GetCommandStatusAsync(IProjectTree node, bool focused, string commandText, CommandStatus progressiveStatus)
         {
             if (ShouldHandle(node))
             {
-                // Enable the command if the build manager is ready to build.
-                var commandStatus = await IsReadyToBuildAsync().ConfigureAwait(false) ? CommandStatus.Enabled : CommandStatus.Supported;
-                return await GetCommandStatusResult.Handled(GetCommandText(), commandStatus).ConfigureAwait(false);
-            }
+                // Enable the command if code analysis is enabled and the build manager is ready to build.
+                if (await IsCodeAnalysisPackageInstalledAsync().ConfigureAwait(false))
+                {
+                    var commandStatus = await IsReadyToBuildAsync().ConfigureAwait(false) ? CommandStatus.Enabled : CommandStatus.Supported;
+                    return await GetCommandStatusResult.Handled(GetCommandText(), commandStatus).ConfigureAwait(false);
+                }
+             }
 
             return CommandStatusResult.Unhandled;
+        }
+
+        private async Task<bool> IsCodeAnalysisPackageInstalledAsync()
+        {
+            if (!_isCodeAnalysisPackageInstalled.HasValue)
+            {
+                // Switch to UI thread for querying the build manager service.
+                await _threadingService.SwitchToUIThread();
+
+                if (_vsShell == null)
+                {
+                    _vsShell = _serviceProvider.GetService<IVsShell, SVsShell>();
+                }
+
+                var codeAnalysisGuid = new Guid(ManagedProjectSystemPackage.CodeAnalysisPackageGuid);
+                ErrorHandler.ThrowOnFailure(_vsShell.IsPackageInstalled(ref codeAnalysisGuid, out int packageInstalled));
+                _isCodeAnalysisPackageInstalled = packageInstalled != 0;
+            }
+
+            return _isCodeAnalysisPackageInstalled.Value;
+        }
+
+        private async Task EnsureCodeAnalysisPackageLoadedAsync()
+        {
+            if (!_codeAnalysisPackageLoadAttempted)
+            {
+                // Switch to UI thread for querying the build manager service.
+                await _threadingService.SwitchToUIThread();
+
+                if (_vsShell == null)
+                {
+                    _vsShell = _serviceProvider.GetService<IVsShell, SVsShell>();
+                }
+
+                var codeAnalysisGuid = new Guid(ManagedProjectSystemPackage.CodeAnalysisPackageGuid);
+                _vsShell.IsPackageLoaded(ref codeAnalysisGuid, out IVsPackage package);
+                if (package == null)
+                {
+                    _vsShell.LoadPackage(ref codeAnalysisGuid, out package);
+                }
+
+                _codeAnalysisCommandTarget = package as IOleCommandTarget;
+                _codeAnalysisPackageLoadAttempted = true;
+            }
         }
 
         private async Task<bool> IsReadyToBuildAsync()
@@ -87,16 +142,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
                 // Build manager APIs require UI thread access.
                 await _threadingService.SwitchToUIThread();
 
-                // Save documents before build.
-                var projectVsHierarchy = (IVsHierarchy)UnconfiguredProject.Services.HostObject;
-                ErrorHandler.ThrowOnFailure(_buildManager.SaveDocumentsBeforeBuild(projectVsHierarchy, (uint)VSConstants.VSITEMID.Root, 0 /*docCookie*/));
+                await EnsureCodeAnalysisPackageLoadedAsync().ConfigureAwait(false);
 
-                // Enable generating package on build ("GeneratePackageOnBuild") for all projects being built.
-                _generatePackageOnBuildPropertyProvider.OverrideGeneratePackageOnBuild(true);
+                // Enable RunCodeAnalysisOnce on this project.
+                _runCodeAnalysisBuildPropertyProvider.EnableRunCodeAnalysisOnBuild(UnconfiguredProject.FullPath);
 
-                // Kick off the build.
-                uint dwFlags = (uint)(VSSOLNBUILDUPDATEFLAGS.SBF_SUPPRESS_SAVEBEFOREBUILD_QUERY | VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD);
-                ErrorHandler.ThrowOnFailure(_buildManager.StartSimpleUpdateProjectConfiguration(projectVsHierarchy, null, null, dwFlags, 0, 0));
+                _codeAnalysisCommandTarget?.Exec(VSConstants.VSStd2K, (uint)CommandId, (uint)commandExecuteOptions, variantArgIn, variantArgOut);
             }
 
             return true;
@@ -110,13 +161,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 
         public int UpdateSolution_Done(int fSucceeded, int fModified, int fCancelCommand)
         {
-            _generatePackageOnBuildPropertyProvider.OverrideGeneratePackageOnBuild(false);
+            _runCodeAnalysisBuildPropertyProvider.DisableRunCodeAnalysisOnBuild();
             return VSConstants.S_OK;
         }
 
         public int UpdateSolution_Cancel()
         {
-            _generatePackageOnBuildPropertyProvider.OverrideGeneratePackageOnBuild(false);
+            _runCodeAnalysisBuildPropertyProvider.DisableRunCodeAnalysisOnBuild();
             return VSConstants.S_OK;
         }
 
@@ -135,7 +186,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         public void Dispose()
         {
             // Build manager APIs require UI thread access.
-            _threadingService.ExecuteSynchronously(async() =>
+            _threadingService.ExecuteSynchronously(async () =>
             {
                 await _threadingService.SwitchToUIThread();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/RunCodeAnalysisProjectContextMenuCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/RunCodeAnalysisProjectContextMenuCommand.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.ProjectSystem.Build;
+using Microsoft.VisualStudio.ProjectSystem.Input;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+{
+    [ProjectCommand(ManagedProjectSystemPackage.VSStd2KCommandSet, ManagedProjectSystemPackage.RunCodeAnalysisProjectContextMenuCmdId)]
+    [AppliesTo(ProjectCapability.CodeAnalysis)]
+    internal class RunCodeAnalysisProjectContextMenuCommand : AbstractRunCodeAnalysisCommand
+    {
+        [ImportingConstructor]
+        public RunCodeAnalysisProjectContextMenuCommand(
+            UnconfiguredProject unconfiguredProject,
+            IProjectThreadingService threadingService,
+            SVsServiceProvider serviceProvider,
+            RunCodeAnalysisBuildPropertyProvider runCodeAnalysisBuildPropertyProvider)
+            : base(unconfiguredProject, threadingService, serviceProvider, runCodeAnalysisBuildPropertyProvider)
+        {
+        }
+
+        protected override bool ShouldHandle(IProjectTree node) => node.IsRoot();
+        protected override string GetCommandText() => VSResources.RunCodeAnalysisProjectContextMenuCommand;
+        protected override long CommandId => ManagedProjectSystemPackage.RunCodeAnalysisProjectContextMenuCmdId;
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/RunCodeAnalysisTopLevelBuildMenuCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/RunCodeAnalysisTopLevelBuildMenuCommand.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using System.IO;
+using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.ProjectSystem.Build;
+using Microsoft.VisualStudio.ProjectSystem.Input;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+{
+    [ProjectCommand(ManagedProjectSystemPackage.VSStd2KCommandSet, ManagedProjectSystemPackage.RunCodeAnalysisTopLevelBuildMenuCmdId)]
+    [AppliesTo(ProjectCapability.CodeAnalysis)]
+    internal class RunCodeAnalysisTopLevelBuildMenuCommand : AbstractRunCodeAnalysisCommand
+    {
+        [ImportingConstructor]
+        public RunCodeAnalysisTopLevelBuildMenuCommand(
+            UnconfiguredProject unconfiguredProject,
+            IProjectThreadingService threadingService,
+            SVsServiceProvider serviceProvider,
+            RunCodeAnalysisBuildPropertyProvider runCodeAnalysisBuildPropertyProvider)
+            : base(unconfiguredProject, threadingService, serviceProvider, runCodeAnalysisBuildPropertyProvider)
+        {
+        }
+
+        protected override bool ShouldHandle(IProjectTree node) => node.IsRoot();
+        protected override string GetCommandText() =>string.Format(VSResources.RunCodeAnalysisTopLevelBuildMenuCommand, Path.GetFileNameWithoutExtension(UnconfiguredProject.FullPath));
+        protected override long CommandId => ManagedProjectSystemPackage.RunCodeAnalysisTopLevelBuildMenuCmdId;
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -451,6 +451,24 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Run C&amp;ode Analysis.
+        /// </summary>
+        internal static string RunCodeAnalysisProjectContextMenuCommand {
+            get {
+                return ResourceManager.GetString("RunCodeAnalysisProjectContextMenuCommand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Run Code &amp;Analysis on {0}.
+        /// </summary>
+        internal static string RunCodeAnalysisTopLevelBuildMenuCommand {
+            get {
+                return ResourceManager.GetString("RunCodeAnalysisTopLevelBuildMenuCommand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _Save As.
         /// </summary>
         internal static string SaveAs {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -276,4 +276,10 @@ In order to debug this project, add an executable project to this solution which
   <data name="XprojMigrationGeneralFailure" xml:space="preserve">
     <value>Failed to migrate XProj project {0}. '{1}' exited with error code {2}.</value>
   </data>
+  <data name="RunCodeAnalysisProjectContextMenuCommand" xml:space="preserve">
+    <value>Run C&amp;ode Analysis</value>
+  </data>
+  <data name="RunCodeAnalysisTopLevelBuildMenuCommand" xml:space="preserve">
+    <value>Run Code &amp;Analysis on {0}</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -38,6 +38,7 @@
     <Compile Include="CommonConstants.cs" />
     <Compile Include="ProjectSystem\Build\CommandLineDesignTimeBuildPropertiesProvider.cs" />
     <Compile Include="ProjectSystem\Build\GeneratePackageOnBuildDesignTimeBuildPropertyProvider.cs" />
+    <Compile Include="ProjectSystem\Build\RunCodeAnalysisBuildPropertyProvider.cs" />
     <Compile Include="ProjectSystem\Build\GeneratePackageOnBuildPropertyProvider.cs" />
     <Compile Include="ProjectSystem\Build\TargetFrameworkGlobalBuildPropertyProvider.cs" />
     <Compile Include="ProjectSystem\ContractNames.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/RunCodeAnalysisBuildPropertyProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/RunCodeAnalysisBuildPropertyProvider.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Build
+{
+    /// <summary>
+    /// Build property provider for CodeAnalysis related properties for solution build.
+    /// </summary>
+    [ExportBuildGlobalPropertiesProvider(designTimeBuildProperties: false)]
+    [Export(typeof(RunCodeAnalysisBuildPropertyProvider))]
+    [AppliesTo(ProjectCapability.CodeAnalysis)]
+    internal class RunCodeAnalysisBuildPropertyProvider : StaticGlobalPropertiesProviderBase
+    {
+        private const string RunCodeAnalysisOnceBuildPropertyName = "RunCodeAnalysisOnce";
+        private const string CodeAnalysisProjectFullPathBuildPropertyName = "CodeAnalysisProjectFullPath";
+
+        private bool _runCodeAnalysisOnce;
+        private string _projectFullPath;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RunCodeAnalysisBuildPropertyProvider"/> class.
+        /// </summary>
+        [ImportingConstructor]
+        internal RunCodeAnalysisBuildPropertyProvider(IProjectService projectService)
+            : base(projectService.Services)
+        {
+        }
+
+        public void EnableRunCodeAnalysisOnBuild(string projectFullPath)
+        {
+            _runCodeAnalysisOnce = true;
+            _projectFullPath = projectFullPath;
+        }
+
+        public void DisableRunCodeAnalysisOnBuild()
+        {
+            _runCodeAnalysisOnce = false;
+            _projectFullPath = null;
+        }
+
+        /// <summary>
+        /// Gets the set of global properties that should apply to the project(s) in this scope.
+        /// </summary>
+        /// <value>A map whose keys are case insensitive.  Never null, but may be empty.</value>
+        public override Task<IImmutableDictionary<string, string>> GetGlobalPropertiesAsync(CancellationToken cancellationToken)
+        {
+            IImmutableDictionary<string, string> properties = Empty.PropertiesMap;
+
+            if (_runCodeAnalysisOnce && !string.IsNullOrEmpty(_projectFullPath))
+            {
+                properties = properties.Add(RunCodeAnalysisOnceBuildPropertyName, "true")
+                    .Add(CodeAnalysisProjectFullPathBuildPropertyName, _projectFullPath);
+            }
+
+            return Task.FromResult(properties);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
@@ -28,5 +28,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public const string ReferenceManagerSharedProjects = nameof(ReferenceManagerSharedProjects);
         public const string ReferenceManagerWinRT = nameof(ReferenceManagerWinRT);
         public const string Pack = nameof(Pack); // Keep this in sync with Microsoft.VisualStudio.Editors.ProjectCapability.Pack
+        public const string CodeAnalysis = nameof(CodeAnalysis); // Keep this in sync with Microsoft.VisualStudio.Editors.ProjectCapability.CodeAnalysis
     }
 }

--- a/src/Targets/Microsoft.Managed.DesignTime.targets
+++ b/src/Targets/Microsoft.Managed.DesignTime.targets
@@ -53,7 +53,8 @@
 
     <ProjectCapability Include="LanguageService" />
     <ProjectCapability Include="ProjectConfigurationsInferredFromUsage" />
-
+    <ProjectCapability Include="CodeAnalysis" />
+    
     <!-- Reference Manager capabilities -->
     <ProjectCapability Include="ReferenceManagerAssemblies" />
     <ProjectCapability Include="ReferenceManagerBrowse" />


### PR DESCRIPTION
**Customer scenario**

Users cannot run Code Analysis (FxCop) from Visual Studio.

**Bugs this fixes:**

Fixes #988

**Workarounds, if any**

Run FxCop from CommandLine

**Risk**

This is new code, so it shouldn't affect existing features. The change involves:

1. Mimic the behavior of native project system to load stancore package for code analysis, if installed.
2. Turn on the CodeAnalysis specific global build properties for enabling FxCop when build is invoked from Run Code Analysis.

**Performance impact**

None

**Is this a regression from a previous update?**

**Root cause analysis:**

New feature

**How was the bug found?**

Dogfooding