### PR TITLE
Added edit project file command to the ITEMNODE context menu

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Menus.vsct
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Menus.vsct
@@ -50,6 +50,9 @@
       <Group guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJECT_EDITFILE" priority="0x0180">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_MENU_PROJECT"/>
       </Group>
+      <Group guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJECT_EDITFILE" priority="0x0180">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE"/>
+      </Group>
     </Groups>
 
     <Buttons>


### PR DESCRIPTION
**Customer scenario**

If CPS initially loads a project, but later encounters some condition that causes a project fault, it will load a faulted tree. This has a different context menu than the standard project node, and thus the user can't right-click and edit their project file to fix the issue.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems?id=370385&fullScreen=false&_a=edit, tracking https://github.com/dotnet/roslyn-project-system/issues/1177.

**Workarounds, if any**

Find the file on disk and edit with an external editor. The "Unload Project" command is also not shown, so there is no ability to edit the project file in VS.

**Risk**

Minimal. This will cause `EditProjectFileCommand` to be called on all Item Nodes, but the status is conditioned on whether or not the node is root. Manual testing has determined that this isn't an issue.

**Performance impact**

Low. 'EditProjectFileCommand.GetCommandStatus` will be called more often now, but the number of commands that are already called is very large, and this check executes on a background thread, checking one property and returning false in all new cases.

**Is this a regression from a previous update?**

Regression from old csproj functionality.

**Root cause analysis:**

CPS scenarios with faulted trees are relatively hard to get into, so no one noticed the different context menu there.

**How was the bug found?**

MVP testing.

Tagging @dotnet/project-system @davkean @lifengl for review.