### PR TITLE
Removed extra trailing slash that breaks building on some machines

### DIFF
--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -552,7 +552,7 @@
        <_XamlPropertyRuleToCopy Include="@(XamlPropertyRule);@(XamlPropertyRuleNoCodeBehind);@(XamlPropertyProjectItemsSchema)" />
 
        <!-- Pick up localized copies as well -->
-       <_XamlPropertyRuleToCopy Include="%(RootDir)%(Directory)\**\%(Filename)%(Extension)" />
+       <_XamlPropertyRuleToCopy Include="%(RootDir)%(Directory)**\%(Filename)%(Extension)" />
     </ItemGroup>
 
     <!-- Copy rule files for testing and setup authoring purposes -->


### PR DESCRIPTION
This is an infrastructure only change. It fixes the ` error MSB3541: Files has invalid value "c:\Users\frsilb\Documents\git\roslyn-project-system\bin\obj\Unused\Debug\\Rules\**\". Illegal characters in path.` issue that many of us were seeing. Tagging @nguerrera @dotnet/project-system for review. /cc @cdmihai.