### PR TITLE
Convert xlf back to resx/xaml following loc handback

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.pl.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.pl.resx
@@ -160,7 +160,7 @@
     <value>Przeglądaj w poszukiwaniu katalogu roboczego</value>
   </data>
   <data name="StartWorkingDirectoryBrowse.Text" xml:space="preserve">
-    <value>&amp;Prze&amp;glądaj...</value>
+    <value>Prze&amp;glądaj...</value>
   </data>
   <data name="EnableDebuggerLabel.Text" xml:space="preserve">
     <value>Aparaty debugowania</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.pt-BR.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.pt-BR.resx
@@ -160,7 +160,7 @@
     <value>Procurar diretório de trabalho</value>
   </data>
   <data name="StartWorkingDirectoryBrowse.Text" xml:space="preserve">
-    <value>&amp;Pro&amp;curar...</value>
+    <value>Pro&amp;curar...</value>
   </data>
   <data name="EnableDebuggerLabel.Text" xml:space="preserve">
     <value>Mecanismos depuradores</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.ru.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.ru.resx
@@ -160,7 +160,7 @@
     <value>Поиск рабочего каталога</value>
   </data>
   <data name="StartWorkingDirectoryBrowse.Text" xml:space="preserve">
-    <value>О&amp;бзор...</value>
+    <value>&amp;Обзор...</value>
   </data>
   <data name="EnableDebuggerLabel.Text" xml:space="preserve">
     <value>Модули отладчика</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.tr.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.tr.resx
@@ -160,7 +160,7 @@
     <value>Çalışma dizinine gözat</value>
   </data>
   <data name="StartWorkingDirectoryBrowse.Text" xml:space="preserve">
-    <value>&amp;Göz&amp;at...</value>
+    <value>Göz&amp;at...</value>
   </data>
   <data name="EnableDebuggerLabel.Text" xml:space="preserve">
     <value>Hata ayıklama altyapıları</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.zh-Hans.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.zh-Hans.resx
@@ -160,7 +160,7 @@
     <value>浏览工作目录</value>
   </data>
   <data name="StartWorkingDirectoryBrowse.Text" xml:space="preserve">
-    <value>浏览(&amp;B)...</value>
+    <value>浏览(&amp;W)...</value>
   </data>
   <data name="EnableDebuggerLabel.Text" xml:space="preserve">
     <value>调试程序引擎</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.zh-Hant.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.zh-Hant.resx
@@ -160,7 +160,7 @@
     <value>瀏覽工作目錄</value>
   </data>
   <data name="StartWorkingDirectoryBrowse.Text" xml:space="preserve">
-    <value>瀏覽(&amp;B/W)...</value>
+    <value>瀏覽(&amp;W)...</value>
   </data>
   <data name="EnableDebuggerLabel.Text" xml:space="preserve">
     <value>偵錯工具引擎</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/DebugPropPage.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/DebugPropPage.xlf
@@ -61,7 +61,7 @@
       </trans-unit>
       <trans-unit id="StartWorkingDirectoryBrowse.Text">
         <source>Bro&amp;wse...</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="EnableDebuggerLabel.Text">
         <source>Debugger engines</source>

--- a/src/Microsoft.VisualStudio.Editors/Resources/Designer.cs.resx
+++ b/src/Microsoft.VisualStudio.Editors/Resources/Designer.cs.resx
@@ -198,7 +198,7 @@ Pokud chcete tento stav ignorovat a pokračovat v operaci , klikněte na OK. Pok
     <value>Není k dispozici</value>
   </data>
   <data name="PPG_ConfigNotFound_2Args" xml:space="preserve">
-    <value>Nepodařilo se najít konfiguraci {0} pro platformu {1}.</value>
+    <value>Konfigurace {0} pro platformu {1} se nenašla.</value>
   </data>
   <data name="PPG_NeutralLanguage_None" xml:space="preserve">
     <value>(žádné)</value>

--- a/src/Microsoft.VisualStudio.Editors/Resources/Designer.it.resx
+++ b/src/Microsoft.VisualStudio.Editors/Resources/Designer.it.resx
@@ -628,7 +628,7 @@ Errore:</value>
 </value>
   </data>
   <data name="PPG_Reference_RemoveImportsFailUnexpected" xml:space="preserve">
-    <value>Non è stato possibile aggiungere o rimuovere '{0}' come importazione del progetto a causa di un errore imprevisto del sistema di progetto. Errore restituito: '{1}'.</value>
+    <value>Non è stato possibile aggiungere o rimuovere '{0}' come importazione del progetto a causa di un errore imprevisto del sistema di progetto.  Errore restituito: '{1}'.</value>
   </data>
   <data name="PPG_Reference_AddWebReference" xml:space="preserve">
     <value>Non è stato possibile aggiungere il riferimento Web. {0}
@@ -732,7 +732,7 @@ Errore:</value>
     <value>Risorse</value>
   </data>
   <data name="APPDES_ErrorLoading_Msg" xml:space="preserve">
-    <value>Si è verificato un errore durante il tentativo di caricamento della finestra delle proprietà del progetto. Chiudere la finestra e riprovare.
+    <value>Si è verificato un errore durante il tentativo di caricare la finestra delle proprietà del progetto.  Chiudere la finestra e riprovare.
 {0}</value>
   </data>
   <data name="APPDES_ErrorLoadingPropPage" xml:space="preserve">
@@ -751,7 +751,7 @@ Errore:</value>
     <value>Il file '{0}' non è stato trovato.</value>
   </data>
   <data name="APPDES_EditorAlreadyOpen_1Arg" xml:space="preserve">
-    <value>Il file '{0}' è già aperto in un editor. Chiudere il file e riprovare.</value>
+    <value>Il file '{0}' è già aperto in un editor.  Chiudere il file e riprovare.</value>
   </data>
   <data name="APPDES_OverflowButton_AccessibilityName" xml:space="preserve">
     <value>Tutte le pagine Creazione progetti</value>
@@ -904,7 +904,7 @@ Errore:</value>
     <value>L'oggetto corrente è stato generato automaticamente e supporta la ridenominazione solo tramite Editor risorse gestite.</value>
   </data>
   <data name="RSE_Err_CantFindResourceFile_1Arg" xml:space="preserve">
-    <value>Il file '{0}' non è stato trovato. Potrebbe essere stato spostato o eliminato.</value>
+    <value>Il file '{0}' non è stato trovato.  È possibile che sia stato spostato o eliminato.</value>
   </data>
   <data name="RSE_Err_LoadingResource_1Arg" xml:space="preserve">
     <value>Non è possibile caricare la risorsa dal file '{0}'.</value>
@@ -934,7 +934,7 @@ Errore:</value>
     <value>Il valore della risorsa contiene dati non validi o è in un formato non corretto.</value>
   </data>
   <data name="RSE_Err_BadIdentifier_2Arg" xml:space="preserve">
-    <value>Il nome della risorsa '{0}' non può essere usato come identificatore valido perché contiene uno o più caratteri non validi: \'{1\}'. Rimuovere o sostituire tali caratteri e riprovare.</value>
+    <value>Il nome della risorsa '{0}' non può essere usato come identificatore valido perché contiene uno o più caratteri non validi: \'{1\}'.  Rimuovere o sostituire tali caratteri e riprovare.</value>
   </data>
   <data name="RSE_Err_MaxFilesLimitation" xml:space="preserve">
     <value>Sono stati specificati troppi file.  Selezionare un numero minore di file e riprovare.</value>
@@ -960,9 +960,9 @@ Errore:</value>
     <value>Non è possibile modificare il file di risorse in questo momento.</value>
   </data>
   <data name="RSE_Err_UpdateADependentFile" xml:space="preserve">
-    <value>Si sta provando a modificare un file di risorse che fa parte di un altro elemento del progetto, ad esempio un form o un controllo. La modifica del file potrebbe comportare il danneggiamento dell'elemento del progetto e di conseguenza sarà necessario eseguire un ripristino manuale. Inoltre, le modifiche apportate a questo file di risorse potrebbero andare perse se si apportano altre modifiche all'elemento del progetto.
+    <value>Si sta provando a modificare un file di risorse che fa parte di un altro elemento del progetto, ad esempio un form o un controllo.  La modifica del file potrebbe comportare il danneggiamento dell'elemento del progetto e di conseguenza sarà necessario eseguire un ripristino manuale.  Inoltre, le modifiche apportate a questo file di risorse potrebbero andare perdute se si effettuano altre modifiche all'elemento del progetto.
 
-Modificare questo file?</value>
+Modificare il file?</value>
   </data>
   <data name="RSE_Err_CantAddUnsupportedResource_1Arg" xml:space="preserve">
     <value>Non è possibile aggiungere la risorsa '{0}'.</value>
@@ -974,7 +974,7 @@ Modificare questo file?</value>
     <value>L'elemento risorsa usa il tipo '{0}', che non è supportato in questo progetto.</value>
   </data>
   <data name="RSE_Err_CantSaveResouce_1Arg" xml:space="preserve">
-    <value>Non è possibile salvare correttamente gli elementi risorsa {0}. Gli elementi verranno ignorati.</value>
+    <value>Non è possibile salvare correttamente gli elementi risorsa {0}.  Gli elementi verranno ignorati.</value>
   </data>
   <data name="RSE_Err_Name" xml:space="preserve">
     <value>'{0}'</value>
@@ -1172,7 +1172,7 @@ Modificare questo file?</value>
     <value>Specificare dove salvare il nuovo file</value>
   </data>
   <data name="RSE_Dlg_ReplaceExistingFile" xml:space="preserve">
-    <value>Il file '{0}' esiste già. Sostituirlo?</value>
+    <value>Il file '{0}' esiste già.  Sostituirlo?</value>
   </data>
   <data name="RSE_Dlg_ReplaceExistingFiles" xml:space="preserve">
     <value>I file seguenti esistono già.  Sostituirli?</value>
@@ -1193,7 +1193,7 @@ Modificare questo file?</value>
     <value>Non è stato possibile creare un'istanza della risorsa '{0}'. {1}</value>
   </data>
   <data name="RSE_Task_NonrecommendedName_1Arg" xml:space="preserve">
-    <value>È consigliabile non usare il nome della risorsa '{0}' perché potrebbe causare errori di compilazione nel codice. Scegliere un altro nome.</value>
+    <value>È consigliabile non usare il nome della risorsa '{0}' perché potrebbe causare errori di compilazione nel codice.  Scegliere un altro nome.</value>
   </data>
   <data name="RSE_Task_CantChangeCustomToolOrNamespace" xml:space="preserve">
     <value>Non è possibile impostare le proprietà dello strumento personalizzato o dello spazio dei nomi dello strumento personalizzato del file per modificare le opzioni di generazione di risorse fortemente tipizzate.  Se il file di progetto è archiviato, provare a estrarlo.</value>
@@ -1250,7 +1250,7 @@ Modificare questo file?</value>
     <value>Valore della risorsa.</value>
   </data>
   <data name="RFS_CantCreateResourcesFolder_Folder_ExMsg" xml:space="preserve">
-    <value>Non è possibile aggiungere una cartella '{0}' a questo progetto.
+    <value>Non è possibile aggiungere una cartella '{0}' al progetto.
 
 {1}</value>
   </data>
@@ -1263,19 +1263,19 @@ Modificare questo file?</value>
     <value>Non è possibile aggiungere '{0}' al progetto.</value>
   </data>
   <data name="RFS_QueryReplaceFile_File" xml:space="preserve">
-    <value>Esiste già un file denominato '{0}'. Sostituirlo?</value>
+    <value>Esiste già un file denominato '{0}'.  Sostituirlo?</value>
   </data>
   <data name="RFS_QueryReplaceFileTitle_Editor" xml:space="preserve">
     <value>{0} - File di destinazione esistente</value>
   </data>
   <data name="RFS_QueryRemoveLink_Folder_Link" xml:space="preserve">
-    <value>Nella cartella di progetto "{1}" esiste già un file collegato con il nome "{0}". Rimuoverlo?</value>
+    <value>Nella cartella di progetto "{1}" esiste già un file collegato con il nome "{0}".  Rimuoverlo?</value>
   </data>
   <data name="RFS_QueryRemoveLinkTitle_Editor" xml:space="preserve">
     <value>{0} - File di destinazione esistente</value>
   </data>
   <data name="RFS_FindNotFound_File" xml:space="preserve">
-    <value>Il file '{0}' non è stato trovato. Potrebbe essere stato spostato o eliminato.</value>
+    <value>Il file '{0}' non è stato trovato.  È possibile che sia stato spostato o eliminato.</value>
   </data>
   <data name="SD_ComboBoxItem_ConnectionStringType" xml:space="preserve">
     <value>Stringa di connessione</value>
@@ -1350,10 +1350,10 @@ Modificare questo file?</value>
     <value>Il valore dell'impostazione '{0}' è stato modificato nel file app.config.</value>
   </data>
   <data name="SD_ReplaceValueWithAppConfigValue" xml:space="preserve">
-    <value>Il valore corrente nel file con estensione settings è '{0}'
+    <value>Il valore corrente nel file .settings è '{0}'
 Il nuovo valore nel file app.config è '{1}'
 
-Aggiornare il valore nel file con estensione settings?</value>
+Aggiornare il valore nel file .settings?</value>
   </data>
   <data name="SD_FailedToLoadAppConfigValues" xml:space="preserve">
     <value>Si è verificato un errore durante la lettura del file app.config. Il file potrebbe essere danneggiato o contenere XML non valido.</value>
@@ -1486,7 +1486,7 @@ Aggiornare il valore nel file con estensione settings?</value>
     <value>Funzionalità di salvataggio automatico My.Settings</value>
   </data>
   <data name="General_MissingService" xml:space="preserve">
-    <value>Il servizio '{0}' non è stato trovato. Assicurarsi che l'applicazione sia installata correttamente.</value>
+    <value>Il servizio '{0}' non è stato trovato.  Assicurarsi che l'applicazione sia installata correttamente.</value>
   </data>
   <data name="PPG_Application_RootNamespaceJSharp" xml:space="preserve">
     <value>&amp;Pacchetto predefinito:</value>
@@ -1531,7 +1531,7 @@ Aggiornare il valore nel file con estensione settings?</value>
     <value>Si è verificato un errore durante il tentativo di apertura o creazione del file di definizione dell'applicazione (ADF) per questo progetto. {0}</value>
   </data>
   <data name="PPG_WPFApp_ErrorControlMessage_1Arg" xml:space="preserve">
-    <value>Si è verificato un errore durante il tentativo di caricamento del file di definizione dell'applicazione (ADF) per il progetto. Non è stato possibile analizzare il file '{0}'. Per correggere l'errore, modificare il file nell'editor XAML.</value>
+    <value>Si è verificato un errore durante il tentativo di caricamento del file di definizione dell'applicazione (ADF) per il progetto.  Non è stato possibile analizzare il file '{0}'.  Per correggere l'errore, modificare il file nell'editor XAML.</value>
   </data>
   <data name="PPG_WPFApp_CantReadPropertyValue" xml:space="preserve">
     <value>(Errore)</value>
@@ -1567,7 +1567,7 @@ Aggiornare il valore nel file con estensione settings?</value>
     <value>Servizi</value>
   </data>
   <data name="PPG_Services_HelpLabelText" xml:space="preserve">
-    <value>I servizi dell'applicazione client consentono alle applicazioni basate su Windows di usare accesso ASP.NET (autenticazione), ruoli e servizi profili (impostazioni). Per abilitare i servizi dell'applicazione client, è necessario impostare la versione di .NET Framework di destinazione dell'applicazione sulla versione completa di .NET Framework 3.5 o versione successiva. </value>
+    <value>I servizi dell'applicazione client consentono alle applicazioni basate su Windows di usare accesso ASP.NET (autenticazione), ruoli e servizi profili (impostazioni). Per abilitare i servizi dell'applicazione client, è necessario impostare la versione di .NET Framework di destinazione dell'applicazione sulla versione completa di .NET Framework 3.5 o versione successiva.  </value>
   </data>
   <data name="PPG_Services_HelpLabelLink" xml:space="preserve">
     <value>Altre informazioni sui servizi dell'applicazione client...</value>
@@ -1612,7 +1612,7 @@ Aggiornare il valore nel file con estensione settings?</value>
     <value>Specificare una stringa di connessione a un database di SQL Server oppure usare la stringa di connessione speciale "Data Source = |SQL/CE|", per fare in modo che in SQL Server Compact vengano generati i file di database locali per l'archiviazione offline.</value>
   </data>
   <data name="SD_ERR_UnreferencedTypeNameList_1Arg" xml:space="preserve">
-    <value>I nomi di tipi seguenti non sono stati riconosciuti: '{0}'. Assicurarsi che siano disponibili riferimenti a questi tipi.</value>
+    <value>I nomi di tipi seguenti non sono stati riconosciuti: '{0}'.  Assicurarsi che siano disponibili riferimenti a questi tipi.</value>
   </data>
   <data name="SD_ERR_DuplicateNameList_1Arg" xml:space="preserve">
     <value>Esistono già impostazioni con i nomi seguenti: {0}.</value>

--- a/src/Microsoft.VisualStudio.Editors/Resources/Designer.ja.resx
+++ b/src/Microsoft.VisualStudio.Editors/Resources/Designer.ja.resx
@@ -283,7 +283,7 @@
     <value>GUID は dddddddd-dddd-dddd-dddd-dddddddddddd の形式でなければなりません。</value>
   </data>
   <data name="PPG_Application_MyAppCommentLine1" xml:space="preserve">
-    <value>メモ: このファイルは自動生成されました。直接変更しないでください。変更したり、</value>
+    <value>メモ:このファイルは自動生成されました。直接変更しないでください。変更したり、</value>
   </data>
   <data name="PPG_Application_MyAppCommentLine2" xml:space="preserve">
     <value> ビルド エラーが発生した場合は、プロジェクト デザイナー へ移動し (プロジェクト</value>
@@ -310,19 +310,19 @@
     <value>次のイベントは MyApplication に対して利用できます:</value>
   </data>
   <data name="PPG_Application_AppEventsCommentLine3" xml:space="preserve">
-    <value>Startup: アプリケーションが開始されたとき、スタートアップ フォームが作成される前に発生します。</value>
+    <value>Startup:アプリケーションが開始されたとき、スタートアップ フォームが作成される前に発生します。</value>
   </data>
   <data name="PPG_Application_AppEventsCommentLine4" xml:space="preserve">
-    <value>Shutdown: アプリケーション フォームがすべて閉じられた後に発生します。このイベントは、アプリケーションが異常終了したときには発生しません。</value>
+    <value>Shutdown:アプリケーション フォームがすべて閉じられた後に発生します。このイベントは、アプリケーションが異常終了したときには発生しません。</value>
   </data>
   <data name="PPG_Application_AppEventsCommentLine5" xml:space="preserve">
-    <value>UnhandledException: ハンドルされていない例外がアプリケーションで発生したときに発生するイベントです。</value>
+    <value>UnhandledException:ハンドルされない例外がアプリケーションで発生したときに発生します。</value>
   </data>
   <data name="PPG_Application_AppEventsCommentLine6" xml:space="preserve">
-    <value>StartupNextInstance: 単一インスタンス アプリケーションが起動され、それが既にアクティブであるときに発生します。 </value>
+    <value>StartupNextInstance:単一インスタンス アプリケーションが起動され、それが既にアクティブであるときに発生します。 </value>
   </data>
   <data name="PPG_Application_AppEventsCommentLine7" xml:space="preserve">
-    <value>NetworkAvailabilityChanged: ネットワーク接続が接続されたとき、または切断されたときに発生します。</value>
+    <value>NetworkAvailabilityChanged:ネットワーク接続が接続されたとき、または切断されたときに発生します。</value>
   </data>
   <data name="PPG_AdvancedBuildSettings_InvalidBaseAddress" xml:space="preserve">
     <value>ベース アドレスは 8 桁以下の 16 進数である必要があります (例: 0x11000000)。</value>
@@ -1244,7 +1244,7 @@
     <value>リソースを埋め込むかリンクするかを指定します。埋め込まれたリソースはリソース ファイルに保存されます。リンクされたリソースは、ディスク上の外部の場所に存在します。</value>
   </data>
   <data name="RSE_PropDesc_Type" xml:space="preserve">
-    <value>リソースは、たとえば String や Bitmap オブジェクトとして生成されるように、この型として厳密に型指定されたリソース クラスで生成されます。</value>
+    <value>このリソースは、この型として厳密に型指定されたリソース クラスで生成されます。たとえば、リソースは String または Bitmap オブジェクトとして生成されます。</value>
   </data>
   <data name="RSE_PropDesc_Value" xml:space="preserve">
     <value>リソースの値です。</value>
@@ -1464,7 +1464,7 @@ app.config ファイルでの新しい値は '{1}' です
     <value>設定がアプリケーションごと (読み取り専用) であるか、ユーザーごと (編集可能) であるかを指定します</value>
   </data>
   <data name="SD_DESCR_SerializedSettingType" xml:space="preserve">
-    <value>設定は、たとえば String や Integer オブジェクトとして生成されるように、この型として厳密に型指定された設定クラスで生成されます。</value>
+    <value>この設定は、この型として厳密に型指定された設定クラスで生成されます。たとえば、設定は String または Integer オブジェクトとして生成されます。</value>
   </data>
   <data name="SD_DESCR_Value" xml:space="preserve">
     <value>設定用の現在の値です。</value>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.cs.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.cs.resx
@@ -127,13 +127,13 @@
     <value>Konzolová aplikace (.NET Core)</value>
   </data>
   <data name="4" xml:space="preserve">
-    <value>Projekt pro vytvoření aplikace příkazového řádku, která běží na platformě .NET Core v systémech Windows, Linux a MacOS.</value>
+    <value>Projekt pro vytvoření aplikace příkazového řádku, která běží na platformě .NET Core v systémech Windows, Linux a MacOS</value>
   </data>
   <data name="5" xml:space="preserve">
     <value>Knihovna tříd (.NET Standard)</value>
   </data>
   <data name="6" xml:space="preserve">
-    <value>Projekt pro vytvoření knihovny tříd určené pro .NET Standard.</value>
+    <value>Projekt pro vytvoření knihovny tříd určené pro .NET Standard</value>
   </data>
   <data name="7" xml:space="preserve">
     <value>Načtený editor souboru projektu</value>
@@ -145,6 +145,6 @@
     <value>Knihovna tříd (.NET Core)</value>
   </data>
   <data name="10" xml:space="preserve">
-    <value>A project for creating a class library that targets .NET Core.</value>
+    <value>Projekt pro vytvoření knihovny tříd určené pro .NET Core</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.de.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.de.resx
@@ -145,6 +145,6 @@
     <value>Klassenbibliothek (.NET Core)</value>
   </data>
   <data name="10" xml:space="preserve">
-    <value>A project for creating a class library that targets .NET Core.</value>
+    <value>Ein Projekt zum Erstellen einer Klassenbibliothek für .NET Core.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.es.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.es.resx
@@ -145,6 +145,6 @@
     <value>Biblioteca de clases (.NET Core)</value>
   </data>
   <data name="10" xml:space="preserve">
-    <value>A project for creating a class library that targets .NET Core.</value>
+    <value>Proyecto para crear una biblioteca de clases para .NET Core.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.fr.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.fr.resx
@@ -145,6 +145,6 @@
     <value>Bibliothèque de classes (.NET Core)</value>
   </data>
   <data name="10" xml:space="preserve">
-    <value>A project for creating a class library that targets .NET Core.</value>
+    <value>Projet de création d'une bibliothèque de classes ciblant .NET Core.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.it.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.it.resx
@@ -145,6 +145,6 @@
     <value>Libreria di classi (.NET Core)</value>
   </data>
   <data name="10" xml:space="preserve">
-    <value>A project for creating a class library that targets .NET Core.</value>
+    <value>Progetto per la creazione di una libreria di classi destinata a .NET Core.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.ja.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.ja.resx
@@ -145,6 +145,6 @@
     <value>クラス ライブラリ (.NET Core)</value>
   </data>
   <data name="10" xml:space="preserve">
-    <value>A project for creating a class library that targets .NET Core.</value>
+    <value>.NET Core を対象とするクラス ライブラリを作成するためのプロジェクトです。</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.ko.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.ko.resx
@@ -145,6 +145,6 @@
     <value>클래스 라이브러리(.NET Core)</value>
   </data>
   <data name="10" xml:space="preserve">
-    <value>A project for creating a class library that targets .NET Core.</value>
+    <value>.NET Core를 대상으로 하는 클래스 라이브러리를 만드는 프로젝트입니다.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.pl.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.pl.resx
@@ -145,6 +145,6 @@
     <value>Biblioteka klas (.NET Core)</value>
   </data>
   <data name="10" xml:space="preserve">
-    <value>A project for creating a class library that targets .NET Core.</value>
+    <value>Projekt służący do tworzenia biblioteki klas przeznaczonej dla środowiska .NET Core.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.pt-BR.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.pt-BR.resx
@@ -145,6 +145,6 @@
     <value>Biblioteca de Classes (.NET Core)</value>
   </data>
   <data name="10" xml:space="preserve">
-    <value>A project for creating a class library that targets .NET Core.</value>
+    <value>Um projeto para criar uma biblioteca de classes direcionada para o .NET Core.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.ru.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.ru.resx
@@ -145,6 +145,6 @@
     <value>Библиотека классов (.NET Core)</value>
   </data>
   <data name="10" xml:space="preserve">
-    <value>A project for creating a class library that targets .NET Core.</value>
+    <value>Проект для создания библиотеки классов, использующей .NET Core.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.tr.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.tr.resx
@@ -145,6 +145,6 @@
     <value>Sınıf Kitaplığı (.NET Core)</value>
   </data>
   <data name="10" xml:space="preserve">
-    <value>A project for creating a class library that targets .NET Core.</value>
+    <value>.NET Core’u hedefleyen bir sınıf kitaplığı oluşturmaya yönelik proje.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.zh-Hans.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.zh-Hans.resx
@@ -145,6 +145,6 @@
     <value>类库 (.NET Core)</value>
   </data>
   <data name="10" xml:space="preserve">
-    <value>A project for creating a class library that targets .NET Core.</value>
+    <value>用于创建目标为 .NET Core 的类库的项目。</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.zh-Hant.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.zh-Hant.resx
@@ -145,6 +145,6 @@
     <value>類別庫 (.NET Core)</value>
   </data>
   <data name="10" xml:space="preserve">
-    <value>A project for creating a class library that targets .NET Core.</value>
+    <value>專案，用於建立以 .NET Core 為目標的類別庫。</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.xlf
@@ -41,7 +41,7 @@
       </trans-unit>
       <trans-unit id="10">
         <source>A project for creating a class library that targets .NET Core.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.cs.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.cs.resx
@@ -178,6 +178,6 @@
     <value>Absolutní cesta k pracovnímu adresáři</value>
   </data>
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
-    <value>The errors on the page must be corrected prior to saving your changes.</value>
+    <value>Před uložením změn je potřeba opravit chyby na stránce.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.de.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.de.resx
@@ -178,6 +178,6 @@
     <value>Absoluter Pfad zum Arbeitsverzeichnis</value>
   </data>
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
-    <value>The errors on the page must be corrected prior to saving your changes.</value>
+    <value>Die Fehler auf der Seite müssen vor dem Speichern Ihrer Änderungen korrigiert werden.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.es.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.es.resx
@@ -178,6 +178,6 @@
     <value>Ruta de acceso absoluta al directorio de trabajo</value>
   </data>
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
-    <value>The errors on the page must be corrected prior to saving your changes.</value>
+    <value>Deben corregirse los errores de la página antes de guardar los cambios.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.fr.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.fr.resx
@@ -178,6 +178,6 @@
     <value>Chemin absolu du répertoire de travail</value>
   </data>
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
-    <value>The errors on the page must be corrected prior to saving your changes.</value>
+    <value>Les erreurs de la page doivent être corrigées avant d’enregistrer vos modifications.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.it.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.it.resx
@@ -178,6 +178,6 @@
     <value>Percorso assoluto della directory di lavoro</value>
   </data>
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
-    <value>The errors on the page must be corrected prior to saving your changes.</value>
+    <value>Prima di salvare le modifiche, è necessario correggere gli errori presenti nella pagina.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.ja.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.ja.resx
@@ -178,6 +178,6 @@
     <value>作業ディレクトリへの絶対パス</value>
   </data>
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
-    <value>The errors on the page must be corrected prior to saving your changes.</value>
+    <value>ページ上のエラーは変更を保存する前に修正する必要があります。</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.ko.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.ko.resx
@@ -178,6 +178,6 @@
     <value>작업 디렉터리의 절대 경로</value>
   </data>
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
-    <value>The errors on the page must be corrected prior to saving your changes.</value>
+    <value>페이지의 오류는 변경 내용을 저장하기 전에 수정해야 합니다.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.pl.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.pl.resx
@@ -178,6 +178,6 @@
     <value>Ścieżka bezwzględna do katalogu roboczego</value>
   </data>
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
-    <value>The errors on the page must be corrected prior to saving your changes.</value>
+    <value>Przed zapisaniem zmian należy poprawić błędy na stronie.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.pt-BR.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.pt-BR.resx
@@ -178,6 +178,6 @@
     <value>Caminho absoluto para o diretório de trabalho</value>
   </data>
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
-    <value>The errors on the page must be corrected prior to saving your changes.</value>
+    <value>Os erros na página devem ser corrigidos antes de salvar suas mudanças.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.ru.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.ru.resx
@@ -178,6 +178,6 @@
     <value>Абсолютный путь к рабочему каталогу</value>
   </data>
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
-    <value>The errors on the page must be corrected prior to saving your changes.</value>
+    <value>Устраните ошибки на странице перед тем, как сохранять изменения.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.tr.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.tr.resx
@@ -178,6 +178,6 @@
     <value>Çalışma dizininin mutlak yolu</value>
   </data>
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
-    <value>The errors on the page must be corrected prior to saving your changes.</value>
+    <value>Değişiklikleriniz kaydedilmeden önce bu sayfadaki hataların düzeltilmesi gerekiyor.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.zh-Hans.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.zh-Hans.resx
@@ -178,6 +178,6 @@
     <value>工作目录的绝对路径</value>
   </data>
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
-    <value>The errors on the page must be corrected prior to saving your changes.</value>
+    <value>保存更改前必须更正页面上的错误。</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.zh-Hant.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.zh-Hant.resx
@@ -178,6 +178,6 @@
     <value>工作目錄的絕對路徑</value>
   </data>
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
-    <value>The errors on the page must be corrected prior to saving your changes.</value>
+    <value>必須先修正頁面上的錯誤，才能儲存您的變更。</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.xlf
@@ -85,7 +85,7 @@
       </trans-unit>
       <trans-unit id="ErrorsMustBeCorrectedPriorToSaving">
         <source>The errors on the page must be corrected prior to saving your changes.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.cs.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.cs.resx
@@ -271,9 +271,9 @@ Pokud chcete projekt ladit, přidejte do řešení spustitelný projekt, který 
     <value>&amp;Zabalit {0}</value>
   </data>
   <data name="XprojMigrationFailedCannotReadReport" xml:space="preserve">
-    <value>Could not read post-migration report at '{0}'.</value>
+    <value>Nejde přečíst zprávu po migraci na {0}.</value>
   </data>
   <data name="XprojMigrationGeneralFailure" xml:space="preserve">
-    <value>Failed to migrate XProj project {0}. '{1}' exited with error code {2}.</value>
+    <value>Nepovedlo se migrovat projekt XProj {0}. {1} se ukončil s kódem chyby {2}.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.de.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.de.resx
@@ -271,9 +271,9 @@ Um das Projekt zu debuggen, fügen Sie dieser Projektmappe ein ausführbares Pro
     <value>{0} &amp;packen</value>
   </data>
   <data name="XprojMigrationFailedCannotReadReport" xml:space="preserve">
-    <value>Could not read post-migration report at '{0}'.</value>
+    <value>Der Postmigrationsbericht unter "{0}" konnte nicht gelesen werden.</value>
   </data>
   <data name="XprojMigrationGeneralFailure" xml:space="preserve">
-    <value>Failed to migrate XProj project {0}. '{1}' exited with error code {2}.</value>
+    <value>Fehler beim Migrieren des XProj-Projekts {0}. "{1}" wurde mit dem Fehlercode {2} beendet.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.es.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.es.resx
@@ -271,9 +271,9 @@ Para depurar este proyecto, agregue un proyecto ejecutable a esta solución con 
     <value>&amp;Paquete {0}</value>
   </data>
   <data name="XprojMigrationFailedCannotReadReport" xml:space="preserve">
-    <value>Could not read post-migration report at '{0}'.</value>
+    <value>No se pudo leer el informe posterior a la migración en "{0}".</value>
   </data>
   <data name="XprojMigrationGeneralFailure" xml:space="preserve">
-    <value>Failed to migrate XProj project {0}. '{1}' exited with error code {2}.</value>
+    <value>Error al migrar el proyecto XProj {0}. "{1}" finalizó con el código de error {2}.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.fr.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.fr.resx
@@ -271,9 +271,9 @@ Pour déboguer ce projet, ajoutez à cette solution un projet exécutable qui fa
     <value>&amp;Compresser {0}</value>
   </data>
   <data name="XprojMigrationFailedCannotReadReport" xml:space="preserve">
-    <value>Could not read post-migration report at '{0}'.</value>
+    <value>Impossible de lire le rapport postmigration de '{0}'.</value>
   </data>
   <data name="XprojMigrationGeneralFailure" xml:space="preserve">
-    <value>Failed to migrate XProj project {0}. '{1}' exited with error code {2}.</value>
+    <value>Échec de la migration du projet XProj {0}. '{1}' a quitté avec le code d'erreur {2}.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.it.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.it.resx
@@ -133,7 +133,7 @@ Fare clic su Ignora per ignorare le modifiche esterne. Le modifiche verranno usa
 Scegliere Salva con nome per salvare le modifiche e caricare il progetto aggiornato dal disco.
 Scegliere Rimuovi per eliminare le modifiche non salvate e caricare il progetto aggiornato dal disco.
 Scegliere Sovrascrivi per sovrascrivere le modifiche esterne con le proprie.
-Scegliere Ignora per ignorare le modifiche esterne. Le modifiche potrebbero andare perse se si chiude e riapre il progetto.
+Fare clic su Ignora per ignorare le modifiche esterne. Le modifiche potrebbero andare perse se si chiude e riapre il progetto.
     </value>
   </data>
   <data name="ConflictingProjectModificationTitle" xml:space="preserve">
@@ -215,7 +215,7 @@ Scegliere Ignora per ignorare le modifiche esterne. Le modifiche potrebbero anda
     <value>Non ci sono profili di avvio attivi configurati per questo progetto.</value>
   </data>
   <data name="DontKnowHowToRunProfile" xml:space="preserve">
-    <value>Il progetto non contiene informazioni sufficienti per eseguire il profilo {0}.</value>
+    <value>Il progetto non dispone di informazioni sufficienti per eseguire il profilo {0}.</value>
   </data>
   <data name="ErrorInProfilesFile" xml:space="preserve">
     <value>Per eseguire il progetto '{0}', è prima necessario correggere un errore nel file delle impostazioni di avvio. Per informazioni dettagliate, vedere l'elenco errori.</value>
@@ -271,9 +271,9 @@ Per eseguire il debug del progetto, aggiungere a questa soluzione un progetto es
     <value>Crea &amp;pacchetto di {0}</value>
   </data>
   <data name="XprojMigrationFailedCannotReadReport" xml:space="preserve">
-    <value>Could not read post-migration report at '{0}'.</value>
+    <value>Non è stato possibile leggere il report post-migrazione all'indirizzo '{0}'.</value>
   </data>
   <data name="XprojMigrationGeneralFailure" xml:space="preserve">
-    <value>Failed to migrate XProj project {0}. '{1}' exited with error code {2}.</value>
+    <value>Non è stato possibile eseguire la migrazione del progetto XProj {0}. '{1}' è stato terminato con il codice errore {2}.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.ja.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.ja.resx
@@ -271,9 +271,9 @@
     <value>{0} のパック(&amp;P)</value>
   </data>
   <data name="XprojMigrationFailedCannotReadReport" xml:space="preserve">
-    <value>Could not read post-migration report at '{0}'.</value>
+    <value>'{0}' で移行後のレポートを読み取れませんでした。</value>
   </data>
   <data name="XprojMigrationGeneralFailure" xml:space="preserve">
-    <value>Failed to migrate XProj project {0}. '{1}' exited with error code {2}.</value>
+    <value>XProj プロジェクト {0} の移行に失敗しました。'{1}' はエラー コード {2} で終了しました。</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.ko.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.ko.resx
@@ -271,9 +271,9 @@
     <value>{0} 팩(&amp;P)</value>
   </data>
   <data name="XprojMigrationFailedCannotReadReport" xml:space="preserve">
-    <value>Could not read post-migration report at '{0}'.</value>
+    <value>'{0}'에서 마이그레이션 후 보고서를 읽을 수 없습니다.</value>
   </data>
   <data name="XprojMigrationGeneralFailure" xml:space="preserve">
-    <value>Failed to migrate XProj project {0}. '{1}' exited with error code {2}.</value>
+    <value>XProj 프로젝트 {0}을(를) 마이그레이션하지 못했습니다. {2} 오류 코드와 함께 '{1}'이(가) 종료되었습니다.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.pl.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.pl.resx
@@ -271,9 +271,9 @@ Aby debugować ten projekt, dodaj projekt wykonywalny do tego rozwiązania, któ
     <value>&amp;Spakuj element {0}</value>
   </data>
   <data name="XprojMigrationFailedCannotReadReport" xml:space="preserve">
-    <value>Could not read post-migration report at '{0}'.</value>
+    <value>Nie można odczytać raportu po migracji w „{0}”.</value>
   </data>
   <data name="XprojMigrationGeneralFailure" xml:space="preserve">
-    <value>Failed to migrate XProj project {0}. '{1}' exited with error code {2}.</value>
+    <value>Nie można migrować projektu XProj {0}. Element „{1}” zakończył działanie z kodem błędu {2}.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.pt-BR.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.pt-BR.resx
@@ -271,9 +271,9 @@ Para depurar esse projeto, adicione um projeto executável a essa solução que 
     <value>&amp;Pacote {0}</value>
   </data>
   <data name="XprojMigrationFailedCannotReadReport" xml:space="preserve">
-    <value>Could not read post-migration report at '{0}'.</value>
+    <value>Não foi possível ler o relatório pós-migração em '{0}'.</value>
   </data>
   <data name="XprojMigrationGeneralFailure" xml:space="preserve">
-    <value>Failed to migrate XProj project {0}. '{1}' exited with error code {2}.</value>
+    <value>Falha ao migrar o projeto XProj {0}. '{1}' fechado com o código de erro {2}.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.ru.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.ru.resx
@@ -271,9 +271,9 @@
     <value>&amp;Упаковать {0}</value>
   </data>
   <data name="XprojMigrationFailedCannotReadReport" xml:space="preserve">
-    <value>Could not read post-migration report at '{0}'.</value>
+    <value>Не удалось прочитать отчет, формируемый после миграции, в "{0}".</value>
   </data>
   <data name="XprojMigrationGeneralFailure" xml:space="preserve">
-    <value>Failed to migrate XProj project {0}. '{1}' exited with error code {2}.</value>
+    <value>Не удалось переместить проект XProj "{0}". "{1}" завершено с кодом ошибки {2}.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.tr.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.tr.resx
@@ -271,9 +271,9 @@ Bu projede hata ayıklamak için bu çözüme, kitaplık projesine başvuran bir
     <value>{0} öğesini &amp;paketle</value>
   </data>
   <data name="XprojMigrationFailedCannotReadReport" xml:space="preserve">
-    <value>Could not read post-migration report at '{0}'.</value>
+    <value>'{0}' üzerindeki geçiş sonrası raporu okunamadı.</value>
   </data>
   <data name="XprojMigrationGeneralFailure" xml:space="preserve">
-    <value>Failed to migrate XProj project {0}. '{1}' exited with error code {2}.</value>
+    <value>{0} XProj projesinin geçişi sağlanamadı. '{1}', {2} hata koduyla çıkış yaptı.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.zh-Hans.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.zh-Hans.resx
@@ -271,9 +271,9 @@
     <value>打包 {0} (&amp;P)</value>
   </data>
   <data name="XprojMigrationFailedCannotReadReport" xml:space="preserve">
-    <value>Could not read post-migration report at '{0}'.</value>
+    <value>无法读取“{0}”处的迁移后报表。</value>
   </data>
   <data name="XprojMigrationGeneralFailure" xml:space="preserve">
-    <value>Failed to migrate XProj project {0}. '{1}' exited with error code {2}.</value>
+    <value>XProj 项目 {0} 迁移失败。“{1}”退出时出现错误代码 {2}。</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.zh-Hant.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.zh-Hant.resx
@@ -271,9 +271,9 @@
     <value>封裝 {0}(&amp;P)</value>
   </data>
   <data name="XprojMigrationFailedCannotReadReport" xml:space="preserve">
-    <value>Could not read post-migration report at '{0}'.</value>
+    <value>無法讀取位於 '{0}' 的移轉後報告。</value>
   </data>
   <data name="XprojMigrationGeneralFailure" xml:space="preserve">
-    <value>Failed to migrate XProj project {0}. '{1}' exited with error code {2}.</value>
+    <value>無法移轉 XProj 檔案 {0}。'{1}' 已結束，出現錯誤碼 {2}。</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.xlf
@@ -205,11 +205,11 @@ In order to debug this project, add an executable project to this solution which
       </trans-unit>
       <trans-unit id="XprojMigrationFailedCannotReadReport">
         <source>Could not read post-migration report at '{0}'.</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="XprojMigrationGeneralFailure">
         <source>Failed to migrate XProj project {0}. '{1}' exited with error code {2}.</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/CSharp.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/CSharp.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="CSharpFile" DisplayName="Soubor C#" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="Kompilátor C#" />
-  <ItemType Name="AdditionalFiles" DisplayName="C# analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="Další soubor analyzátoru C#" />
   <FileExtension Name=".cs" ContentType="CSharpFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/PackageReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="PackageReference" DisplayName="Balíček" PageTemplate="generic" Description="Balíček" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" />
+    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectPackageReferences" />
   </Rule.DataSource>
   <StringProperty Name="Description" ReadOnly="True" Visible="True" DisplayName="Popis" Description="Popis závislosti" />
   <StringProperty Name="Version" ReadOnly="True" DisplayName="Verze" Description="Verze závislosti">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/VisualBasic.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/VisualBasic.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="VisualBasicFile" DisplayName="Soubor VB" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="Kompilátor VB" />
-  <ItemType Name="AdditionalFiles" DisplayName="VB analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="Další soubor analyzátoru VB" />
   <FileExtension Name=".vb" ContentType="VisualBasicFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/CSharp.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/CSharp.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="CSharpFile" DisplayName="C#-Datei" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="C#-Compiler" />
-  <ItemType Name="AdditionalFiles" DisplayName="C# analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="C#-Analyse – zusätzliche Datei" />
   <FileExtension Name=".cs" ContentType="CSharpFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/PackageReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="PackageReference" DisplayName="Paket" PageTemplate="generic" Description="Paket" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" />
+    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectPackageReferences" />
   </Rule.DataSource>
   <StringProperty Name="Description" ReadOnly="True" Visible="True" DisplayName="Beschreibung" Description="Beschreibung der Abhängigkeit." />
   <StringProperty Name="Version" ReadOnly="True" DisplayName="Version" Description="Version der Abhängigkeit.">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/VisualBasic.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/VisualBasic.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="VisualBasicFile" DisplayName="VB-Datei" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="VB-Compiler" />
-  <ItemType Name="AdditionalFiles" DisplayName="VB analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="VB-Analyse – zusätzliche Datei" />
   <FileExtension Name=".vb" ContentType="VisualBasicFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/CSharp.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/CSharp.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="CSharpFile" DisplayName="Archivo de C#" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="Compilador de C#" />
-  <ItemType Name="AdditionalFiles" DisplayName="C# analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="Archivo adicional analizador de C#" />
   <FileExtension Name=".cs" ContentType="CSharpFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/PackageReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="PackageReference" DisplayName="Paquete" PageTemplate="generic" Description="Paquete" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" />
+    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectPackageReferences" />
   </Rule.DataSource>
   <StringProperty Name="Description" ReadOnly="True" Visible="True" DisplayName="Descripción" Description="Descripción de la dependencia." />
   <StringProperty Name="Version" ReadOnly="True" DisplayName="Versión" Description="Versión de la dependencia.">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/VisualBasic.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/VisualBasic.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="VisualBasicFile" DisplayName="Archivo VB" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="Compilador VB" />
-  <ItemType Name="AdditionalFiles" DisplayName="VB analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="Archivo adicional analizador de VB" />
   <FileExtension Name=".vb" ContentType="VisualBasicFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/AdditionalFiles.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/AdditionalFiles.xaml
@@ -21,7 +21,7 @@
       <DataSource Persistence="Intrinsic" ItemType="AdditionalFiles" PersistedName="Identity" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="FullPath" DisplayName="Chemin complet" ReadOnly="true" Category="Misc" Description="Emplacement du fichier.">
+  <StringProperty Name="FullPath" DisplayName="Chemin d'accès complet" ReadOnly="true" Category="Misc" Description="Emplacement du fichier.">
     <StringProperty.DataSource>
       <DataSource Persistence="Intrinsic" ItemType="AdditionalFiles" PersistedName="FullPath" />
     </StringProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/CSharp.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/CSharp.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="CSharpFile" DisplayName="Fichier C#" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="Compilateur C#" />
-  <ItemType Name="AdditionalFiles" DisplayName="C# analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="Fichier supplémentaire de l'analyseur C#" />
   <FileExtension Name=".cs" ContentType="CSharpFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/EmbeddedResource.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/EmbeddedResource.xaml
@@ -21,7 +21,7 @@
       <DataSource Persistence="Intrinsic" ItemType="EmbeddedResource" PersistedName="Identity" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="FullPath" DisplayName="Chemin complet" ReadOnly="true" Category="Misc" Description="Emplacement du fichier.">
+  <StringProperty Name="FullPath" DisplayName="Chemin d'accès complet" ReadOnly="true" Category="Misc" Description="Emplacement du fichier.">
     <StringProperty.DataSource>
       <DataSource Persistence="Intrinsic" ItemType="EmbeddedResource" PersistedName="FullPath" />
     </StringProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/None.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/None.xaml
@@ -21,7 +21,7 @@
       <DataSource Persistence="Intrinsic" ItemType="None" PersistedName="Identity" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="FullPath" DisplayName="Chemin complet" ReadOnly="true" Category="Misc" Description="Emplacement du fichier.">
+  <StringProperty Name="FullPath" DisplayName="Chemin d'accès complet" ReadOnly="true" Category="Misc" Description="Emplacement du fichier.">
     <StringProperty.DataSource>
       <DataSource Persistence="Intrinsic" ItemType="None" PersistedName="FullPath" />
     </StringProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/PackageReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="PackageReference" DisplayName="Package" PageTemplate="generic" Description="Package" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" />
+    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectPackageReferences" />
   </Rule.DataSource>
   <StringProperty Name="Description" ReadOnly="True" Visible="True" DisplayName="Description" Description="Description de la dépendance." />
   <StringProperty Name="Version" ReadOnly="True" DisplayName="Version" Description="Version de la dépendance.">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedAssemblyReference.xaml
@@ -31,7 +31,7 @@
       <DataSource PersistedName="{}{Identity}" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="ResolvedPath" ReadOnly="True" DisplayName="Chemin" Description="Emplacement du fichier référencé.">
+  <StringProperty Name="ResolvedPath" ReadOnly="True" DisplayName="Chemin d'accès" Description="Emplacement du fichier référencé.">
     <StringProperty.DataSource>
       <DataSource PersistedName="Identity" />
     </StringProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/VisualBasic.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/VisualBasic.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="VisualBasicFile" DisplayName="Fichier VB" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="Compilateur VB" />
-  <ItemType Name="AdditionalFiles" DisplayName="VB analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="Fichier supplémentaire de l'analyseur VB" />
   <FileExtension Name=".vb" ContentType="VisualBasicFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/AdditionalFiles.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/AdditionalFiles.xaml
@@ -9,7 +9,7 @@
     <Category Name="Misc" DisplayName="Varie" />
   </Rule.Categories>
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Azione di compilazione" Category="Advanced" Description="Descrizione della relazione tra il file e i processi di compilazione e distribuzione." EnumProvider="ItemTypes" />
-  <EnumProperty Name="CopyToOutputDirectory" DisplayName="Copia nella directory di output" Category="Advanced" Description="Consente di specificare se il file di origine verrà copiato nella directory di output.">
+  <EnumProperty Name="CopyToOutputDirectory" DisplayName="Copia nella directory di output" Category="Advanced" Description="Specifica se il file di origine verrà copiato nella directory di output.">
     <EnumValue Name="Never" DisplayName="Non copiare" />
     <EnumValue Name="Always" DisplayName="Copia sempre" />
     <EnumValue Name="PreserveNewest" DisplayName="Copia se più recente" />
@@ -49,7 +49,7 @@
     </StringProperty.DataSource>
   </StringProperty>
   <StringProperty Name="LastGenOutput" Visible="false" Description="Nome dell'ultimo file generato come risultato di SFG." />
-  <BoolProperty Name="DesignTime" Visible="false" Description="Valore che indica se per questo file esiste una finestra di progettazione." />
+  <BoolProperty Name="DesignTime" Visible="false" Description="Valore che indica se per il file esiste una finestra di progettazione." />
   <BoolProperty Name="AutoGen" Visible="false" Description="Valore che indica se si tratta di un file generato." />
   <StringProperty Name="CustomTool" Visible="false" Description="Proprietà DTE per l'accesso alla proprietà Generator.">
     <StringProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/CSharp.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/CSharp.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="CSharpFile" DisplayName="File C#" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="Compilatore C#" />
-  <ItemType Name="AdditionalFiles" DisplayName="C# analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="File aggiuntivo dell'analizzatore C#" />
   <FileExtension Name=".cs" ContentType="CSharpFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/CSharp.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/CSharp.xaml
@@ -9,7 +9,7 @@
     <Category Name="Misc" DisplayName="Varie" />
   </Rule.Categories>
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Azione di compilazione" Category="Advanced" Description="Descrizione della relazione tra il file e i processi di compilazione e distribuzione." EnumProvider="ItemTypes" />
-  <EnumProperty Name="CopyToOutputDirectory" DisplayName="Copia nella directory di output" Category="Advanced" Description="Consente di specificare se il file di origine verrà copiato nella directory di output.">
+  <EnumProperty Name="CopyToOutputDirectory" DisplayName="Copia nella directory di output" Category="Advanced" Description="Specifica se il file di origine verrà copiato nella directory di output.">
     <EnumValue Name="Never" DisplayName="Non copiare" />
     <EnumValue Name="Always" DisplayName="Copia sempre" />
     <EnumValue Name="PreserveNewest" DisplayName="Copia se più recente" />
@@ -37,6 +37,6 @@
   </StringProperty>
   <StringProperty Name="SubType" Visible="false" />
   <StringProperty Name="LastGenOutput" Visible="false" Description="Nome dell'ultimo file generato come risultato di SFG." />
-  <BoolProperty Name="DesignTime" Visible="false" Description="Valore che indica se per questo file esiste una finestra di progettazione." />
+  <BoolProperty Name="DesignTime" Visible="false" Description="Valore che indica se per il file esiste una finestra di progettazione." />
   <BoolProperty Name="AutoGen" Visible="false" Description="Valore che indica se si tratta di un file generato." />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/EmbeddedResource.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/EmbeddedResource.xaml
@@ -9,7 +9,7 @@
     <Category Name="Misc" DisplayName="Varie" />
   </Rule.Categories>
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Azione di compilazione" Category="Advanced" Description="Descrizione della relazione tra il file e i processi di compilazione e distribuzione." EnumProvider="ItemTypes" />
-  <EnumProperty Name="CopyToOutputDirectory" DisplayName="Copia nella directory di output" Category="Advanced" Description="Consente di specificare se il file di origine verrà copiato nella directory di output.">
+  <EnumProperty Name="CopyToOutputDirectory" DisplayName="Copia nella directory di output" Category="Advanced" Description="Specifica se il file di origine verrà copiato nella directory di output.">
     <EnumValue Name="Never" DisplayName="Non copiare" />
     <EnumValue Name="Always" DisplayName="Copia sempre" />
     <EnumValue Name="PreserveNewest" DisplayName="Copia se più recente" />
@@ -49,7 +49,7 @@
     </StringProperty.DataSource>
   </StringProperty>
   <StringProperty Name="LastGenOutput" Visible="false" Description="Nome dell'ultimo file generato come risultato di SFG." />
-  <BoolProperty Name="DesignTime" Visible="false" Description="Valore che indica se per questo file esiste una finestra di progettazione." />
+  <BoolProperty Name="DesignTime" Visible="false" Description="Valore che indica se per il file esiste una finestra di progettazione." />
   <BoolProperty Name="AutoGen" Visible="false" Description="Valore che indica se si tratta di un file generato." />
   <StringProperty Name="CustomTool" Visible="false" Description="Proprietà DTE per l'accesso alla proprietà Generator.">
     <StringProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/None.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/None.xaml
@@ -9,7 +9,7 @@
     <Category Name="Misc" DisplayName="Varie" />
   </Rule.Categories>
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Azione di compilazione" Category="Advanced" Description="Descrizione della relazione tra il file e i processi di compilazione e distribuzione." EnumProvider="ItemTypes" />
-  <EnumProperty Name="CopyToOutputDirectory" DisplayName="Copia nella directory di output" Category="Advanced" Description="Consente di specificare se il file di origine verrà copiato nella directory di output.">
+  <EnumProperty Name="CopyToOutputDirectory" DisplayName="Copia nella directory di output" Category="Advanced" Description="Specifica se il file di origine verrà copiato nella directory di output.">
     <EnumValue Name="Never" DisplayName="Non copiare" />
     <EnumValue Name="Always" DisplayName="Copia sempre" />
     <EnumValue Name="PreserveNewest" DisplayName="Copia se più recente" />
@@ -49,7 +49,7 @@
     </StringProperty.DataSource>
   </StringProperty>
   <StringProperty Name="LastGenOutput" Visible="false" Description="Nome dell'ultimo file generato come risultato di SFG." />
-  <BoolProperty Name="DesignTime" Visible="false" Description="Valore che indica se per questo file esiste una finestra di progettazione." />
+  <BoolProperty Name="DesignTime" Visible="false" Description="Valore che indica se per il file esiste una finestra di progettazione." />
   <BoolProperty Name="AutoGen" Visible="false" Description="Valore che indica se si tratta di un file generato." />
   <StringProperty Name="CustomTool" Visible="false" Description="Proprietà DTE per l'accesso alla proprietà Generator.">
     <StringProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/PackageReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="PackageReference" DisplayName="Pacchetto" PageTemplate="generic" Description="Pacchetto" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" />
+    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectPackageReferences" />
   </Rule.DataSource>
   <StringProperty Name="Description" ReadOnly="True" Visible="True" DisplayName="Descrizione" Description="Descrizione della dipendenza." />
   <StringProperty Name="Version" ReadOnly="True" DisplayName="Versione" Description="Versione della dipendenza.">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedAssemblyReference.xaml
@@ -21,12 +21,12 @@
       <DataSource Persistence="ProjectFile" ItemType="Reference" HasConfigurationCondition="False" />
     </BoolProperty.DataSource>
   </BoolProperty>
-  <EnumProperty Name="FileType" ReadOnly="True" Visible="False" DisplayName="Tipo di file" Description="Tipo di file del riferimento.">
+  <EnumProperty Name="FileType" ReadOnly="True" Visible="False" DisplayName="Tipo di file" Description="Il tipo di file del riferimento.">
     <EnumValue Name="Assembly" DisplayName="Assembly .NET" />
     <EnumValue Name="ActiveX" DisplayName="Libreria di tipi COM" />
     <EnumValue Name="Native Assembly" DisplayName="Assembly nativo" />
   </EnumProperty>
-  <StringProperty Name="Identity" ReadOnly="True" DisplayName="Identità" Description="Identità di sicurezza dell'assembly con riferimenti (vedere System.Reflection.Assembly.Evidence o System.Security.Policy.Evidence).">
+  <StringProperty Name="Identity" ReadOnly="True" DisplayName="Identità" Description="Identità di sicurezza dell'assembly a cui viene fatto riferimento (vedere System.Reflection.Assembly.Evidence o System.Security.Policy.Evidence).">
     <StringProperty.DataSource>
       <DataSource PersistedName="{}{Identity}" />
     </StringProperty.DataSource>
@@ -37,14 +37,14 @@
     </StringProperty.DataSource>
   </StringProperty>
   <StringProperty Name="RuntimeVersion" ReadOnly="True" Visible="False" DisplayName="Versione runtime" Description="Versione del runtime .NET con cui è stato compilato l'assembly."></StringProperty>
-  <BoolProperty Name="SpecificVersion" DisplayName="Versione specifica" Description="Indica se è possibile risolvere l'assembly indipendentemente dalle regole di multitargeting per la risoluzione degli assembly.">
+  <BoolProperty Name="SpecificVersion" DisplayName="Versione specifica" Description="Indica se è possibile risolvere l'assembly senza tener conto delle regole di multitargeting.">
     <BoolProperty.DataSource>
       <DataSource Persistence="AssemblyReference" ItemType="Reference" HasConfigurationCondition="False" />
     </BoolProperty.DataSource>
   </BoolProperty>
-  <BoolProperty Name="StrongName" ReadOnly="True" Visible="False" DisplayName="Nome sicuro" Description="True indica che il riferimento è stato firmato con una coppia di chiavi."></BoolProperty>
+  <BoolProperty Name="StrongName" ReadOnly="True" Visible="False" DisplayName="Nome sicuro" Description="Se ha valore True, significa che il riferimento è stato firmato con una coppia di chiavi."></BoolProperty>
   <StringProperty Name="Version" ReadOnly="True" DisplayName="Versione" Description="Versione del riferimento."></StringProperty>
-  <StringProperty Name="RequiredTargetFramework" DisplayName="Framework di destinazione obbligatorio" Visible="False" />
+  <StringProperty Name="RequiredTargetFramework" DisplayName="Framework di destinazione necessario" Visible="False" />
   <StringProperty Name="HintPath" Visible="false" />
   <StringProperty Name="SDKIdentity" Visible="false" />
   <!-- This is the metadata we store on the reference item when we add it. -->

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/VisualBasic.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/VisualBasic.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="VisualBasicFile" DisplayName="File VB" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="Compilatore VB" />
-  <ItemType Name="AdditionalFiles" DisplayName="VB analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="File aggiuntivo dell'analizzatore VB" />
   <FileExtension Name=".vb" ContentType="VisualBasicFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/CSharp.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/CSharp.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="CSharpFile" DisplayName="C# ファイル" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="C# コンパイラ" />
-  <ItemType Name="AdditionalFiles" DisplayName="C# analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="C# アナライザー追加ファイル" />
   <FileExtension Name=".cs" ContentType="CSharpFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/PackageReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="PackageReference" DisplayName="パッケージ" PageTemplate="generic" Description="パッケージ" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" />
+    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectPackageReferences" />
   </Rule.DataSource>
   <StringProperty Name="Description" ReadOnly="True" Visible="True" DisplayName="説明" Description="依存関係の説明。" />
   <StringProperty Name="Version" ReadOnly="True" DisplayName="バージョン" Description="依存関係のバージョン。">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/VisualBasic.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/VisualBasic.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="VisualBasicFile" DisplayName="VB ファイル" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="VB コンパイラ" />
-  <ItemType Name="AdditionalFiles" DisplayName="VB analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="VB アナライザー追加ファイル" />
   <FileExtension Name=".vb" ContentType="VisualBasicFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/CSharp.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/CSharp.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="CSharpFile" DisplayName="C# 파일" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="C# 컴파일러" />
-  <ItemType Name="AdditionalFiles" DisplayName="C# analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="C# 분석기 추가 파일" />
   <FileExtension Name=".cs" ContentType="CSharpFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/PackageReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="PackageReference" DisplayName="패키지" PageTemplate="generic" Description="패키지" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" />
+    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectPackageReferences" />
   </Rule.DataSource>
   <StringProperty Name="Description" ReadOnly="True" Visible="True" DisplayName="설명" Description="종속성 설명입니다." />
   <StringProperty Name="Version" ReadOnly="True" DisplayName="버전" Description="종속성의 버전입니다.">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/VisualBasic.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/VisualBasic.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="VisualBasicFile" DisplayName="VB 파일" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="VB 컴파일러" />
-  <ItemType Name="AdditionalFiles" DisplayName="VB analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="VB 분석기 추가 파일" />
   <FileExtension Name=".vb" ContentType="VisualBasicFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/CSharp.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/CSharp.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="CSharpFile" DisplayName="Plik C#" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="Kompilator C#" />
-  <ItemType Name="AdditionalFiles" DisplayName="C# analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="Dodatkowy plik analizatora C#" />
   <FileExtension Name=".cs" ContentType="CSharpFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/PackageReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="PackageReference" DisplayName="Pakiet" PageTemplate="generic" Description="Pakiet" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" />
+    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectPackageReferences" />
   </Rule.DataSource>
   <StringProperty Name="Description" ReadOnly="True" Visible="True" DisplayName="Opis" Description="Opis zależności." />
   <StringProperty Name="Version" ReadOnly="True" DisplayName="Wersja" Description="Wersja zależności.">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/VisualBasic.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/VisualBasic.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="VisualBasicFile" DisplayName="Plik VB" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="Kompilator VB" />
-  <ItemType Name="AdditionalFiles" DisplayName="VB analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="Dodatkowy plik analizatora VB" />
   <FileExtension Name=".vb" ContentType="VisualBasicFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/CSharp.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/CSharp.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="CSharpFile" DisplayName="Arquivo C#" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="Compilador C#" />
-  <ItemType Name="AdditionalFiles" DisplayName="C# analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="Arquivo adicional do analisador C#" />
   <FileExtension Name=".cs" ContentType="CSharpFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/PackageReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="PackageReference" DisplayName="Pacote" PageTemplate="generic" Description="Pacote" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" />
+    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectPackageReferences" />
   </Rule.DataSource>
   <StringProperty Name="Description" ReadOnly="True" Visible="True" DisplayName="Descrição" Description="Descrição da dependência." />
   <StringProperty Name="Version" ReadOnly="True" DisplayName="Versão" Description="Versão da independência.">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/VisualBasic.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/VisualBasic.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="VisualBasicFile" DisplayName="arquivo do VB" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="compilador do VB" />
-  <ItemType Name="AdditionalFiles" DisplayName="VB analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="Arquivo adicional do analisador VB" />
   <FileExtension Name=".vb" ContentType="VisualBasicFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/CSharp.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/CSharp.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="CSharpFile" DisplayName="Файл C#" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="Компилятор C#" />
-  <ItemType Name="AdditionalFiles" DisplayName="C# analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="Дополнительный файл анализатора C#" />
   <FileExtension Name=".cs" ContentType="CSharpFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/PackageReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="PackageReference" DisplayName="Пакет" PageTemplate="generic" Description="Пакет" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" />
+    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectPackageReferences" />
   </Rule.DataSource>
   <StringProperty Name="Description" ReadOnly="True" Visible="True" DisplayName="Описание" Description="Описание зависимости." />
   <StringProperty Name="Version" ReadOnly="True" DisplayName="Версия" Description="Версия зависимости.">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/VisualBasic.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/VisualBasic.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="VisualBasicFile" DisplayName="Файл VB" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="Компилятор VB" />
-  <ItemType Name="AdditionalFiles" DisplayName="VB analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="Дополнительный файл анализатора VB" />
   <FileExtension Name=".vb" ContentType="VisualBasicFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/CSharp.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/CSharp.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="CSharpFile" DisplayName="C# dosyası" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="C# derleyicisi" />
-  <ItemType Name="AdditionalFiles" DisplayName="C# analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="C# çözümleyicisi ek dosyası" />
   <FileExtension Name=".cs" ContentType="CSharpFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/PackageReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="PackageReference" DisplayName="Paket" PageTemplate="generic" Description="Paket" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" />
+    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectPackageReferences" />
   </Rule.DataSource>
   <StringProperty Name="Description" ReadOnly="True" Visible="True" DisplayName="Açıklama" Description="Bağımlılık açıklaması" />
   <StringProperty Name="Version" ReadOnly="True" DisplayName="Sürüm" Description="Bağımlılık sürümü.">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/VisualBasic.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/VisualBasic.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="VisualBasicFile" DisplayName="VB dosyası" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="VB derleyicisi" />
-  <ItemType Name="AdditionalFiles" DisplayName="VB analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="VB çözümleyicisi ek dosyası" />
   <FileExtension Name=".vb" ContentType="VisualBasicFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.ProjectItemsSchema.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.ProjectItemsSchema.xaml.xlf
@@ -13,7 +13,7 @@
       </trans-unit>
       <trans-unit id="ItemType|AdditionalFiles|DisplayName">
         <source>C# analyzer additional file</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.ProjectItemsSchema.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.ProjectItemsSchema.xaml.xlf
@@ -13,7 +13,7 @@
       </trans-unit>
       <trans-unit id="ItemType|AdditionalFiles|DisplayName">
         <source>VB analyzer additional file</source>
-        <note></note>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/CSharp.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/CSharp.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="CSharpFile" DisplayName="C# 文件" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="C# 编译器" />
-  <ItemType Name="AdditionalFiles" DisplayName="C# analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="C# 分析器其他文件" />
   <FileExtension Name=".cs" ContentType="CSharpFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/PackageReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="PackageReference" DisplayName="打包" PageTemplate="generic" Description="打包" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" />
+    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectPackageReferences" />
   </Rule.DataSource>
   <StringProperty Name="Description" ReadOnly="True" Visible="True" DisplayName="说明" Description="依赖项说明。" />
   <StringProperty Name="Version" ReadOnly="True" DisplayName="版本" Description="依赖项的版本。">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/VisualBasic.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/VisualBasic.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="VisualBasicFile" DisplayName="VB 文件" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="VB 编译器" />
-  <ItemType Name="AdditionalFiles" DisplayName="VB analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="VB 分析器其他文件" />
   <FileExtension Name=".vb" ContentType="VisualBasicFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/CSharp.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/CSharp.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="CSharpFile" DisplayName="C# 檔案" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="C# 編譯器" />
-  <ItemType Name="AdditionalFiles" DisplayName="C# analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="C# 分析器其他檔案" />
   <FileExtension Name=".cs" ContentType="CSharpFile" />
 </ProjectSchemaDefinitions>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/PackageReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="PackageReference" DisplayName="套件" PageTemplate="generic" Description="套件" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" />
+    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectPackageReferences" />
   </Rule.DataSource>
   <StringProperty Name="Description" ReadOnly="True" Visible="True" DisplayName="說明" Description="相依性描述。" />
   <StringProperty Name="Version" ReadOnly="True" DisplayName="版本" Description="相依性的版本。">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/VisualBasic.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/VisualBasic.ProjectItemsSchema.xaml
@@ -3,6 +3,6 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
   <ContentType Name="VisualBasicFile" DisplayName="VB 檔案" ItemType="Compile"></ContentType>
   <ItemType Name="Compile" DisplayName="VB 編譯器" />
-  <ItemType Name="AdditionalFiles" DisplayName="VB analyzer additional file" />
+  <ItemType Name="AdditionalFiles" DisplayName="VB 分析器其他檔案" />
   <FileExtension Name=".vb" ContentType="VisualBasicFile" />
 </ProjectSchemaDefinitions>


### PR DESCRIPTION
**Customer scenario**

Some strings are still not translated as they were added after last handback

**Bugs this fixes:**

[VSO 370232](https://devdiv.visualstudio.com/DevDiv/_workitems?id=370232&_a=edit)

**Workarounds, if any**

None

**Risk**

Low, small number of new strings are now translated.

**Performance impact**

None

**Is this a regression from a previous update?**

No. The strings are new.

**Root cause analysis:**

We didn't miss anything. Strings were added after last handback.

**How was the bug found?**

N/A

@srivatsn @dotnet/project-system 