### PR TITLE
Ensure that we pass absolute reference paths to Roslyn Language Servi…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="ProjectSystem\Debug\LaunchSettingsProviderTests.cs" />
     <Compile Include="ProjectSystem\Debug\LaunchSettingsTests.cs" />
     <Compile Include="ProjectSystem\Imaging\ProjectImageProviderAggregatorTests.cs" />
+    <Compile Include="ProjectSystem\LanguageServices\Handlers\MetadataReferenceItemHandlerTests.cs" />
     <Compile Include="ProjectSystem\LanguageServices\Handlers\SourceItemHandlerTests.cs" />
     <Compile Include="ProjectSystem\PhysicalProjectTreeStorageTests.cs" />
     <Compile Include="ProjectSystem\Properties\AssemblyInfoPropertiesProviderTests.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IWorkspaceProjectContextFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IWorkspaceProjectContextFactory.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
     internal static class IWorkspaceProjectContextFactory
     {
-        public static IWorkspaceProjectContext Create(UnconfiguredProject project, Action<string> addSourceFile = null, Action<string> removeSourceFile = null)
+        public static IWorkspaceProjectContext CreateForSourceFiles(UnconfiguredProject project, Action<string> addSourceFile = null, Action<string> removeSourceFile = null)
         {
             var context = new Mock<IWorkspaceProjectContext>();
 
@@ -27,6 +27,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             {
                 context.Setup(c => c.RemoveSourceFile(It.IsAny<string>()))
                     .Callback<string>(p1 => removeSourceFile(p1));
+            }
+
+            return context.Object;
+        }
+
+        public static IWorkspaceProjectContext CreateForMetadataReferences(UnconfiguredProject project, Action<string> addMetadataReference = null, Action<string> removeMetadataReference = null)
+        {
+            var context = new Mock<IWorkspaceProjectContext>();
+
+            context.SetupGet(c => c.ProjectFilePath)
+                .Returns(project.FullPath);
+
+            if (addMetadataReference != null)
+            {
+                context.Setup(c => c.AddMetadataReference(It.IsAny<string>(), It.IsAny<MetadataReferenceProperties>()))
+                    .Callback<string, MetadataReferenceProperties>((p1, p2) => addMetadataReference(p1));
+            }
+
+            if (removeMetadataReference != null)
+            {
+                context.Setup(c => c.RemoveMetadataReference(It.IsAny<string>()))
+                    .Callback<string>(p1 => removeMetadataReference(p1));
             }
 
             return context.Object;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
@@ -56,14 +56,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             var handler = new MetadataReferenceItemHandler(project);
             var projectDir = Path.GetDirectoryName(project.FullPath);
-            var added = CSharpCommandLineParser.Default.Parse(args: new[] { @"/reference:Assembly1.dll", @"/reference:C:\ProjectFolder\Assembly2.dll", @"/reference:..\ProjectFolder\Assembly2.dll" }, baseDirectory: projectDir, sdkDirectory: null);
+            var added = CSharpCommandLineParser.Default.Parse(args: new[] { @"/reference:Assembly1.dll", @"/reference:C:\ProjectFolder\Assembly2.dll", @"/reference:..\ProjectFolder\Assembly3.dll" }, baseDirectory: projectDir, sdkDirectory: null);
             var removed = CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null);
 
             handler.Handle(added: added, removed: removed, context: context, isActiveContext: true);
 
-            Assert.Equal(2, referencesPushedToWorkspace.Count);
+            Assert.Equal(3, referencesPushedToWorkspace.Count);
             Assert.Contains(@"C:\ProjectFolder\Assembly1.dll", referencesPushedToWorkspace);
             Assert.Contains(@"C:\ProjectFolder\Assembly2.dll", referencesPushedToWorkspace);
+            Assert.Contains(@"C:\ProjectFolder\Assembly3.dll", referencesPushedToWorkspace);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
+{
+    [ProjectSystemTrait]
+    public class MetadataReferenceItemHandlerTests
+    {
+        [Fact]
+        public void Constructor()
+        {
+            Assert.Throws<ArgumentNullException>(() => new MetadataReferenceItemHandler(project: null));
+            new MetadataReferenceItemHandler(UnconfiguredProjectFactory.Create());
+        }
+
+        [Fact]
+        public void DuplicateMetadataReferencesPushedToWorkspace()
+        {
+            var referencesPushedToWorkspace = new HashSet<string>(StringComparers.Paths);
+            Action<string> onReferenceAdded = s => referencesPushedToWorkspace.Add(s);
+            Action<string> onReferenceRemoved = s => referencesPushedToWorkspace.Remove(s);
+
+            var project = UnconfiguredProjectFactory.Create(filePath: @"C:\Myproject.csproj");
+            var context = IWorkspaceProjectContextFactory.CreateForMetadataReferences(project, onReferenceAdded, onReferenceRemoved);
+
+            var handler = new MetadataReferenceItemHandler(project);
+            var projectDir = Path.GetDirectoryName(project.FullPath);
+            var added = CSharpCommandLineParser.Default.Parse(args: new[] { @"/reference:C:\Assembly1.dll", @"/reference:C:\Assembly2.dll", @"/reference:C:\Assembly1.dll" }, baseDirectory: projectDir, sdkDirectory: null);
+            var empty = CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null);
+
+            handler.Handle(added: added, removed: empty, context: context, isActiveContext: true);
+
+            Assert.Equal(2, referencesPushedToWorkspace.Count);
+            Assert.Contains(@"C:\Assembly1.dll", referencesPushedToWorkspace);
+            Assert.Contains(@"C:\Assembly2.dll", referencesPushedToWorkspace);
+
+            var removed = CSharpCommandLineParser.Default.Parse(args: new[] { @"/reference:C:\Assembly1.dll", @"/reference:C:\Assembly1.dll" }, baseDirectory: projectDir, sdkDirectory: null);
+            handler.Handle(added: empty, removed: removed, context: context, isActiveContext: true);
+
+            Assert.Equal(1, referencesPushedToWorkspace.Count);
+            Assert.Contains(@"C:\Assembly2.dll", referencesPushedToWorkspace);
+        }
+
+        [Fact]
+        public void RootedReferencesPushedToWorkspace()
+        {
+            var referencesPushedToWorkspace = new HashSet<string>(StringComparers.Paths);
+            Action<string> onReferenceAdded = s => referencesPushedToWorkspace.Add(s);
+            Action<string> onReferenceRemoved = s => referencesPushedToWorkspace.Remove(s);
+
+            var project = UnconfiguredProjectFactory.Create(filePath: @"C:\ProjectFolder\Myproject.csproj");
+            var context = IWorkspaceProjectContextFactory.CreateForMetadataReferences(project, onReferenceAdded, onReferenceRemoved);
+
+            var handler = new MetadataReferenceItemHandler(project);
+            var projectDir = Path.GetDirectoryName(project.FullPath);
+            var added = CSharpCommandLineParser.Default.Parse(args: new[] { @"/reference:Assembly1.dll", @"/reference:C:\ProjectFolder\Assembly2.dll", @"/reference:..\ProjectFolder\Assembly2.dll" }, baseDirectory: projectDir, sdkDirectory: null);
+            var removed = CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null);
+
+            handler.Handle(added: added, removed: removed, context: context, isActiveContext: true);
+
+            Assert.Equal(2, referencesPushedToWorkspace.Count);
+            Assert.Contains(@"C:\ProjectFolder\Assembly1.dll", referencesPushedToWorkspace);
+            Assert.Contains(@"C:\ProjectFolder\Assembly2.dll", referencesPushedToWorkspace);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandlerTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Action<string> onSourceFileRemoved = s => sourceFilesPushedToWorkspace.Remove(s);
 
             var project = UnconfiguredProjectFactory.Create(filePath: @"C:\Myproject.csproj");
-            var context = IWorkspaceProjectContextFactory.Create(project, onSourceFileAdded, onSourceFileRemoved);
+            var context = IWorkspaceProjectContextFactory.CreateForSourceFiles(project, onSourceFileAdded, onSourceFileRemoved);
 
             var handler = new SourceItemHandler(project, IPhysicalProjectTreeFactory.Create());
             var projectDir = Path.GetDirectoryName(project.FullPath);
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Action<string> onSourceFileRemoved = s => sourceFilesPushedToWorkspace.Remove(s);
 
             var project = UnconfiguredProjectFactory.Create(filePath: @"C:\ProjectFolder\Myproject.csproj");
-            var context = IWorkspaceProjectContextFactory.Create(project, onSourceFileAdded, onSourceFileRemoved);
+            var context = IWorkspaceProjectContextFactory.CreateForSourceFiles(project, onSourceFileAdded, onSourceFileRemoved);
 
             var handler = new SourceItemHandler(project, IPhysicalProjectTreeFactory.Create());
             var projectDir = Path.GetDirectoryName(project.FullPath);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
@@ -11,11 +11,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     /// </summary>
     [Export(typeof(ILanguageServiceCommandLineHandler))]
     [AppliesTo(ProjectCapability.CSharpOrVisualBasicLanguageService)]
-    internal class MetadataReferenceFilesLanguageServiceItemHandler : ILanguageServiceCommandLineHandler
+    internal class MetadataReferenceItemHandler : ILanguageServiceCommandLineHandler
     {
+        private readonly UnconfiguredProject _unconfiguredProject;
+
         [ImportingConstructor]
-        public MetadataReferenceFilesLanguageServiceItemHandler(UnconfiguredProject project)
+        public MetadataReferenceItemHandler(UnconfiguredProject project)
         {
+            Requires.NotNull(project, nameof(project));
+
+            _unconfiguredProject = project;
         }
 
         public void Handle(CommandLineArguments added, CommandLineArguments removed, IWorkspaceProjectContext context, bool isActiveContext)
@@ -25,12 +30,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             foreach (CommandLineReference reference in removed.MetadataReferences)
             {
-                context.RemoveMetadataReference(reference.Reference);
+                var fullPath = _unconfiguredProject.MakeRooted(reference.Reference);
+                context.RemoveMetadataReference(fullPath);
             }
 
             foreach (CommandLineReference reference in added.MetadataReferences)
             {
-                context.AddMetadataReference(reference.Reference, reference.Properties);
+                var fullPath = _unconfiguredProject.MakeRooted(reference.Reference);
+                context.AddMetadataReference(fullPath, reference.Properties);
             }
         }
     }


### PR DESCRIPTION
…ces.

**Customer scenario**

For certain assembly references which get added with relative paths, we end up with no intellisense and squiggles for anything referenced from those assemblies, even though build works just fine. For the repro case in the bug, it happened to be COM references that are passed to the command line parser with a `/link` argument with a relative path.

**Bugs this fixes:**

Fixes #786

**Workarounds, if any**

None.

**Risk**

None, we just making an additional call to UnconfiguredProject.MakeRooted(path) for all added/removed references.

**Performance impact**

None.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

Normal references are always resolved to full paths by the MSBuild evaluation and hence intellisense work fine for them. However, COM references (and possibly others?) get resolved to relative paths, and were not tested until reported in #786.
 
**How did we miss it?  What tests are we adding to guard against it in the future?**

I have added unit tests which fail before this change, and pass after the fix. Also verified the repro case manually and it works fine now.

**How was the bug found?**

Customer reported.