### PR TITLE
Add CustomTool and Custom Tool Namespace property to the C# and VB file properties and property window

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CSharp.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CSharp.BrowseObject.xaml
@@ -16,6 +16,17 @@
     <Category Name="Misc" DisplayName="Misc" />
   </Rule.Categories>
 
+  <StringProperty
+      Name="Generator"
+      Category="Advanced"
+      DisplayName="Custom Tool"
+      Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty
+      Name="CustomToolNamespace"
+      Category="Advanced"
+      DisplayName="Custom Tool Namespace"
+      Description="The namespace into which the output of the custom tool is placed." />
+
   <DynamicEnumProperty
       Name="{}{ItemType}"
       DisplayName="Build Action"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/VisualBasic.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/VisualBasic.BrowseObject.xaml
@@ -16,6 +16,17 @@
     <Category Name="Misc" DisplayName="Misc" />
   </Rule.Categories>
 
+  <StringProperty
+      Name="Generator"
+      Category="Advanced"
+      DisplayName="Custom Tool"
+      Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty
+      Name="CustomToolNamespace"
+      Category="Advanced"
+      DisplayName="Custom Tool Namespace"
+      Description="The namespace into which the output of the custom tool is placed." />
+
   <DynamicEnumProperty
       Name="{}{ItemType}"
       DisplayName="Build Action"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/VisualBasic.xaml
@@ -16,6 +16,17 @@
     <Category Name="Misc" DisplayName="Misc" />
   </Rule.Categories>
 
+  <StringProperty
+      Name="Generator"
+      Category="Advanced"
+      DisplayName="Custom Tool"
+      Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty
+      Name="CustomToolNamespace"
+      Category="Advanced"
+      DisplayName="Custom Tool Namespace"
+      Description="The namespace into which the output of the custom tool is placed." />
+
   <DynamicEnumProperty
       Name="{}{ItemType}"
       DisplayName="Build Action"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/CSharp.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/CSharp.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Upřesnit" />
     <Category Name="Misc" DisplayName="Různé" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Akce sestavení" Category="Advanced" Description="Jak se soubor vztahuje k procesům sestavení a nasazení." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Kopírovat do výstupního adresáře" Category="Advanced" Description="Určuje zdrojový soubor, který se zkopíruje do výstupního adresáře.">
     <EnumValue Name="Never" DisplayName="Nekopírovat" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/NuGetRestore.xaml
@@ -36,6 +36,7 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/VisualBasic.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/VisualBasic.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Upřesnit" />
     <Category Name="Misc" DisplayName="Různé" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Akce sestavení" Category="Advanced" Description="Jak se soubor vztahuje k procesům sestavení a nasazení." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Kopírovat do výstupního adresáře" Category="Advanced" Description="Určuje zdrojový soubor, který se zkopíruje do výstupního adresáře.">
     <EnumValue Name="Never" DisplayName="Nekopírovat" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/VisualBasic.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Upřesnit" />
     <Category Name="Misc" DisplayName="Různé" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Akce sestavení" Category="Advanced" Description="Jak se soubor vztahuje k procesům sestavení a nasazení." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Kopírovat do výstupního adresáře" Category="Advanced" Description="Určuje zdrojový soubor, který se zkopíruje do výstupního adresáře.">
     <EnumValue Name="Never" DisplayName="Nekopírovat" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/CSharp.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/CSharp.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Erweitert" />
     <Category Name="Misc" DisplayName="Sonst." />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Buildvorgang" Category="Advanced" Description="Wie die Datei mit den Build- und Bereitstellungsprozessen verknüpft ist." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="In Ausgabeverzeichnis kopieren" Category="Advanced" Description="Gibt an, dass die Quelldatei in das Ausgabeverzeichnis kopiert wird.">
     <EnumValue Name="Never" DisplayName="Nicht kopieren" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/NuGetRestore.xaml
@@ -36,6 +36,7 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/VisualBasic.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/VisualBasic.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Erweitert" />
     <Category Name="Misc" DisplayName="Sonst." />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Buildvorgang" Category="Advanced" Description="Wie die Datei mit den Build- und Bereitstellungsprozessen verknüpft ist." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="In Ausgabeverzeichnis kopieren" Category="Advanced" Description="Gibt an, dass die Quelldatei in das Ausgabeverzeichnis kopiert wird.">
     <EnumValue Name="Never" DisplayName="Nicht kopieren" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/VisualBasic.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Erweitert" />
     <Category Name="Misc" DisplayName="Sonst." />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Buildvorgang" Category="Advanced" Description="Wie die Datei mit den Build- und Bereitstellungsprozessen verknüpft ist." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="In Ausgabeverzeichnis kopieren" Category="Advanced" Description="Gibt an, dass die Quelldatei in das Ausgabeverzeichnis kopiert wird.">
     <EnumValue Name="Never" DisplayName="Nicht kopieren" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/CSharp.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/CSharp.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Avanzadas" />
     <Category Name="Misc" DisplayName="Varios" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Acción de compilación" Category="Advanced" Description="Cómo se relaciona el archivo con los procesos de compilación e implementación." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Copiar en el directorio de salida" Category="Advanced" Description="Especifica que el archivo de código fuente se copiará en el directorio de salida.">
     <EnumValue Name="Never" DisplayName="No copiar" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/NuGetRestore.xaml
@@ -36,6 +36,7 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/VisualBasic.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/VisualBasic.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Avanzadas" />
     <Category Name="Misc" DisplayName="Varios" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Acción de compilación" Category="Advanced" Description="Cómo se relaciona el archivo con los procesos de compilación e implementación." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Copiar en el directorio de salida" Category="Advanced" Description="Especifica que el archivo de código fuente se copiará en el directorio de salida.">
     <EnumValue Name="Never" DisplayName="No copiar" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/VisualBasic.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Avanzadas" />
     <Category Name="Misc" DisplayName="Varios" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Acción de compilación" Category="Advanced" Description="Cómo se relaciona el archivo con los procesos de compilación e implementación." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Copiar en el directorio de salida" Category="Advanced" Description="Especifica que el archivo de código fuente se copiará en el directorio de salida.">
     <EnumValue Name="Never" DisplayName="No copiar" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/CSharp.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/CSharp.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Avancé" />
     <Category Name="Misc" DisplayName="Divers" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Action de génération" Category="Advanced" Description="Description de la relation entre le fichier, la build et les processus de déploiement." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Copier dans le répertoire de sortie" Category="Advanced" Description="Spécifie le fichier source qui sera copié dans le répertoire de sortie.">
     <EnumValue Name="Never" DisplayName="Ne pas copier" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/NuGetRestore.xaml
@@ -36,6 +36,7 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/VisualBasic.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/VisualBasic.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Avancé" />
     <Category Name="Misc" DisplayName="Divers" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Action de génération" Category="Advanced" Description="Description de la relation entre le fichier, la build et les processus de déploiement." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Copier dans le répertoire de sortie" Category="Advanced" Description="Spécifie le fichier source qui sera copié dans le répertoire de sortie.">
     <EnumValue Name="Never" DisplayName="Ne pas copier" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/VisualBasic.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Avancé" />
     <Category Name="Misc" DisplayName="Divers" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Action de génération" Category="Advanced" Description="Description de la relation entre le fichier, la build et les processus de déploiement." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Copier dans le répertoire de sortie" Category="Advanced" Description="Spécifie le fichier source qui sera copié dans le répertoire de sortie.">
     <EnumValue Name="Never" DisplayName="Ne pas copier" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/CSharp.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/CSharp.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Avanzate" />
     <Category Name="Misc" DisplayName="Varie" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Azione di compilazione" Category="Advanced" Description="Descrizione della relazione tra il file e i processi di compilazione e distribuzione." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Copia nella directory di output" Category="Advanced" Description="Specifica se il file di origine verrà copiato nella directory di output.">
     <EnumValue Name="Never" DisplayName="Non copiare" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/NuGetRestore.xaml
@@ -36,6 +36,7 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/VisualBasic.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/VisualBasic.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Avanzate" />
     <Category Name="Misc" DisplayName="Varie" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Azione di compilazione" Category="Advanced" Description="Descrizione della relazione tra il file e i processi di compilazione e distribuzione." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Copia nella directory di output" Category="Advanced" Description="Specifica se il file di origine verrà copiato nella directory di output.">
     <EnumValue Name="Never" DisplayName="Non copiare" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/VisualBasic.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Avanzate" />
     <Category Name="Misc" DisplayName="Varie" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Azione di compilazione" Category="Advanced" Description="Descrizione della relazione tra il file e i processi di compilazione e distribuzione." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Copia nella directory di output" Category="Advanced" Description="Specifica se il file di origine verrà copiato nella directory di output.">
     <EnumValue Name="Never" DisplayName="Non copiare" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/CSharp.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/CSharp.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="詳細設定" />
     <Category Name="Misc" DisplayName="その他" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="ビルド アクション" Category="Advanced" Description="ビルドおよび配置のプロセスにファイルがどのように関連しているかを示します。" EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="出力ディレクトリにコピー" Category="Advanced" Description="ソース ファイルを出力ディレクトリにコピーするよう指定します。">
     <EnumValue Name="Never" DisplayName="コピーしない" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/NuGetRestore.xaml
@@ -36,6 +36,7 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/VisualBasic.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/VisualBasic.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="詳細設定" />
     <Category Name="Misc" DisplayName="その他" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="ビルド アクション" Category="Advanced" Description="ビルドおよび配置のプロセスにファイルがどのように関連しているかを示します。" EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="出力ディレクトリにコピー" Category="Advanced" Description="ソース ファイルを出力ディレクトリにコピーするよう指定します。">
     <EnumValue Name="Never" DisplayName="コピーしない" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/VisualBasic.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="詳細設定" />
     <Category Name="Misc" DisplayName="その他" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="ビルド アクション" Category="Advanced" Description="ビルドおよび配置のプロセスにファイルがどのように関連しているかを示します。" EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="出力ディレクトリにコピー" Category="Advanced" Description="ソース ファイルを出力ディレクトリにコピーするよう指定します。">
     <EnumValue Name="Never" DisplayName="コピーしない" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/CSharp.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/CSharp.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="고급" />
     <Category Name="Misc" DisplayName="기타" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="빌드 작업" Category="Advanced" Description="파일이 빌드 및 배포 프로세스와 연결되는 방법입니다." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="출력 디렉터리에 복사" Category="Advanced" Description="소스 파일을 출력 디렉터리로 복사할 것인지 여부를 지정합니다.">
     <EnumValue Name="Never" DisplayName="복사 안 함" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/NuGetRestore.xaml
@@ -36,6 +36,7 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/VisualBasic.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/VisualBasic.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="고급" />
     <Category Name="Misc" DisplayName="기타" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="빌드 작업" Category="Advanced" Description="파일이 빌드 및 배포 프로세스와 연결되는 방법입니다." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="출력 디렉터리에 복사" Category="Advanced" Description="소스 파일을 출력 디렉터리로 복사할 것인지 여부를 지정합니다.">
     <EnumValue Name="Never" DisplayName="복사 안 함" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/VisualBasic.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="고급" />
     <Category Name="Misc" DisplayName="기타" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="빌드 작업" Category="Advanced" Description="파일이 빌드 및 배포 프로세스와 연결되는 방법입니다." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="출력 디렉터리에 복사" Category="Advanced" Description="소스 파일을 출력 디렉터리로 복사할 것인지 여부를 지정합니다.">
     <EnumValue Name="Never" DisplayName="복사 안 함" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/CSharp.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/CSharp.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Zaawansowane" />
     <Category Name="Misc" DisplayName="Różne" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Akcja kompilacji" Category="Advanced" Description="Relacja pliku do procesów kompilacji i wdrożenia." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Kopiuj do katalogu wyjściowego" Category="Advanced" Description="Określa plik źródłowy, który zostanie skopiowany do katalogu wyjściowego.">
     <EnumValue Name="Never" DisplayName="Nie kopiuj" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/NuGetRestore.xaml
@@ -36,6 +36,7 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/VisualBasic.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/VisualBasic.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Zaawansowane" />
     <Category Name="Misc" DisplayName="Różne" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Akcja kompilacji" Category="Advanced" Description="Relacja pliku do procesów kompilacji i wdrożenia." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Kopiuj do katalogu wyjściowego" Category="Advanced" Description="Określa plik źródłowy, który zostanie skopiowany do katalogu wyjściowego.">
     <EnumValue Name="Never" DisplayName="Nie kopiuj" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/VisualBasic.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Zaawansowane" />
     <Category Name="Misc" DisplayName="Różne" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Akcja kompilacji" Category="Advanced" Description="Relacja pliku do procesów kompilacji i wdrożenia." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Kopiuj do katalogu wyjściowego" Category="Advanced" Description="Określa plik źródłowy, który zostanie skopiowany do katalogu wyjściowego.">
     <EnumValue Name="Never" DisplayName="Nie kopiuj" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/CSharp.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/CSharp.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Avançado" />
     <Category Name="Misc" DisplayName="Diversos" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Ação de Compilação" Category="Advanced" Description="Como o arquivo está relacionado aos processos de compilação e implantação." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Copiar para Diretório de Saída" Category="Advanced" Description="Especifica se o arquivo fonte deve ser copiado no diretório de saída.">
     <EnumValue Name="Never" DisplayName="Não copiar" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/NuGetRestore.xaml
@@ -36,6 +36,7 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/VisualBasic.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/VisualBasic.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Avançado" />
     <Category Name="Misc" DisplayName="Diversos" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Ação de Compilação" Category="Advanced" Description="Como o arquivo está relacionado aos processos de compilação e implantação." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Copiar para Diretório de Saída" Category="Advanced" Description="Especifica se o arquivo fonte deve ser copiado no diretório de saída.">
     <EnumValue Name="Never" DisplayName="Não copiar" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/VisualBasic.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Avançado" />
     <Category Name="Misc" DisplayName="Diversos" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Ação de Compilação" Category="Advanced" Description="Como o arquivo está relacionado aos processos de compilação e implantação." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Copiar para Diretório de Saída" Category="Advanced" Description="Especifica se o arquivo fonte deve ser copiado no diretório de saída.">
     <EnumValue Name="Never" DisplayName="Não copiar" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/CSharp.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/CSharp.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Дополнительно" />
     <Category Name="Misc" DisplayName="Прочее" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Действие при сборке" Category="Advanced" Description="Как файл связан с процессами сборки и развертывания." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Копировать в выходной каталог" Category="Advanced" Description="Указывает, что файл исходного кода будет скопирован в выходной каталог.">
     <EnumValue Name="Never" DisplayName="Не копировать" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/NuGetRestore.xaml
@@ -36,6 +36,7 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/VisualBasic.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/VisualBasic.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Дополнительно" />
     <Category Name="Misc" DisplayName="Прочее" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Действие при сборке" Category="Advanced" Description="Как файл связан с процессами сборки и развертывания." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Копировать в выходной каталог" Category="Advanced" Description="Указывает, что файл исходного кода будет скопирован в выходной каталог.">
     <EnumValue Name="Never" DisplayName="Не копировать" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/VisualBasic.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Дополнительно" />
     <Category Name="Misc" DisplayName="Прочее" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Действие при сборке" Category="Advanced" Description="Как файл связан с процессами сборки и развертывания." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Копировать в выходной каталог" Category="Advanced" Description="Указывает, что файл исходного кода будет скопирован в выходной каталог.">
     <EnumValue Name="Never" DisplayName="Не копировать" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/CSharp.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/CSharp.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Gelişmiş" />
     <Category Name="Misc" DisplayName="Çeşitli" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Derleme Eylemi" Category="Advanced" Description="Dosyanın oluşturma ve dağıtım işlemleriyle olan ilişkisi." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Çıkış Dizinine Kopyala" Category="Advanced" Description="Kaynak dosyasının çıkış dizinine kopyalanacağını belirtir.">
     <EnumValue Name="Never" DisplayName="Kopyalama" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/NuGetRestore.xaml
@@ -36,6 +36,7 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/VisualBasic.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/VisualBasic.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Gelişmiş" />
     <Category Name="Misc" DisplayName="Çeşitli" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Derleme Eylemi" Category="Advanced" Description="Dosyanın oluşturma ve dağıtım işlemleriyle olan ilişkisi." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Çıkış Dizinine Kopyala" Category="Advanced" Description="Kaynak dosyasının çıkış dizinine kopyalanacağını belirtir.">
     <EnumValue Name="Never" DisplayName="Kopyalama" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/VisualBasic.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="Gelişmiş" />
     <Category Name="Misc" DisplayName="Çeşitli" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Derleme Eylemi" Category="Advanced" Description="Dosyanın oluşturma ve dağıtım işlemleriyle olan ilişkisi." EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="Çıkış Dizinine Kopyala" Category="Advanced" Description="Kaynak dosyasının çıkış dizinine kopyalanacağını belirtir.">
     <EnumValue Name="Never" DisplayName="Kopyalama" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.cs.xlf
@@ -83,6 +83,26 @@
         <target state="translated">Název souboru nebo složky</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.de.xlf
@@ -83,6 +83,26 @@
         <target state="translated">Name der Datei oder des Ordners.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.es.xlf
@@ -83,6 +83,26 @@
         <target state="translated">Nombre del archivo o carpeta.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.fr.xlf
@@ -83,6 +83,26 @@
         <target state="translated">Nom du fichier ou du dossier.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.it.xlf
@@ -83,6 +83,26 @@
         <target state="translated">Nome del file o della cartella.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.ja.xlf
@@ -83,6 +83,26 @@
         <target state="translated">ファイルまたはフォルダーの名前です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.ko.xlf
@@ -83,6 +83,26 @@
         <target state="translated">파일 또는 폴더의 이름입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.pl.xlf
@@ -83,6 +83,26 @@
         <target state="translated">Nazwa pliku lub folderu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.pt-BR.xlf
@@ -83,6 +83,26 @@
         <target state="translated">Nome do arquivo ou da pasta.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.ru.xlf
@@ -83,6 +83,26 @@
         <target state="translated">Имя файла или папки.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.tr.xlf
@@ -83,6 +83,26 @@
         <target state="translated">Dosya veya klasörün adı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.xlf
@@ -67,6 +67,22 @@
         <source>Name of the file or folder.</source>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.zh-Hans.xlf
@@ -83,6 +83,26 @@
         <target state="translated">文件或文件夹的名称。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CSharp.BrowseObject.xaml.zh-Hant.xlf
@@ -83,6 +83,26 @@
         <target state="translated">檔案或資料夾的名稱。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.cs.xlf
@@ -83,6 +83,26 @@
         <target state="translated">Název souboru nebo složky</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.de.xlf
@@ -83,6 +83,26 @@
         <target state="translated">Name der Datei oder des Ordners.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.es.xlf
@@ -83,6 +83,26 @@
         <target state="translated">Nombre del archivo o carpeta.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.fr.xlf
@@ -83,6 +83,26 @@
         <target state="translated">Nom du fichier ou du dossier.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.it.xlf
@@ -83,6 +83,26 @@
         <target state="translated">Nome del file o della cartella.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.ja.xlf
@@ -83,6 +83,26 @@
         <target state="translated">ファイルまたはフォルダーの名前です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.ko.xlf
@@ -83,6 +83,26 @@
         <target state="translated">파일 또는 폴더의 이름입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.pl.xlf
@@ -83,6 +83,26 @@
         <target state="translated">Nazwa pliku lub folderu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.pt-BR.xlf
@@ -83,6 +83,26 @@
         <target state="translated">Nome do arquivo ou da pasta.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.ru.xlf
@@ -83,6 +83,26 @@
         <target state="translated">Имя файла или папки.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.tr.xlf
@@ -83,6 +83,26 @@
         <target state="translated">Dosya veya klasörün adı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.xlf
@@ -67,6 +67,22 @@
         <source>Name of the file or folder.</source>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.zh-Hans.xlf
@@ -83,6 +83,26 @@
         <target state="translated">文件或文件夹的名称。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.BrowseObject.xaml.zh-Hant.xlf
@@ -83,6 +83,26 @@
         <target state="translated">檔案或資料夾的名稱。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.cs.xlf
@@ -98,6 +98,26 @@
         <target state="translated">Hodnota určující, jestli jde o vygenerovaný soubor</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.de.xlf
@@ -98,6 +98,26 @@
         <target state="translated">Ein Wert, der angibt, ob es sich um eine generierte Datei handelt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.es.xlf
@@ -98,6 +98,26 @@
         <target state="translated">Valor que indica si este es un archivo generado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.fr.xlf
@@ -98,6 +98,26 @@
         <target state="translated">Valeur indiquant s'il s'agit d'un fichier généré.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.it.xlf
@@ -98,6 +98,26 @@
         <target state="translated">Valore che indica se si tratta di un file generato.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.ja.xlf
@@ -98,6 +98,26 @@
         <target state="translated">生成されたファイルであるかどうかを示す値です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.ko.xlf
@@ -98,6 +98,26 @@
         <target state="translated">생성된 파일인지 여부를 나타내는 값입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.pl.xlf
@@ -98,6 +98,26 @@
         <target state="translated">Wartość wskazująca, czy jest to wygenerowany plik.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.pt-BR.xlf
@@ -98,6 +98,26 @@
         <target state="translated">Um valor indicando se esse é um arquivo gerado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.ru.xlf
@@ -98,6 +98,26 @@
         <target state="translated">Значение, указывающее, является ли этот файл созданным.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.tr.xlf
@@ -98,6 +98,26 @@
         <target state="translated">Bunun oluşturulmuş bir dosya olup olmadığını gösteren değer.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.xlf
@@ -79,6 +79,22 @@
         <source>A value indicating whether this is a generated file.</source>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.zh-Hans.xlf
@@ -98,6 +98,26 @@
         <target state="translated">该值指示此文件是否为生成的文件。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/VisualBasic.xaml.zh-Hant.xlf
@@ -98,6 +98,26 @@
         <target state="translated">這個值指出這是否為產生的檔案。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/CSharp.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/CSharp.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="高级" />
     <Category Name="Misc" DisplayName="杂项" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="生成操作" Category="Advanced" Description="该文件与生成和部署过程的关系。" EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="复制到输出目录" Category="Advanced" Description="指定将源文件复制到输出目录。">
     <EnumValue Name="Never" DisplayName="不复制" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/NuGetRestore.xaml
@@ -36,6 +36,7 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/VisualBasic.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/VisualBasic.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="高级" />
     <Category Name="Misc" DisplayName="杂项" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="生成操作" Category="Advanced" Description="该文件与生成和部署过程的关系。" EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="复制到输出目录" Category="Advanced" Description="指定将源文件复制到输出目录。">
     <EnumValue Name="Never" DisplayName="不复制" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/VisualBasic.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="高级" />
     <Category Name="Misc" DisplayName="杂项" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="生成操作" Category="Advanced" Description="该文件与生成和部署过程的关系。" EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="复制到输出目录" Category="Advanced" Description="指定将源文件复制到输出目录。">
     <EnumValue Name="Never" DisplayName="不复制" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/CSharp.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/CSharp.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="進階" />
     <Category Name="Misc" DisplayName="其他" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="建置動作" Category="Advanced" Description="檔案與組建和部署處理序相關聯的方式。" EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="複製到輸出目錄" Category="Advanced" Description="指定是否要將原始程式檔複製到輸出目錄。">
     <EnumValue Name="Never" DisplayName="不要複製" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/NuGetRestore.xaml
@@ -36,6 +36,7 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/VisualBasic.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/VisualBasic.BrowseObject.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="進階" />
     <Category Name="Misc" DisplayName="其他" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="建置動作" Category="Advanced" Description="檔案與組建和部署處理序相關聯的方式。" EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="複製到輸出目錄" Category="Advanced" Description="指定是否要將原始程式檔複製到輸出目錄。">
     <EnumValue Name="Never" DisplayName="不要複製" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/VisualBasic.xaml
@@ -8,6 +8,8 @@
     <Category Name="Advanced" DisplayName="進階" />
     <Category Name="Misc" DisplayName="其他" />
   </Rule.Categories>
+  <StringProperty Name="Generator" Category="Advanced" DisplayName="Custom Tool" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" DisplayName="Custom Tool Namespace" Description="The namespace into which the output of the custom tool is placed." />
   <DynamicEnumProperty Name="{}{ItemType}" DisplayName="建置動作" Category="Advanced" Description="檔案與組建和部署處理序相關聯的方式。" EnumProvider="ItemTypes" />
   <EnumProperty Name="CopyToOutputDirectory" DisplayName="複製到輸出目錄" Category="Advanced" Description="指定是否要將原始程式檔複製到輸出目錄。">
     <EnumValue Name="Never" DisplayName="不要複製" />


### PR DESCRIPTION

@madskristensen @davkean @srivatsn @dotnet/project-system

**Customer scenario**

Users cannot use the Custom tool to generate associated code without the CustomTool in option in the Properties window

**Bugs this fixes:**

#1136 and [VSO](https://devdiv.visualstudio.com/DevDiv/_workitems?id=373568&_a=edit)

**Workarounds, if any**

Right-click C# items and go to property pages. That page has CustomTool textbox to provide the CustomTool

**Risk**

Low, since we are not modifying the behavior of existing component

**Performance impact**

More compilation time to run the generator

**Is this a regression from a previous update?**

No

**Root cause analysis:**

We are discovering these things to gain parity

**How was the bug found?**

Adhoc testing