### PR TITLE
Set TargetFramework to 4.6 for the setup Vsix

### DIFF
--- a/src/VsixV3/EditorsPackage/Microsoft.VisualStudio.Editors.vsmanproj
+++ b/src/VsixV3/EditorsPackage/Microsoft.VisualStudio.Editors.vsmanproj
@@ -8,6 +8,7 @@
   <Import Project="..\..\..\build\Targets\VSL.Settings.targets" />
 
   <PropertyGroup>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FinalizeManifest>true</FinalizeManifest>
     <FinalizeSkipLayout>true</FinalizeSkipLayout>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>

--- a/src/VsixV3/ProjectSystemPackage/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles.swixproj
+++ b/src/VsixV3/ProjectSystemPackage/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles.swixproj
@@ -3,6 +3,7 @@
   <Import Project="..\..\..\build\Targets\VSL.Settings.targets" />
 
   <PropertyGroup>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <OutputArchitecture>neutral</OutputArchitecture>
     <OutputLocalized>false</OutputLocalized>
     <OutputType>vsix</OutputType>

--- a/src/VsixV3/ProjectSystemPackage/Microsoft.VisualStudio.ProjectSystem.Managed.vsmanproj
+++ b/src/VsixV3/ProjectSystemPackage/Microsoft.VisualStudio.ProjectSystem.Managed.vsmanproj
@@ -3,6 +3,7 @@
   <Import Project="..\..\..\build\Targets\VSL.Settings.targets" />
 
   <PropertyGroup>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FinalizeManifest>true</FinalizeManifest>
     <FinalizeSkipLayout>true</FinalizeSkipLayout>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>


### PR DESCRIPTION
**Customer scenario**

Move the setup projects to Framework 4.6 like the rest of the projects. 

**Bugs this fixes:**

The sign build machines did not build because they did not have the targeting pack for 4.0

**Workarounds, if any**

Install the machine with the required targeting pack

**Risk**

Infrastructure work - No risk

**Performance impact**

None

**Is this a regression from a previous update?**

**How was the bug found?**

Signed build started failing