### PR TITLE
Moving the hardcoded strings from the Debug UI to Resources file

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
@@ -56,7 +56,7 @@
                 Grid.Row="0"
                 x:Uid="profileLabel" 
                 Margin="4,4,3,5"
-                Content="_Profile"
+                Content="{x:Static Member=local:PropertyPageResources.Profile}"
                 IsTabStop="False" 
                 VerticalAlignment="Center"
                 Target="{Binding ElementName=profileCombo}"/>
@@ -92,7 +92,7 @@
                     Margin="6,8,1,8"
                     VerticalContentAlignment="Center"
                     VerticalAlignment="Center"
-                    Content="_New..."
+                    Content="{x:Static Member=local:PropertyPageResources.NewBtn}"
                     IsEnabled="{Binding Path=NewProfileEnabled, Mode=OneWay}"
                     Command="{Binding Path=NewProfileCommand}">
                 </Button>
@@ -104,7 +104,7 @@
                     Margin="6,8,1,8"
                     VerticalContentAlignment="Center"
                     VerticalAlignment="Center"
-                    Content="D_elete"
+                    Content="{x:Static Member=local:PropertyPageResources.DeleteBtn}"
                     IsEnabled="{Binding Path=DeleteProfileEnabled, Mode=OneWay}"
                     Command="{Binding Path=DeleteProfileCommand}">
                 </Button>
@@ -113,10 +113,9 @@
                 x:Uid="launchLabel"
                 Grid.Row="1" 
                 Margin="4,5,3,4"
-                Content="_Launch:"
+                Content="{x:Static Member=local:PropertyPageResources.Launch}"
                 MinWidth="150" 
-                IsTabStop="False" 
-                VerticalAlignment="Center"
+                IsTabStop="False"
                 Target="{Binding ElementName=launchCombo}"/>
             <ComboBox
                 Grid.Row="1"
@@ -137,7 +136,7 @@
                 Grid.Row="2"
                 x:Uid="executableLabel"
                 Margin="4,4,3,5"
-                Content="E_xecutable:"
+                Content="{x:Static Member=local:PropertyPageResources.Executable}"
                 IsTabStop="False" 
                 VerticalAlignment="Center"
                 Visibility="{Binding Path=SupportsExecutable, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
@@ -165,7 +164,7 @@
                 HorizontalAlignment="Left"
                 VerticalContentAlignment="Center"
                 VerticalAlignment="Center"
-                Content="Browse..."
+                Content="{x:Static Member=local:PropertyPageResources.BrowseBtn}"
                 IsEnabled="{Binding Path=IsProfileSelected, Mode=OneWay}"
                 Visibility="{Binding Path=SupportsExecutable, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
                 Command="{Binding Path=BrowseExecutableCommand}"/>
@@ -173,8 +172,8 @@
                 Grid.Row="4"
                 x:Uid="argumentsLabel"
                 Margin="4,4,3,0"
-                Content="_Application arguments:"
-                IsTabStop="False" 
+                Content="{x:Static Member=local:PropertyPageResources.ApplicationArguments}"
+                IsTabStop="False"
                 VerticalAlignment="Top"
                 Visibility="{Binding Path=SupportsArguments, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
                 Target="{Binding ElementName=txtArguments}"/>
@@ -196,7 +195,7 @@
                 Grid.Row="5"
                 x:Uid="workingDirectoryLabel"
                 Margin="4,4,3,5"
-                Content="W_orking directory:"
+                Content="{x:Static Member=local:PropertyPageResources.WorkingDirectory}"
                 VerticalAlignment="Center"
                 Visibility="{Binding Path=SupportsWorkingDirectory, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
                 Target="{Binding ElementName=txtWorkingDirectory}"/>
@@ -224,7 +223,7 @@
                 HorizontalAlignment="Left"
                 VerticalContentAlignment="Center"
                 VerticalAlignment="Center"
-                Content="Browse..."
+                Content="{x:Static Member=local:PropertyPageResources.BrowseBtn}"
                 IsEnabled="{Binding Path=IsProfileSelected, Mode=OneWay}"
                 Visibility="{Binding Path=SupportsWorkingDirectory, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
                 Command="{Binding Path=BrowseDirectoryCommand}"/>
@@ -239,7 +238,7 @@
                 IsEnabled="{Binding Path=IsProfileSelected, Mode=OneWay}"
                 Visibility="{Binding Path=SupportsLaunchUrl, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
                 VerticalContentAlignment="Center"
-                Content="Launch _URL:"/>
+                Content="{x:Static Member=local:PropertyPageResources.LaunchURL}"/>
             <local:WatermarkTextBox 
                 Grid.Row="6"
                 Grid.Column="1"
@@ -266,7 +265,7 @@
                 IsTabStop="False"
                 VerticalAlignment="Top"
                 Visibility="{Binding Path=SupportsEnvironmentVariables, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
-                Content="Environment variables:"/>
+                Content="{x:Static Member=local:PropertyPageResources.EnvironmentVariables}"/>
             <DataGrid
                 x:Name="dataGridEnvironmentVariables"
                 Grid.Row="7"
@@ -301,7 +300,7 @@
                     </Style>
                 </DataGrid.CellStyle>
                 <DataGrid.Columns>
-                    <local:EnvironmentDataGridTemplateColumn x:Uid="HeaderName" Header="Name" MinWidth="80">
+                    <local:EnvironmentDataGridTemplateColumn x:Uid="HeaderName" Header="{x:Static Member=local:PropertyPageResources.NameHeader}" MinWidth="80">
                         <local:EnvironmentDataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <Border Padding="4,0,4,0">
@@ -323,7 +322,7 @@
                             </DataTemplate>
                         </local:EnvironmentDataGridTemplateColumn.CellEditingTemplate>
                     </local:EnvironmentDataGridTemplateColumn>
-                    <local:EnvironmentDataGridTemplateColumn x:Uid="HeaderValue" Header="Value" MinWidth="255">
+                    <local:EnvironmentDataGridTemplateColumn x:Uid="HeaderValue" Header="{x:Static Member=local:PropertyPageResources.ValueHeader}" MinWidth="255">
                         <local:EnvironmentDataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <Border Padding="4,0,4,0">
@@ -356,27 +355,27 @@
                     Margin="0,8,0,10" 
                     MinWidth="80"
                     MinHeight="23"
-                    Command="{Binding Path=AddEnvironmentVariableRowCommand}">
+                    Command="{Binding Path=AddEnvironmentVariableRowCommand}"
+                    Content="{x:Static Member=local:PropertyPageResources.AddBtn}">
                     <Button.IsEnabled>
                         <MultiBinding Converter="{StaticResource MultiValueBoolToBoolAnd}">
                             <Binding Path="EnvironmentVariablesValid" Mode="OneWay"/>
                             <Binding Path="IsProfileSelected" Mode="OneWay"/>
                         </MultiBinding>
                     </Button.IsEnabled>
-                    A_dd
                 </Button>
                 <Button 
                     x:Uid="RemoveEnvironmentVariableButton" 
                     MinWidth="80"
                     MinHeight="23"
-                    Command="{Binding Path=RemoveEnvironmentVariableRowCommand}">
+                    Command="{Binding Path=RemoveEnvironmentVariableRowCommand}"
+                    Content="{x:Static Member=local:PropertyPageResources.RemoveBtn}">
                     <Button.IsEnabled>
                         <MultiBinding Converter="{StaticResource MultiValueBoolToBoolAnd}">
                             <Binding Path="RemoveEnvironmentVariablesRow" Mode="OneWay"/>
                             <Binding Path="IsProfileSelected" Mode="OneWay"/>
                         </MultiBinding>
                     </Button.IsEnabled>
-                    Remo_ve
                 </Button>
             </StackPanel>
             <!-- Where the custom control is placed for the active provider -->

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.Designer.cs
@@ -61,11 +61,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add.
+        /// </summary>
+        public static string AddBtn {
+            get {
+                return ResourceManager.GetString("AddBtn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to All files.
         /// </summary>
         public static string AllFiles {
             get {
                 return ResourceManager.GetString("AllFiles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Application arguments:.
+        /// </summary>
+        public static string ApplicationArguments {
+            get {
+                return ResourceManager.GetString("ApplicationArguments", resourceCulture);
             }
         }
         
@@ -79,6 +97,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Browse....
+        /// </summary>
+        public static string BrowseBtn {
+            get {
+                return ResourceManager.GetString("BrowseBtn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Debug.
         /// </summary>
         public static string DebugPropertyPageTitle {
@@ -88,11 +115,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Delete.
+        /// </summary>
+        public static string DeleteBtn {
+            get {
+                return ResourceManager.GetString("DeleteBtn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Duplicate Key.
         /// </summary>
         public static string DuplicateKey {
             get {
                 return ResourceManager.GetString("DuplicateKey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Environment variables:.
+        /// </summary>
+        public static string EnvironmentVariables {
+            get {
+                return ResourceManager.GetString("EnvironmentVariables", resourceCulture);
             }
         }
         
@@ -124,6 +169,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Executable.
+        /// </summary>
+        public static string Executable {
+            get {
+                return ResourceManager.GetString("Executable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Executable files.
         /// </summary>
         public static string ExecutableFiles {
@@ -138,6 +192,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         public static string ExecutablePathWatermark {
             get {
                 return ResourceManager.GetString("ExecutablePathWatermark", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Launch:.
+        /// </summary>
+        public static string Launch {
+            get {
+                return ResourceManager.GetString("Launch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Launch URL:.
+        /// </summary>
+        public static string LaunchURL {
+            get {
+                return ResourceManager.GetString("LaunchURL", resourceCulture);
             }
         }
         
@@ -160,6 +232,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Name.
+        /// </summary>
+        public static string NameHeader {
+            get {
+                return ResourceManager.GetString("NameHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to New....
+        /// </summary>
+        public static string NewBtn {
+            get {
+                return ResourceManager.GetString("NewBtn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to New profile.
         /// </summary>
         public static string NewProfileCaption {
@@ -174,6 +264,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         public static string NewProfileSeedName {
             get {
                 return ResourceManager.GetString("NewProfileSeedName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Profile:.
+        /// </summary>
+        public static string Profile {
+            get {
+                return ResourceManager.GetString("Profile", resourceCulture);
             }
         }
         
@@ -232,11 +331,38 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove.
+        /// </summary>
+        public static string RemoveBtn {
+            get {
+                return ResourceManager.GetString("RemoveBtn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Value cannot be empty..
         /// </summary>
         public static string ValueCannotBeEmpty {
             get {
                 return ResourceManager.GetString("ValueCannotBeEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Value.
+        /// </summary>
+        public static string ValueHeader {
+            get {
+                return ResourceManager.GetString("ValueHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Working directory:.
+        /// </summary>
+        public static string WorkingDirectory {
+            get {
+                return ResourceManager.GetString("WorkingDirectory", resourceCulture);
             }
         }
         

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.resx
@@ -179,4 +179,47 @@
   </data>
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
     <value>The errors on the page must be corrected prior to saving your changes.</value>
-  </data></root>
+  </data>
+  <data name="AddBtn" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="ApplicationArguments" xml:space="preserve">
+    <value>Application arguments:</value>
+  </data>
+  <data name="BrowseBtn" xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="DeleteBtn" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="EnvironmentVariables" xml:space="preserve">
+    <value>Environment variables:</value>
+  </data>
+  <data name="Executable" xml:space="preserve">
+    <value>Executable</value>
+  </data>
+  <data name="Launch" xml:space="preserve">
+    <value>Launch:</value>
+  </data>
+  <data name="LaunchURL" xml:space="preserve">
+    <value>Launch URL:</value>
+  </data>
+  <data name="NameHeader" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="NewBtn" xml:space="preserve">
+    <value>New...</value>
+  </data>
+  <data name="Profile" xml:space="preserve">
+    <value>Profile:</value>
+  </data>
+  <data name="RemoveBtn" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="ValueHeader" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="WorkingDirectory" xml:space="preserve">
+    <value>Working directory:</value>
+  </data>
+</root>


### PR DESCRIPTION
**Customer scenario**

Debug properties page is not currently localized.

**Bugs this fixes:**

https://github.com/dotnet/roslyn-project-system/issues/1286

**Workarounds, if any**
None

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**
Low 

**Performance impact**
Low

**Is this a regression from a previous update?**
No

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?
Page was copied over from old system. Missed seeing the strings not being localized.

**How was the bug found?**

 ad hoc testing