### PR TITLE
Fully Preserve Project File Formatting

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
@@ -19,7 +19,8 @@ namespace Microsoft.VisualStudio.Packaging
         public const string DefaultCapabilities = ProjectCapability.AppDesigner + "; " +
                                                   ProjectCapability.EditAndContinue + "; " +
                                                   ProjectCapability.HandlesOwnReload + "; " +
-                                                  ProjectCapability.OpenProjectFile;
+                                                  ProjectCapability.OpenProjectFile + "; " +
+                                                  ProjectCapability.PreserveFormatting;
 
         public ManagedProjectSystemPackage()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/TempFileTextBufferManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/TempFileTextBufferManager.cs
@@ -85,16 +85,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         public async Task ResetBufferAsync()
         {
             var projectXml = await _projectXmlAccessor.GetProjectXmlAsync().ConfigureAwait(false);
+            var existingText = await ReadBufferXmlAsync().ConfigureAwait(false);
 
-            // We compare the text we want to write with the text currently in the buffer, ignoring whitespace. If they're
-            // the same, then we don't write anything. We ignore whitespace because of
-            // https://github.com/dotnet/roslyn-project-system/issues/743. Once we can read the whitespace correctly from
-            // the msbuild model, we can stop stripping whitespace for this comparison. This instance is tracked by
-            // https://github.com/dotnet/roslyn-project-system/issues/1094
-            var normalizedExistingText = _whitespaceRegex.Replace(await ReadBufferXmlAsync().ConfigureAwait(true), "");
-            var normalizedProjectText = _whitespaceRegex.Replace(projectXml, "");
-
-            if (!normalizedExistingText.Equals(normalizedProjectText, StringComparison.Ordinal))
+            if (!existingText.Equals(projectXml, StringComparison.Ordinal))
             {
                 await _threadingService.SwitchToUIThread();
                 // If the docdata is not dirty, we just update the buffer to avoid the file reload pop-up. Otherwise,
@@ -123,7 +116,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
                     {
                         _textBuffer.SetStateFlags(oldFlags);
                     }
-
                 }
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
@@ -28,5 +28,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public const string ReferenceManagerSharedProjects = nameof(ReferenceManagerSharedProjects);
         public const string ReferenceManagerWinRT = nameof(ReferenceManagerWinRT);
         public const string Pack = nameof(Pack); // Keep this in sync with Microsoft.VisualStudio.Editors.ProjectCapability.Pack
+        public const string PreserveFormatting = nameof(PreserveFormatting);
     }
 }


### PR DESCRIPTION
**Customer scenario**

Currently, we strip whitespace from project files, and don't respect whitespace changes when deciding if the project file editor buffer is up to date. This change reacts to https://mseng.visualstudio.com/DefaultCollection/VSIDEProj/_git/VSIDEProj.CPS/pullrequest/175897, enabling us to preserve all project file formatting.

**Bugs this fixes:**

Fixes https://github.com/dotnet/roslyn-project-system/issues/1094, https://github.com/dotnet/roslyn-project-system/issues/743, https://github.com/dotnet/roslyn-project-system/issues/512. 

**Workarounds, if any**

Edit with an external editor, and don't use the NuGet UI to add packages.

**Risk**

Very little risk on our side, the main risk is in CPS/MSBuild. 

**Performance impact**

We actually improve performance with this change, as we're no longer normalizing text to do a whitespace-insensitive comparison.

**Is this a regression from a previous update?**

No, known issue.

**How was the bug found?**

Internal testing.

Tagging @dotnet/project-system @davkean @jviau for review.