### PR TITLE
Get Assembly name from PropertyControlData in Build Property page

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
@@ -74,6 +74,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                      New SingleConfigPropertyControlData(SingleConfigPropertyControlData.Configs.Release,
                         VsProjPropId.VBPROJPROPID_OutputPath, "OutputPath", txtOutputPath, New Control() {lblOutputPath}),
                      New PropertyControlData(VsProjPropId.VBPROJPROPID_DocumentationFile, "DocumentationFile", txtXMLDocumentationFile, AddressOf XMLDocumentationFileInit, AddressOf XMLDocumentationFileGet, ControlDataFlags.None, New Control() {txtXMLDocumentationFile, chkXMLDocumentationFile}),
+                     New PropertyControlData(VsProjPropId.VBPROJPROPID_AssemblyName, "AssemblyName", Nothing, AddressOf AssemblyNameSet, Nothing),
                      New PropertyControlData(VsProjPropId.VBPROJPROPID_RegisterForComInterop, "RegisterForComInterop", chkRegisterForCOM, AddressOf RegisterForCOMInteropSet, AddressOf RegisterForCOMInteropGet),
                      New PropertyControlData(VsProjPropId110.VBPROJPROPID_OutputTypeEx, "OutputTypeEx", Nothing, AddressOf OutputTypeSet, Nothing),
                      New SingleConfigPropertyControlData(SingleConfigPropertyControlData.Configs.Release,
@@ -164,6 +165,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private Sub AdvancedButton_Click(sender As Object, e As EventArgs) Handles btnAdvanced.Click
             ShowChildPage(My.Resources.Designer.PPG_AdvancedBuildSettings_Title, GetType(AdvBuildSettingsPropPage), HelpKeywords.CSProjPropAdvancedCompile)
         End Sub
+
+        Private Function AssemblyNameSet(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
+            ' Setting the Assembly Name should not affect already defined values
+            Return True
+        End Function
 
         Private Function ShouldEnableRegisterForCOM() As Boolean
 


### PR DESCRIPTION
During the computation of the Xml Documentation Path, the property page had no access to the AssemblyName value. Introducing a PropertyControlData mapping to the AssemblyName fixes this problem. 

@dotnet/project-system for review

**Customer scenario**

Enabling XML Documentation file, generates invalid path

**Bugs this fixes:**

#1280 and [VSO bug](https://devdiv.visualstudio.com/DevDiv/_workitems?id=371252&_a=edit)

**Workarounds, if any**

Users have to manually hand edit files to a valid name

**Risk**

Low, since the PropertyControl has no UI component associated with it.

**Performance impact**

Low

**Is this a regression from a previous update?**

No

**Root cause analysis:**

We are discovering these issues as we are looking at the interaction between Property pages and CPS more closely

**How was the bug found?**

Adhoc testing