### PR TITLE
Added removing global json from the solution after migration

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests.csproj
@@ -71,6 +71,7 @@
     <Compile Include="ProjectSystem\VS\LanguageServices\CSharpCodeDomProviderTests.cs" />
     <Compile Include="ProjectSystem\VS\Properties\CSharpProjectGuidProviderTests.cs" />
     <Compile Include="ProjectSystem\VS\CSharpProjectCompatibilityProviderTests.cs" />
+    <Compile Include="ProjectSystem\VS\Xproj\GlobalJsonRemoverTests.cs" />
     <Compile Include="ProjectSystem\VS\Xproj\MigrateXprojProjectFactoryTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/GlobalJsonRemoverTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/GlobalJsonRemoverTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using EnvDTE;
 using EnvDTE80;
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 using Microsoft.VisualStudio.Shell.Interop;
 using Moq;
 using Xunit;
@@ -24,6 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         [Fact]
         public void GlobalJsonRemover_RemovesJson_WhenExists()
         {
+            UnitTestHelper.IsRunningUnitTests = true;
             var solution = IVsSolutionFactory.CreateWithSolutionDirectory(DirectoryInfoCallback);
             var projectItem = ProjectItemFactory.Create();
             var dteSolution = SolutionFactory.ImplementFindProjectItem(path =>
@@ -57,6 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         [Fact]
         public void GlobalJsonRemover_NoJson_DoesntCrash()
         {
+            UnitTestHelper.IsRunningUnitTests = true;
             var solution = IVsSolutionFactory.CreateWithSolutionDirectory(DirectoryInfoCallback);
             var dteSolution = SolutionFactory.ImplementFindProjectItem(path =>
             {
@@ -88,6 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         [Fact]
         public void GlobalJsonRemover_AfterRemoval_UnadvisesEvents()
         {
+            UnitTestHelper.IsRunningUnitTests = true;
             var solution = IVsSolutionFactory.CreateWithSolutionDirectory(DirectoryInfoCallback);
             var projectItem = ProjectItemFactory.Create();
             var dteSolution = SolutionFactory.ImplementFindProjectItem(path =>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/GlobalJsonRemoverTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/GlobalJsonRemoverTests.cs
@@ -1,0 +1,132 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using EnvDTE;
+using EnvDTE80;
+using Microsoft.VisualStudio.Shell.Interop;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
+{
+    [ProjectSystemTrait]
+    public class GlobalJsonRemoverTests
+    {
+        private const string Directory = @"C:\Temp";
+
+        [Fact]
+        public void GlobalJsonRemover_InvalidServiceProvider_Throws()
+        {
+            Assert.Throws<ArgumentNullException>("serviceProvider", () => new GlobalJsonRemover(null));
+        }
+
+        [Fact]
+        public void GlobalJsonRemover_RemovesJson_WhenExists()
+        {
+            var solution = IVsSolutionFactory.CreateWithSolutionDirectory(DirectoryInfoCallback);
+            var projectItem = ProjectItemFactory.Create();
+            var dteSolution = SolutionFactory.ImplementFindProjectItem(path =>
+            {
+                Assert.Equal(Path.Combine(Directory, "global.json"), path);
+                return projectItem;
+            });
+            var dte = DteFactory.ImplementSolution(() => dteSolution);
+
+            var serviceProvider = IServiceProviderFactory.ImplementGetService(t =>
+            {
+                if (typeof(SVsSolution) == t)
+                {
+                    return solution;
+                }
+
+                if (typeof(DTE) == t)
+                {
+                    return dte;
+                }
+
+                Assert.False(true);
+                throw new InvalidOperationException();
+            });
+
+            var remover = new GlobalJsonRemover(serviceProvider);
+            Assert.Equal(VSConstants.S_OK, remover.OnAfterOpenSolution(null, 0));
+            Mock.Get(projectItem).Verify(p => p.Remove(), Times.Once);
+        }
+
+        [Fact]
+        public void GlobalJsonRemover_NoJson_DoesntCrash()
+        {
+            var solution = IVsSolutionFactory.CreateWithSolutionDirectory(DirectoryInfoCallback);
+            var dteSolution = SolutionFactory.ImplementFindProjectItem(path =>
+            {
+                Assert.Equal(Path.Combine(Directory, "global.json"), path);
+                return null;
+            });
+            var dte = DteFactory.ImplementSolution(() => dteSolution);
+
+            var serviceProvider = IServiceProviderFactory.ImplementGetService(t =>
+            {
+                if (typeof(SVsSolution) == t)
+                {
+                    return solution;
+                }
+
+                if (typeof(DTE) == t)
+                {
+                    return dte;
+                }
+
+                Assert.False(true);
+                throw new InvalidOperationException();
+            });
+
+            var remover = new GlobalJsonRemover(serviceProvider);
+            Assert.Equal(VSConstants.S_OK, remover.OnAfterOpenSolution(null, 0));
+        }
+
+        [Fact]
+        public void GlobalJsonRemover_AfterRemoval_UnadvisesEvents()
+        {
+            var solution = IVsSolutionFactory.CreateWithSolutionDirectory(DirectoryInfoCallback);
+            var projectItem = ProjectItemFactory.Create();
+            var dteSolution = SolutionFactory.ImplementFindProjectItem(path =>
+            {
+                Assert.Equal(Path.Combine(Directory, "global.json"), path);
+                return projectItem;
+            });
+            var dte = DteFactory.ImplementSolution(() => dteSolution);
+
+            var serviceProvider = IServiceProviderFactory.ImplementGetService(t =>
+            {
+                if (typeof(SVsSolution) == t)
+                {
+                    return solution;
+                }
+
+                if (typeof(DTE) == t)
+                {
+                    return dte;
+                }
+
+                Assert.False(true);
+                throw new InvalidOperationException();
+            });
+
+            var remover = new GlobalJsonRemover(serviceProvider)
+            {
+                SolutionCookie = 1234
+            };
+            Assert.Equal(VSConstants.S_OK, remover.OnAfterOpenSolution(null, 0));
+            Mock.Get(solution).Verify(s => s.UnadviseSolutionEvents(1234), Times.Once);
+        }
+
+        private int DirectoryInfoCallback(out string directory, out string solutionFile, out string opts)
+        {
+            directory = Directory;
+            solutionFile = null;
+            opts = null;
+            return VSConstants.S_OK;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
@@ -389,11 +389,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
 
             var migrator = CreateInstance(ProcessRunnerFactory.CreateRunner(), fileSystem);
 
+            GlobalJsonRemover remover = null;
+
+            var solution = IVsSolutionFactory.Implement((IVsSolutionEvents events, out uint cookie) =>
+            {
+                remover = (GlobalJsonRemover)events;
+                cookie = 1234;
+                return VSConstants.S_OK;
+            }, IVsSolutionFactory.DefaultUnadviseCallback, CreateSolutionInfo());
+
             var loggedMessages = new List<LogMessage>();
             var logger = IVsUpgradeLoggerFactory.CreateLogger(loggedMessages);
             var globalJsonBackedUp = Path.Combine(BackupLocation, "global.json");
 
-            migrator.BackupAndDeleteGlobalJson(SlnLocation, BackupLocation, XprojLocation, ProjectName, logger);
+            migrator.BackupAndDeleteGlobalJson(SlnLocation, solution, BackupLocation, XprojLocation, ProjectName, logger);
             Assert.False(fileSystem.FileExists(GlobalJsonLocation));
             Assert.True(fileSystem.FileExists(globalJsonBackedUp));
             Assert.Equal(1, loggedMessages.Count);
@@ -404,6 +413,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
                 Message = string.Format(VSResources.MigrationBackupFile, GlobalJsonLocation, globalJsonBackedUp),
                 Project = ProjectName
             }, loggedMessages[0]);
+            Assert.NotNull(remover);
+            Assert.Equal(1234u, remover.SolutionCookie);
         }
 
         [Fact]
@@ -416,10 +427,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
                 fileSystem.Create(CsprojLocation);
             });
 
+            GlobalJsonRemover remover = null;
+            var solution = IVsSolutionFactory.Implement((IVsSolutionEvents events, out uint cookie) =>
+            {
+                remover = (GlobalJsonRemover)events;
+                cookie = 1234;
+                return VSConstants.S_OK;
+            }, IVsSolutionFactory.DefaultUnadviseCallback, CreateSolutionInfo());
+
             var loggedMessages = new List<LogMessage>();
             var logger = IVsUpgradeLoggerFactory.CreateLogger(loggedMessages);
 
-            var migrator = CreateInstance(processRunner, fileSystem);
+            var migrator = CreateInstance(processRunner, fileSystem, solution);
 
             Assert.Equal(VSConstants.S_OK, migrator.UpgradeProject(XprojLocation, 0, BackupLocation, out string outCsproj, logger, out int upgradeRequired, out Guid newProjectFactory));
             Assert.True(fileSystem.FileExists(CsprojLocation));
@@ -434,11 +453,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
             Assert.Equal(CsprojLocation, outCsproj);
             Assert.Equal((int)__VSPPROJECTUPGRADEVIAFACTORYREPAIRFLAGS.VSPUVF_PROJECT_ONEWAYUPGRADE, upgradeRequired);
             Assert.Equal(Guid.Parse(CSharpProjectSystemPackage.ProjectTypeGuid), newProjectFactory);
+            Assert.NotNull(remover);
+            Assert.Equal(1234u, remover.SolutionCookie);
         }
 
-        private MigrateXprojProjectFactory CreateInstance(ProcessRunner processRunner, IFileSystem fileSystem)
+        private MigrateXprojProjectFactory CreateInstance(ProcessRunner processRunner, IFileSystem fileSystem, IVsSolution solutionParam = null)
         {
-            var solution = IVsSolutionFactory.CreateWithSolutionDirectory(CreateSolutionInfo());
+            var solution = solutionParam ?? IVsSolutionFactory.CreateWithSolutionDirectory(CreateSolutionInfo());
             var serviceProvider = IServiceProviderFactory.Create(typeof(SVsSolution), solution);
 
             var migrator = new MigrateXprojProjectFactory(processRunner, fileSystem, serviceProvider);

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Flavor;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -459,6 +460,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
 
         private MigrateXprojProjectFactory CreateInstance(ProcessRunner processRunner, IFileSystem fileSystem, IVsSolution solutionParam = null)
         {
+            UnitTestHelper.IsRunningUnitTests = true;
             var solution = solutionParam ?? IVsSolutionFactory.CreateWithSolutionDirectory(CreateSolutionInfo());
             var serviceProvider = IServiceProviderFactory.Create(typeof(SVsSolution), solution);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj
@@ -53,6 +53,7 @@
     </Compile>
     <Compile Include="ProjectSystem\VS\LanguageServices\CSharpLanguageFeaturesProvider.cs" />
     <Compile Include="ProjectSystem\VS\CSharpProjectGuidProvider.cs" />
+    <Compile Include="ProjectSystem\VS\Xproj\GlobalJsonRemover.cs" />
     <Compile Include="ProjectSystem\VS\Xproj\MigrateXprojProjectFactory.cs" />
     <Compile Include="ProjectSystem\VS\Xproj\MigrationError.cs" />
     <Compile Include="ProjectSystem\VS\Xproj\MigrationReport.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/GlobalJsonRemover.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/GlobalJsonRemover.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using EnvDTE;
+using EnvDTE80;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
+{
+    internal class GlobalJsonRemover : IVsSolutionEvents
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public GlobalJsonRemover(IServiceProvider serviceProvider)
+        {
+            Requires.NotNull(serviceProvider, nameof(serviceProvider));
+            _serviceProvider = serviceProvider;
+        }
+
+        public int OnAfterOpenSolution(object pUnkReserved, int fNewSolution)
+        {
+            var dte = _serviceProvider.GetService<DTE2, DTE>();
+            var solution = _serviceProvider.GetService<IVsSolution, SVsSolution>();
+            try
+            {
+                Verify.HResult(solution.GetSolutionInfo(out string directory, out string solutionFile, out string optsFile));
+                ProjectItem globalJson = dte.Solution.FindProjectItem(Path.Combine(directory, "global.json"));
+                globalJson?.Remove();
+                return VSConstants.S_OK;
+            }
+            finally
+            {
+                Verify.HResult(solution.UnadviseSolutionEvents(SolutionCookie));
+            }
+        }
+
+        public uint SolutionCookie { get; set; } = VSConstants.VSCOOKIE_NIL;
+
+        #region Unused
+        public int OnAfterOpenProject(IVsHierarchy pHierarchy, int fAdded)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnQueryCloseProject(IVsHierarchy pHierarchy, int fRemoving, ref int pfCancel)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnBeforeCloseProject(IVsHierarchy pHierarchy, int fRemoved)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnAfterLoadProject(IVsHierarchy pStubHierarchy, IVsHierarchy pRealHierarchy)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnQueryUnloadProject(IVsHierarchy pRealHierarchy, ref int pfCancel)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnBeforeUnloadProject(IVsHierarchy pRealHierarchy, IVsHierarchy pStubHierarchy)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnQueryCloseSolution(object pUnkReserved, ref int pfCancel)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnBeforeCloseSolution(object pUnkReserved)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnAfterCloseSolution(object pUnkReserved)
+        {
+            return VSConstants.S_OK;
+        }
+        #endregion
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/GlobalJsonRemover.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/GlobalJsonRemover.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using EnvDTE;
 using EnvDTE80;
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
@@ -20,6 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
 
         public int OnAfterOpenSolution(object pUnkReserved, int fNewSolution)
         {
+            UIThreadHelper.VerifyOnUIThread();
             var dte = _serviceProvider.GetService<DTE2, DTE>();
             var solution = _serviceProvider.GetService<IVsSolution, SVsSolution>();
             try

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 using Microsoft.VisualStudio.Shell.Flavor;
 using Microsoft.VisualStudio.Shell.Interop;
 using Newtonsoft.Json;
@@ -33,6 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         public int UpgradeProject(string xprojLocation, uint upgradeFlags, string backupDirectory, out string migratedProjectFileLocation,
             IVsUpgradeLogger logger, out int upgradeRequired, out Guid migratedProjectGuid)
         {
+            UIThreadHelper.VerifyOnUIThread();
             bool success = false;
             var projectName = Path.GetFileNameWithoutExtension(xprojLocation);
             var hr = UpgradeProject_CheckOnly(xprojLocation, logger, out upgradeRequired, out migratedProjectGuid, out uint dummy);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Mocks\IVsSolutionFactory.cs" />
     <Compile Include="Mocks\IVsFileChangeExFactory.cs" />
     <Compile Include="Mocks\IVsStartupProjectsListServiceFactory.cs" />
+    <Compile Include="Mocks\ProjectItemFactory.cs" />
     <Compile Include="Mocks\Reference3Factory.cs" />
     <Compile Include="Mocks\RegistrationContextFactory.cs" />
     <Compile Include="Mocks\IVsAddProjectItemDlgFactory.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsSolutionFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsSolutionFactory.cs
@@ -1,11 +1,20 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using Moq;
 
 namespace Microsoft.VisualStudio.Shell.Interop
 {
     internal static class IVsSolutionFactory
     {
+        public static FuncWithOut<IVsSolutionEvents, uint, int> DefaultAdviseCallback => (IVsSolutionEvents events, out uint cookie) =>
+        {
+            cookie = 0;
+            return VSConstants.S_OK;
+        };
+
+        public static Func<uint, int> DefaultUnadviseCallback => (uint cookie) => VSConstants.S_OK;
+
         public static IVsSolution CreateWithSolutionDirectory(FuncWithOutThreeArgs<string, string, string, int> func)
         {
             var mock = new Mock<IVsSolution>();
@@ -21,6 +30,22 @@ namespace Microsoft.VisualStudio.Shell.Interop
             var mock = new Mock<IVsSolution>();
             mock.Setup(x => x.AdviseSolutionEvents(It.IsAny<IVsSolutionEvents>(), out adviseCookie)).Returns(VSConstants.S_OK);
             mock.Setup(x => x.UnadviseSolutionEvents(It.IsAny<uint>())).Returns(VSConstants.S_OK);
+            return mock.Object;
+        }
+
+        public static IVsSolution Implement(FuncWithOut<IVsSolutionEvents, uint, int> adviseCallback,
+            Func<uint, int> unadviseCallback,
+            FuncWithOutThreeArgs<string, string, string, int> solutionInfoCallback)
+        {
+            var mock = new Mock<IVsSolution>();
+            uint cookie;
+            string directory;
+            string solutionFile;
+            string userSettings;
+
+            mock.Setup(x => x.AdviseSolutionEvents(It.IsAny<IVsSolutionEvents>(), out cookie)).Returns(adviseCallback);
+            mock.Setup(x => x.UnadviseSolutionEvents(It.IsAny<uint>())).Returns(unadviseCallback);
+            mock.Setup(x => x.GetSolutionInfo(out directory, out solutionFile, out userSettings)).Returns(solutionInfoCallback);
             return mock.Object;
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ProjectItemFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ProjectItemFactory.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+
+namespace EnvDTE
+{
+    internal static class ProjectItemFactory
+    {
+        public static ProjectItem Create() => Mock.Of<ProjectItem>();
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/SolutionFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/SolutionFactory.cs
@@ -23,5 +23,13 @@ namespace EnvDTE80
 
             return mock.Object;
         }
+
+        public static Solution ImplementFindProjectItem(Func<string, ProjectItem> callback)
+        {
+            var mock = new Mock<Solution>();
+            mock.As<Solution2>();
+            mock.Setup(m => m.FindProjectItem(It.IsAny<string>())).Returns(callback);
+            return mock.Object;
+        }
     }
 }


### PR DESCRIPTION
**Customer scenario**

During migration, we remove the global.json file from the disk, but not from the solution, leaving a broken link.

**Bugs this fixes:**

Fixes final issue in https://github.com/dotnet/roslyn-project-system/issues/1184.

**Workarounds, if any**

The user can manually delete the file from the solution after migration.

**Risk**

We don't have any downstream dependencies for this.

**Performance impact**

Low. We add one extra observer for solution state, which runs a quick delete after the migration has been completed and the solution has been fully loaded. We also unsubscribe from events immediately after finishing deletion.

**Is this a regression from a previous update?**

No, known limitation of the new migration features.

**How was the bug found?**

MVP/internal testing.

Tagging @dotnet/project-system for review. /cc @livarcocc and @piotrpMSFT.