### PR TITLE
Remove the Launch URL checkbox from console apps debug page

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/ExecutableLaunchSettingsUIProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/ExecutableLaunchSettingsUIProvider.cs
@@ -45,11 +45,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         }
 
         /// <summary>
-        /// All controls are supported
+        /// Launch url is not supported
         /// </summary>
         public bool ShouldEnableProperty(string propertyName)
         {
-            return true;
+            return  string.Equals(propertyName, UIProfilePropertyName.LaunchUrl, System.StringComparison.OrdinalIgnoreCase) ? false : true;
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/ProjectLaunchSettingsUIProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/ProjectLaunchSettingsUIProvider.cs
@@ -46,11 +46,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         }
 
         /// <summary>
-        /// Disable the executable controls
+        /// Disable the executable and launch url controls
         /// </summary>
         public bool ShouldEnableProperty(string propertyName)
         {
-            return string.Equals(propertyName, UIProfilePropertyName.Executable, System.StringComparison.OrdinalIgnoreCase)? false : true;
+            return string.Equals(propertyName, UIProfilePropertyName.Executable, System.StringComparison.OrdinalIgnoreCase) || 
+                   string.Equals(propertyName, UIProfilePropertyName.LaunchUrl, System.StringComparison.OrdinalIgnoreCase) ? false : true;
         }
 
         /// <summary>


### PR DESCRIPTION
**Customer scenario**
The project and executable settings show the launch URL checkbox for Console\Classlibary projects. Since the this field is not hooked up internally, it does nothing. Customers will wonder why launch url is enabled yet their browser is not launched.

**Bugs this fixes:**
https://github.com/dotnet/roslyn-project-system/issues/1264

**Workarounds, if any**
Just ignore the field

**Risk**
Low. Very simple change to hide this field for these providers

**Performance impact**
None. Just UI updating

**Is this a regression from a previous update?**
No. We shipped previous versions with this enabled. It was an oversight.

**Root cause analysis:**
Not much adhoc testing of the property pages

**How was the bug found?**
Adhoc testing of the web extensions to the property pages
