### PR TITLE
Fix assert in DTAR when a project has unresolved assembly

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/Reference3Factory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/Reference3Factory.cs
@@ -16,7 +16,7 @@ namespace VSLangProj80
             return mock.Object;
         }
 
-        public static Reference3 CreateAssemblyReference(string name, string version, string path = null)
+        public static Reference3 CreateAssemblyReference(string name, string version = null, string path = null, prjReferenceType referenceType = prjReferenceType.prjReferenceTypeAssembly)
         {
             var mock = new Mock<Reference3>();
             mock.SetupGet(r => r.Name)
@@ -32,7 +32,7 @@ namespace VSLangProj80
                 .Returns(path != null);
 
             mock.SetupGet(r => r.Type)
-                .Returns(prjReferenceType.prjReferenceTypeAssembly);
+                .Returns(referenceType);
 
             return mock.Object;            
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/References/DesignTimeAssemblyResolutionTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/References/DesignTimeAssemblyResolutionTests.cs
@@ -149,6 +149,33 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             Assert.Equal(0u, resolvedAssemblyPaths);
         }
 
+        [Fact]
+        public void ResolveAssemblyPathInTargetFx_UnresolvedAssembly_SetsResolvedAssemblyPathsToZero()
+        {   // BUG: https://devdiv.visualstudio.com/DevDiv/_workitems?id=368836
+
+            var reference = Reference3Factory.CreateAssemblyReference("mscorlib", "1.0.0.0");
+
+            var resolution = CreateInstance(reference);
+
+            var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { "mscorlib" }, 1, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
+
+            Assert.Equal(VSConstants.S_OK, result);
+            Assert.Equal(0u, resolvedAssemblyPaths);
+        }
+
+        [Fact]
+        public void ResolveAssemblyPathInTargetFx_NonAssembly_SetsResolvedAssemblyPathsToZero()
+        {   
+            var reference = Reference3Factory.CreateAssemblyReference("mscorlib", "1.0.0.0", referenceType: prjReferenceType.prjReferenceTypeActiveX);
+
+            var resolution = CreateInstance(reference);
+
+            var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { "mscorlib" }, 1, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
+
+            Assert.Equal(VSConstants.S_OK, result);
+            Assert.Equal(0u, resolvedAssemblyPaths);
+        }
+
         [Theory]
         [InlineData(null)]
         [InlineData("")]
@@ -198,7 +225,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         [InlineData("encyclopædia",                                                                 "encyclopaedia",    "",                 @"C:\System.dll")]
         [InlineData("System, Version=1.0.0.0",                                                      "System",           "",                 @"C:\System.dll")]
         [InlineData("System, Version=2.0.0.0",                                                      "System",           "1.0.0.0",          @"C:\System.dll")]
-        public void ResolveAssemblyPathInTargetFx_NameThatDoesNotMatch_SetsResolvedAssemblysToZero(string input, string name, string version, string path)
+        public void ResolveAssemblyPathInTargetFx_NameThatDoesNotMatch_SetsResolvedAssemblyPathsToZero(string input, string name, string version, string path)
         {
             var reference = Reference3Factory.CreateAssemblyReference(name, version, path);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
@@ -134,10 +134,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
                 foreach (Reference3 reference in project.References.OfType<Reference3>())
                 {
                     // We only want resolved assembly references
-                    if (reference.Type != prjReferenceType.prjReferenceTypeAssembly && !reference.Resolved)
-                        continue;
-
-                    resolvedReferences[reference.Name] = new ResolvedReference(reference.Path, TryParseVersionOrNull(reference.Version));
+                    if (reference.Type == prjReferenceType.prjReferenceTypeAssembly && reference.Resolved)
+                    {
+                        resolvedReferences[reference.Name] = new ResolvedReference(reference.Path, TryParseVersionOrNull(reference.Version));
+                    }
                 }
             }
 


### PR DESCRIPTION
**Customer scenario**

Clicking Publish, opening a project or generally interacting with the project system (such as opening a RESX) with unresolved references shows a dialog stating:

```
The project system has encountered an error.

An internal error occurred. Please contact Microsoft Product Support Services.
```

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems?id=368836&_a=edit
https://github.com/dotnet/roslyn-project-system/issues/1223

**Workarounds, if any**

Fix/remove the unresolved reference. While clicking OK in some situations will result in no behavior change - other situations such as not being able to open a RESX will have no workaround other than fixing the reference[1].

[1] Note: In some situations, which I'm still debugging, certain references (System.Data in particular) are being considered unresolved even though they aren't, so there's nothing obvious for the user to fix. Update, this is caused by https://github.com/aspnet/Tooling/issues/961

**Risk**

Low

**Performance impact**

None

**Is this a regression from a previous update?**

No

**Root cause analysis:**

Missed test case.

**How was the bug found?**

Ad hoc testing and customer reported.

**Dev Note**

Our check for resolved assemblies was broken, and was causing us to pass through unresolved references which was later causing us to assert because the resolved path was null.