### PR TITLE
Add PackageVersion to support NuGet's Project Version compute heuristics

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -66,4 +66,20 @@
                     Visible="False" 
                     ReadOnly="True" />
 
+    <StringProperty Name="PackageVersion" 
+                    Visible="False" 
+                    ReadOnly="True" />
+
+    <StringProperty Name="Version" 
+                    Visible="False" 
+                    ReadOnly="True" />
+
+    <StringProperty Name="VersionPrefix" 
+                    Visible="False" 
+                    ReadOnly="True" />
+
+    <StringProperty Name="VersionSuffix" 
+                    Visible="False" 
+                    ReadOnly="True" />
+
 </Rule>


### PR DESCRIPTION
Fixes #1132 

**Customer scenario**

.NET core users can version projects that produce packages by doing:

```xml
  <PropertyGroup>
    <PackageVersion>1.2.0</PackageVersion>
  </PropertyGroup>
```

However, this version information is not currently passed on to parent projects in P2P scenarios. Instead the project is always listed as having version 1.0.0. This ultimately means the version numbers in *.deps.json files will be incorrect. NuGet is working on a fix that requires us to add package verison information to restore nomination.

**Bugs this fixes:**

#1132, Part of Fix for https://github.com/NuGet/Home/issues/3901 

**Workarounds, if any**

None

**Risk**

Low. This just adds rules with more MSBuild properties that are picked up in a property bag by existing code

**Performance impact**

None

**Is this a regression from a previous update?**

No

**Root cause analysis:**

This feature has never been implemented

**How was the bug found?**

Dogfooding

/cc @srivatsn @nguerrera @dsplaisted 
/cc NuGet team @rrelyea @alpaix @emgarten 
/cc @MattGertz for RTW consideration. We would need to take this if NuGet brings a fix for  https://github.com/NuGet/Home/issues/3901, however both fixes are independent and can go in separately