### PR TITLE
Property page save bug. Issue 1265

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -658,14 +658,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
         /// <summary>
         /// Replaces the current set of profiles with the contents of profiles. If changes were
-        /// made, the file will be checked out and saved.
+        /// made, the file will be checked out and saved. Note it ignores the value of the active profile
+        /// as this setting is controlled by a user property.
         /// </summary>
         public async Task UpdateAndSaveSettingsAsync(ILaunchSettings newSettings)
         {
             // Make sure the profiles are copied. We don't want them to mutate.
-            ILaunchSettings newSnapshot = new LaunchSettings(newSettings.Profiles, newSettings.GlobalSettings, newSettings.ActiveProfile?.Name);
+            var curSnapshot = CurrentSnapshot;
+            var activeProfile = curSnapshot?.ActiveProfile?.Name;
 
-            // Being saved and changeMade are different since the active profile change does not require them to be saved.
+            ILaunchSettings newSnapshot = new LaunchSettings(newSettings.Profiles, newSettings.GlobalSettings, activeProfile);
+
             await CheckoutSettingsFileAsync().ConfigureAwait(false);
 
             SaveSettingsToDisk(newSettings);
@@ -683,6 +686,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             {
                 return CurrentSnapshot;
             }
+
             await _firstSnapshotCompletionSource.Task.TryWaitForCompleteOrTimeout(timeout).ConfigureAwait(false);
             return CurrentSnapshot;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -664,10 +664,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public async Task UpdateAndSaveSettingsAsync(ILaunchSettings newSettings)
         {
             // Make sure the profiles are copied. We don't want them to mutate.
-            var curSnapshot = CurrentSnapshot;
-            var activeProfile = curSnapshot?.ActiveProfile?.Name;
+            var activeProfileName = ActiveProfile?.Name;
 
-            ILaunchSettings newSnapshot = new LaunchSettings(newSettings.Profiles, newSettings.GlobalSettings, activeProfile);
+            ILaunchSettings newSnapshot = new LaunchSettings(newSettings.Profiles, newSettings.GlobalSettings, activeProfileName);
 
             await CheckoutSettingsFileAsync().ConfigureAwait(false);
 


### PR DESCRIPTION
**Customer scenario**
Editing profiles on the debug page can change the active profile, however, the debug drop down does not reflect the change. Thus when they run their application they think that are running say, profile1, when in fact they are running profile 2. 

**Bugs this fixes:**
https://github.com/dotnet/roslyn-project-system/issues/1265

**Workarounds, if any**
The workaround is to change the selection in the debug dropdown however, it is not obvious that is the problem.

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**
Low.  A simple change to the save function to keep the active profile stable. Only affects saving profiles

**Performance impact**
None. One or two small comparisons on save.

**Is this a regression from a previous update?**
Regression caused by the feature to make the debug property page extensible.

**Root cause analysis:**
Added units to cover this scenario.

**How was the bug found?**
Adhoc testing of the web debug page changes