### PR TITLE
Add MSBuildProjectFile to NuGetRestore rules

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -50,6 +50,10 @@
                     Visible="False" 
                     ReadOnly="True" />
 
+    <StringProperty Name="MSBuildProjectFile" 
+                    Visible="False" 
+                    ReadOnly="True" />
+
     <StringProperty Name="PackageTargetFallback" 
                     Visible="False" 
                     ReadOnly="True" />


### PR DESCRIPTION
Fixes #1293

**Customer scenario**

Customers that rename .NETStandard/.NETCore projects subsequently experience Restore and Build breaks until they close the solution.

**Bugs this fixes:**

#1293
https://github.com/NuGet/Home/issues/4287

**Workarounds, if any**

Close and reopen the solution, or Visual Studio

**Risk**

Low. This fix simply adds another MSBuild property to the list of properties we listen to when choosing to Nominate restore

**Performance impact**

Low

**Is this a regression from a previous update?**

No

**Root cause analysis:**

The breaks occur because NuGet has not been nominated to restore following the project name change, hence the new project name is not in NuGet's cache. The NuGet restorer only nominates a restore operation when tracked properties change. This list mostly included properties NuGet actually needs to perform the restore operation, and did not include `MSBuildProjectFile` which changes when a user renames a project.

**How was the bug found?**

Dogfooding

/cc @dotnet/project-system @rrelyea @alpaix