### PR TITLE
Add binding redirect for Immutable for tests

### DIFF
--- a/src/Common/Test/App.config
+++ b/src/Common/Test/App.config
@@ -13,4 +13,12 @@
       </listeners>
     </trace>
   </system.diagnostics>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>


### PR DESCRIPTION
Tests were failing inside VS due to Immutable mismatch - CPS expects version 1.2, but due to MSBuild dependency we deploy 1.2.1.

Make note this wasn't causing us to fail command-line runs because they run inside the xUnit appdomain (due to xunit.AppDomain == denied) and looks like (according to fuslog) it's failing back to a LoadFrom bind to the exact binding in the directory next to the test when the Load bind fails.