### PR TITLE
Fix CoreCompile is never up-to-date

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -36,6 +36,7 @@
     <Compile Include="Extensions\ProjectConfigurationExtensions.cs" />
     <Compile Include="ProjectSystem\Build\BuildProperty.cs" />
     <Compile Include="CommonConstants.cs" />
+    <Compile Include="ProjectSystem\Build\TurnOffUseHostCompilerIfAvailableBuildPropertiesProvider.cs" />
     <Compile Include="ProjectSystem\Build\CommandLineDesignTimeBuildPropertiesProvider.cs" />
     <Compile Include="ProjectSystem\Build\GeneratePackageOnBuildDesignTimeBuildPropertyProvider.cs" />
     <Compile Include="ProjectSystem\Build\GeneratePackageOnBuildPropertyProvider.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/BuildProperty.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/BuildProperty.cs
@@ -17,5 +17,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
         ///     that would have been passed to Csc.exe and Vbc.exe.
         /// </summary>
         public static string ProvideCommandLineArgs = nameof(ProvideCommandLineArgs);
+
+        /// <summary>
+        ///     Indicates whether Csc/Vbc tasks should call into the in-proc host compiler.
+        /// </summary>
+        public static string UseHostCompilerIfAvailable = nameof(UseHostCompilerIfAvailable);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/TurnOffUseHostCompilerIfAvailableBuildPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/TurnOffUseHostCompilerIfAvailableBuildPropertiesProvider.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Build
+{
+    /// <summary>
+    ///     Turns off UseHostCompilerIfAvailable to prevent CoreCompile from always being called during builds, see: https://github.com/dotnet/sdk/issues/708.
+    /// </summary>
+    [ExportBuildGlobalPropertiesProvider]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicLanguageService)]
+    internal class TurnOffUseHostCompilerIfAvailableBuildPropertiesProvider : StaticGlobalPropertiesProviderBase
+    {
+        private static readonly Task<IImmutableDictionary<string, string>> BuildProperties = Task.FromResult<IImmutableDictionary<string, string>>(
+            Empty.PropertiesMap.Add(BuildProperty.UseHostCompilerIfAvailable, "false"));
+
+        [ImportingConstructor]
+        public TurnOffUseHostCompilerIfAvailableBuildPropertiesProvider(IProjectService projectService)
+            : base(projectService.Services)
+        {
+        }
+
+        public override Task<IImmutableDictionary<string, string>> GetGlobalPropertiesAsync(CancellationToken cancellationToken)
+        {
+            return BuildProperties;
+        }
+    }
+}


### PR DESCRIPTION
**Customer scenario**

.NET Core projects and other CPS-based C#/VB assemblies are always considered out-of-date. This means that we always call C#/VB compiler to output the binary regardless of whether it's up-to-date or not. 

This also has the impact of causing non-CPS based projects to also be considered out-of-date, causing every downstream proejct, and so forth to be rebuilt, increasing builds times and otherwise, making devs sad and unhappy.

NOTE: This does not add/fix the "fast up-to-date check" as called out by feature https://github.com/dotnet/roslyn-project-system/issues/62. We will still continue to shell out to MSBuild, and rely on it being up-to-date.

**Bugs this fixes:**

#825

**Workarounds, if any**

Devs can set the `$(UseHostCompilerIfAvailable)` property inside their project to `false`. However, this is considered undocumented - and not something we want developers to set themselves. It's also not obvious that this needs to be set.

**Risk**

Low

We don't use register a "host compiler", so the only usage of this property outside of tasks (which aren't hit without a host compiler) is the check that causes the compiler to be always called: https://github.com/Microsoft/msbuild/blob/765376a043d081569629998867d03e4a5eb9a256/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets#L3237. That's the line we're fixing.

**Performance impact**
This will make subsequent builds of a up-to-date project faster.

**Is this a regression from a previous update?**
No.

**Root cause analysis:**
We're only starting to see real world usage of this project now.

Our integration infrastructure is up and running yet, I've filed https://github.com/dotnet/roslyn-project-system/issues/1335 to track this.

**How was the bug found?**
Customer reported.

**Dev Notes**
Fixes: #825

There are certain situations where MSBuild will always call Csc/Vbc regardless of whether it's inputs/outputs are up-to-date. One these occasions is when it's building the project and UseHostCompilerIfAvailable is set to true (see _ComputeNonExistentFileProperty in Microsoft.Common.targets).

For CPS projects (and out-of-proc legacy project system builds), never use the host compiler - we always shell out builds to the process VBCSCompiler, or csc/vbc if that fails so we set this property to false.