### PR TITLE
Fix project system localization issues

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.es.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.es.resx
@@ -118,13 +118,13 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AssemblyNameLabel.Text" xml:space="preserve">
-    <value>&amp;Nombre de ensamblado:</value>
+    <value>Nombre de ensam&amp;blado:</value>
   </data>
   <data name="RootNamespaceLabel.Text" xml:space="preserve">
     <value>Espa&amp;cio de nombres predeterminado:</value>
   </data>
   <data name="OutputTypeLabel.Text" xml:space="preserve">
-    <value>Tipo de &amp;salida:</value>
+    <value>&amp;Tipo de salida:</value>
   </data>
   <data name="StartupObjectLabel.Text" xml:space="preserve">
     <value>&amp;Objeto de inicio:</value>
@@ -139,7 +139,7 @@
     <value>Especifique cómo se administrarán los recursos de la aplicación:</value>
   </data>
   <data name="IconRadioButton.Text" xml:space="preserve">
-    <value>I&amp;cono y manifiesto</value>
+    <value>Icono y mani&amp;fiesto</value>
   </data>
   <data name="ManifestExplanationLabel.Text" xml:space="preserve">
     <value>Un manifiesto determina una configuración específica para una aplicación. Para insertar un manifiesto personalizado, agréguelo primero al proyecto y, después, selecciónelo en la lista siguiente.</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.fr.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.fr.resx
@@ -124,7 +124,7 @@
     <value>Espace de noms par dé&amp;faut :</value>
   </data>
   <data name="OutputTypeLabel.Text" xml:space="preserve">
-    <value>Type de s&amp;ortie :</value>
+    <value>&amp;Type de sortie :</value>
   </data>
   <data name="StartupObjectLabel.Text" xml:space="preserve">
     <value>&amp;Objet de démarrage :</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.pl.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.pl.resx
@@ -121,7 +121,7 @@
     <value>&amp;Nazwa zestawu:</value>
   </data>
   <data name="RootNamespaceLabel.Text" xml:space="preserve">
-    <value>Domyśl&amp;na przestrzeń nazw:</value>
+    <value>&amp;Domyślna przestrzeń nazw:</value>
   </data>
   <data name="OutputTypeLabel.Text" xml:space="preserve">
     <value>Typ wy&amp;jściowy:</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.zh-Hans.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.zh-Hans.resx
@@ -121,7 +121,7 @@
     <value>程序集名称(&amp;N):</value>
   </data>
   <data name="RootNamespaceLabel.Text" xml:space="preserve">
-    <value>默认命名空间(&amp;I):</value>
+    <value>默认命名空间(&amp;L):</value>
   </data>
   <data name="OutputTypeLabel.Text" xml:space="preserve">
     <value>输出类型(&amp;U):</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.it.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.it.resx
@@ -133,7 +133,7 @@
     <value>&amp;Società:</value>
   </data>
   <data name="DescriptionLabel.Text" xml:space="preserve">
-    <value>De&amp;scrizione:</value>
+    <value>Descri&amp;zione:</value>
   </data>
   <data name="ComVisibleCheckBox.Text" xml:space="preserve">
     <value>&amp;Rendi assembly visibile a COM</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.ko.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.ko.resx
@@ -139,7 +139,7 @@
     <value>어셈블리를 COM에 노출(&amp;M)</value>
   </data>
   <data name="NeutralLanguageLabel.Text" xml:space="preserve">
-    <value>중립 언어(&amp;):</value>
+    <value>중립 언어(&amp;N):</value>
   </data>
   <data name="AssemblyVersionLabel.Text" xml:space="preserve">
     <value>어셈블리 버전(&amp;A):</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.pl.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.pl.resx
@@ -145,7 +145,7 @@
     <value>&amp;Wersja zestawu:</value>
   </data>
   <data name="FileVersionLabel.Text" xml:space="preserve">
-    <value>&amp;Wersja pliku:</value>
+    <value>Wersja pli&amp;ku:</value>
   </data>
   <data name="FileVersionMajorTextBox.AccessibleName" xml:space="preserve">
     <value>Główna</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.es.xlf
@@ -5,7 +5,7 @@
       <group id="src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.resx" />
       <trans-unit id="AssemblyNameLabel.Text">
         <source>Assembly &amp;name:</source>
-        <target state="translated">&amp;Nombre de ensamblado:</target>
+        <target state="translated">Nombre de ensam&amp;blado:</target>
         <note />
       </trans-unit>
       <trans-unit id="RootNamespaceLabel.Text">
@@ -15,7 +15,7 @@
       </trans-unit>
       <trans-unit id="OutputTypeLabel.Text">
         <source>O&amp;utput type:</source>
-        <target state="translated">Tipo de &amp;salida:</target>
+        <target state="translated">&amp;Tipo de salida:</target>
         <note />
       </trans-unit>
       <trans-unit id="StartupObjectLabel.Text">
@@ -40,7 +40,7 @@
       </trans-unit>
       <trans-unit id="IconRadioButton.Text">
         <source>I&amp;con and manifest</source>
-        <target state="translated">I&amp;cono y manifiesto</target>
+        <target state="translated">Icono y mani&amp;fiesto</target>
         <note />
       </trans-unit>
       <trans-unit id="ManifestExplanationLabel.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.fr.xlf
@@ -15,7 +15,7 @@
       </trans-unit>
       <trans-unit id="OutputTypeLabel.Text">
         <source>O&amp;utput type:</source>
-        <target state="translated">Type de s&amp;ortie :</target>
+        <target state="translated">&amp;Type de sortie :</target>
         <note />
       </trans-unit>
       <trans-unit id="StartupObjectLabel.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.pl.xlf
@@ -10,7 +10,7 @@
       </trans-unit>
       <trans-unit id="RootNamespaceLabel.Text">
         <source>Defau&amp;lt namespace:</source>
-        <target state="translated">Domyśl&amp;na przestrzeń nazw:</target>
+        <target state="translated">&amp;Domyślna przestrzeń nazw:</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputTypeLabel.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.zh-Hans.xlf
@@ -10,7 +10,7 @@
       </trans-unit>
       <trans-unit id="RootNamespaceLabel.Text">
         <source>Defau&amp;lt namespace:</source>
-        <target state="translated">默认命名空间(&amp;I):</target>
+        <target state="translated">默认命名空间(&amp;L):</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputTypeLabel.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.it.xlf
@@ -30,7 +30,7 @@
       </trans-unit>
       <trans-unit id="DescriptionLabel.Text">
         <source>&amp;Description:</source>
-        <target state="translated">De&amp;scrizione:</target>
+        <target state="translated">Descri&amp;zione:</target>
         <note />
       </trans-unit>
       <trans-unit id="ComVisibleCheckBox.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.ko.xlf
@@ -40,7 +40,7 @@
       </trans-unit>
       <trans-unit id="NeutralLanguageLabel.Text">
         <source>&amp;Neutral language:</source>
-        <target state="translated">중립 언어(&amp;):</target>
+        <target state="translated">중립 언어(&amp;N):</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionLabel.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.pl.xlf
@@ -50,7 +50,7 @@
       </trans-unit>
       <trans-unit id="FileVersionLabel.Text">
         <source>&amp;File version:</source>
-        <target state="translated">&amp;Wersja pliku:</target>
+        <target state="translated">Wersja pli&amp;ku:</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.cs.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.cs.resx
@@ -147,4 +147,10 @@
   <data name="10" xml:space="preserve">
     <value>Projekt pro vytvoření knihovny tříd určené pro .NET Core</value>
   </data>
+  <data name="11" xml:space="preserve">
+    <value>xUnit Test Project (.NET Core)</value>
+  </data>
+  <data name="12" xml:space="preserve">
+    <value>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.de.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.de.resx
@@ -147,4 +147,10 @@
   <data name="10" xml:space="preserve">
     <value>Ein Projekt zum Erstellen einer Klassenbibliothek für .NET Core.</value>
   </data>
+  <data name="11" xml:space="preserve">
+    <value>xUnit Test Project (.NET Core)</value>
+  </data>
+  <data name="12" xml:space="preserve">
+    <value>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.es.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.es.resx
@@ -147,4 +147,10 @@
   <data name="10" xml:space="preserve">
     <value>Proyecto para crear una biblioteca de clases para .NET Core.</value>
   </data>
+  <data name="11" xml:space="preserve">
+    <value>xUnit Test Project (.NET Core)</value>
+  </data>
+  <data name="12" xml:space="preserve">
+    <value>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.fr.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.fr.resx
@@ -147,4 +147,10 @@
   <data name="10" xml:space="preserve">
     <value>Projet de création d'une bibliothèque de classes ciblant .NET Core.</value>
   </data>
+  <data name="11" xml:space="preserve">
+    <value>xUnit Test Project (.NET Core)</value>
+  </data>
+  <data name="12" xml:space="preserve">
+    <value>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.it.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.it.resx
@@ -147,4 +147,10 @@
   <data name="10" xml:space="preserve">
     <value>Progetto per la creazione di una libreria di classi destinata a .NET Core.</value>
   </data>
+  <data name="11" xml:space="preserve">
+    <value>xUnit Test Project (.NET Core)</value>
+  </data>
+  <data name="12" xml:space="preserve">
+    <value>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.ja.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.ja.resx
@@ -147,4 +147,10 @@
   <data name="10" xml:space="preserve">
     <value>.NET Core を対象とするクラス ライブラリを作成するためのプロジェクトです。</value>
   </data>
+  <data name="11" xml:space="preserve">
+    <value>xUnit Test Project (.NET Core)</value>
+  </data>
+  <data name="12" xml:space="preserve">
+    <value>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.ko.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.ko.resx
@@ -147,4 +147,10 @@
   <data name="10" xml:space="preserve">
     <value>.NET Core를 대상으로 하는 클래스 라이브러리를 만드는 프로젝트입니다.</value>
   </data>
+  <data name="11" xml:space="preserve">
+    <value>xUnit Test Project (.NET Core)</value>
+  </data>
+  <data name="12" xml:space="preserve">
+    <value>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.pl.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.pl.resx
@@ -147,4 +147,10 @@
   <data name="10" xml:space="preserve">
     <value>Projekt służący do tworzenia biblioteki klas przeznaczonej dla środowiska .NET Core.</value>
   </data>
+  <data name="11" xml:space="preserve">
+    <value>xUnit Test Project (.NET Core)</value>
+  </data>
+  <data name="12" xml:space="preserve">
+    <value>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.pt-BR.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.pt-BR.resx
@@ -147,4 +147,10 @@
   <data name="10" xml:space="preserve">
     <value>Um projeto para criar uma biblioteca de classes direcionada para o .NET Core.</value>
   </data>
+  <data name="11" xml:space="preserve">
+    <value>xUnit Test Project (.NET Core)</value>
+  </data>
+  <data name="12" xml:space="preserve">
+    <value>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.resx
@@ -123,6 +123,12 @@
   <data name="10" xml:space="preserve">
     <value>A project for creating a class library that targets .NET Core.</value>
   </data>
+  <data name="11" xml:space="preserve">
+    <value>xUnit Test Project (.NET Core)</value>
+  </data>
+  <data name="12" xml:space="preserve">
+    <value>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</value>
+  </data>
   <data name="2" xml:space="preserve">
     <value>C# Project Files (*.csproj);*.csproj</value>
   </data>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.ru.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.ru.resx
@@ -147,4 +147,10 @@
   <data name="10" xml:space="preserve">
     <value>Проект для создания библиотеки классов, использующей .NET Core.</value>
   </data>
+  <data name="11" xml:space="preserve">
+    <value>xUnit Test Project (.NET Core)</value>
+  </data>
+  <data name="12" xml:space="preserve">
+    <value>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.tr.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.tr.resx
@@ -147,4 +147,10 @@
   <data name="10" xml:space="preserve">
     <value>.NET Core’u hedefleyen bir sınıf kitaplığı oluşturmaya yönelik proje.</value>
   </data>
+  <data name="11" xml:space="preserve">
+    <value>xUnit Test Project (.NET Core)</value>
+  </data>
+  <data name="12" xml:space="preserve">
+    <value>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.zh-Hans.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.zh-Hans.resx
@@ -147,4 +147,10 @@
   <data name="10" xml:space="preserve">
     <value>用于创建目标为 .NET Core 的类库的项目。</value>
   </data>
+  <data name="11" xml:space="preserve">
+    <value>xUnit Test Project (.NET Core)</value>
+  </data>
+  <data name="12" xml:space="preserve">
+    <value>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.zh-Hant.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/VSPackage.zh-Hant.resx
@@ -147,4 +147,10 @@
   <data name="10" xml:space="preserve">
     <value>專案，用於建立以 .NET Core 為目標的類別庫。</value>
   </data>
+  <data name="11" xml:space="preserve">
+    <value>xUnit Test Project (.NET Core)</value>
+  </data>
+  <data name="12" xml:space="preserve">
+    <value>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.cs.xlf
@@ -53,6 +53,16 @@
         <target state="translated">Projekt pro vytvoření knihovny tříd určené pro .NET Core</target>
         <note />
       </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="new">xUnit Test Project (.NET Core)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</source>
+        <target state="new">A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.de.xlf
@@ -53,6 +53,16 @@
         <target state="translated">Ein Projekt zum Erstellen einer Klassenbibliothek für .NET Core.</target>
         <note />
       </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="new">xUnit Test Project (.NET Core)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</source>
+        <target state="new">A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.es.xlf
@@ -53,6 +53,16 @@
         <target state="translated">Proyecto para crear una biblioteca de clases para .NET Core.</target>
         <note />
       </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="new">xUnit Test Project (.NET Core)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</source>
+        <target state="new">A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.fr.xlf
@@ -53,6 +53,16 @@
         <target state="translated">Projet de création d'une bibliothèque de classes ciblant .NET Core.</target>
         <note />
       </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="new">xUnit Test Project (.NET Core)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</source>
+        <target state="new">A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.it.xlf
@@ -53,6 +53,16 @@
         <target state="translated">Progetto per la creazione di una libreria di classi destinata a .NET Core.</target>
         <note />
       </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="new">xUnit Test Project (.NET Core)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</source>
+        <target state="new">A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.ja.xlf
@@ -53,6 +53,16 @@
         <target state="translated">.NET Core を対象とするクラス ライブラリを作成するためのプロジェクトです。</target>
         <note />
       </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="new">xUnit Test Project (.NET Core)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</source>
+        <target state="new">A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.ko.xlf
@@ -53,6 +53,16 @@
         <target state="translated">.NET Core를 대상으로 하는 클래스 라이브러리를 만드는 프로젝트입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="new">xUnit Test Project (.NET Core)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</source>
+        <target state="new">A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.pl.xlf
@@ -53,6 +53,16 @@
         <target state="translated">Projekt służący do tworzenia biblioteki klas przeznaczonej dla środowiska .NET Core.</target>
         <note />
       </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="new">xUnit Test Project (.NET Core)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</source>
+        <target state="new">A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.pt-BR.xlf
@@ -53,6 +53,16 @@
         <target state="translated">Um projeto para criar uma biblioteca de classes direcionada para o .NET Core.</target>
         <note />
       </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="new">xUnit Test Project (.NET Core)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</source>
+        <target state="new">A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.ru.xlf
@@ -53,6 +53,16 @@
         <target state="translated">Проект для создания библиотеки классов, использующей .NET Core.</target>
         <note />
       </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="new">xUnit Test Project (.NET Core)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</source>
+        <target state="new">A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.tr.xlf
@@ -53,6 +53,16 @@
         <target state="translated">.NET Core’u hedefleyen bir sınıf kitaplığı oluşturmaya yönelik proje.</target>
         <note />
       </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="new">xUnit Test Project (.NET Core)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</source>
+        <target state="new">A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.xlf
@@ -43,6 +43,14 @@
         <source>A project for creating a class library that targets .NET Core.</source>
         <note />
       </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</source>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.zh-Hans.xlf
@@ -53,6 +53,16 @@
         <target state="translated">用于创建目标为 .NET Core 的类库的项目。</target>
         <note />
       </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="new">xUnit Test Project (.NET Core)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</source>
+        <target state="new">A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/xlf/VSPackage.zh-Hant.xlf
@@ -53,6 +53,16 @@
         <target state="translated">專案，用於建立以 .NET Core 為目標的類別庫。</target>
         <note />
       </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="new">xUnit Test Project (.NET Core)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</source>
+        <target state="new">A project that contains xunit tests that can run on .NET Core on Windows, Linux and MacOS</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
@@ -56,7 +56,7 @@
                 Grid.Row="0"
                 x:Uid="profileLabel" 
                 Margin="4,4,3,5"
-                Content="_Profile"
+                Content="{x:Static Member=local:PropertyPageResources.Profile}"
                 IsTabStop="False" 
                 VerticalAlignment="Center"
                 Target="{Binding ElementName=profileCombo}"/>
@@ -92,7 +92,7 @@
                     Margin="6,8,1,8"
                     VerticalContentAlignment="Center"
                     VerticalAlignment="Center"
-                    Content="_New..."
+                    Content="{x:Static Member=local:PropertyPageResources.NewBtn}"
                     IsEnabled="{Binding Path=NewProfileEnabled, Mode=OneWay}"
                     Command="{Binding Path=NewProfileCommand}">
                 </Button>
@@ -104,7 +104,7 @@
                     Margin="6,8,1,8"
                     VerticalContentAlignment="Center"
                     VerticalAlignment="Center"
-                    Content="D_elete"
+                    Content="{x:Static Member=local:PropertyPageResources.DeleteBtn}"
                     IsEnabled="{Binding Path=DeleteProfileEnabled, Mode=OneWay}"
                     Command="{Binding Path=DeleteProfileCommand}">
                 </Button>
@@ -113,10 +113,9 @@
                 x:Uid="launchLabel"
                 Grid.Row="1" 
                 Margin="4,5,3,4"
-                Content="_Launch:"
+                Content="{x:Static Member=local:PropertyPageResources.Launch}"
                 MinWidth="150" 
-                IsTabStop="False" 
-                VerticalAlignment="Center"
+                IsTabStop="False"
                 Target="{Binding ElementName=launchCombo}"/>
             <ComboBox
                 Grid.Row="1"
@@ -137,7 +136,7 @@
                 Grid.Row="2"
                 x:Uid="executableLabel"
                 Margin="4,4,3,5"
-                Content="E_xecutable:"
+                Content="{x:Static Member=local:PropertyPageResources.Executable}"
                 IsTabStop="False" 
                 VerticalAlignment="Center"
                 Visibility="{Binding Path=SupportsExecutable, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
@@ -165,7 +164,7 @@
                 HorizontalAlignment="Left"
                 VerticalContentAlignment="Center"
                 VerticalAlignment="Center"
-                Content="Browse..."
+                Content="{x:Static Member=local:PropertyPageResources.BrowseBtn}"
                 IsEnabled="{Binding Path=IsProfileSelected, Mode=OneWay}"
                 Visibility="{Binding Path=SupportsExecutable, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
                 Command="{Binding Path=BrowseExecutableCommand}"/>
@@ -173,8 +172,8 @@
                 Grid.Row="4"
                 x:Uid="argumentsLabel"
                 Margin="4,4,3,0"
-                Content="_Application arguments:"
-                IsTabStop="False" 
+                Content="{x:Static Member=local:PropertyPageResources.ApplicationArguments}"
+                IsTabStop="False"
                 VerticalAlignment="Top"
                 Visibility="{Binding Path=SupportsArguments, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
                 Target="{Binding ElementName=txtArguments}"/>
@@ -196,7 +195,7 @@
                 Grid.Row="5"
                 x:Uid="workingDirectoryLabel"
                 Margin="4,4,3,5"
-                Content="W_orking directory:"
+                Content="{x:Static Member=local:PropertyPageResources.WorkingDirectory}"
                 VerticalAlignment="Center"
                 Visibility="{Binding Path=SupportsWorkingDirectory, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
                 Target="{Binding ElementName=txtWorkingDirectory}"/>
@@ -224,7 +223,7 @@
                 HorizontalAlignment="Left"
                 VerticalContentAlignment="Center"
                 VerticalAlignment="Center"
-                Content="Browse..."
+                Content="{x:Static Member=local:PropertyPageResources.BrowseBtn}"
                 IsEnabled="{Binding Path=IsProfileSelected, Mode=OneWay}"
                 Visibility="{Binding Path=SupportsWorkingDirectory, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
                 Command="{Binding Path=BrowseDirectoryCommand}"/>
@@ -239,7 +238,7 @@
                 IsEnabled="{Binding Path=IsProfileSelected, Mode=OneWay}"
                 Visibility="{Binding Path=SupportsLaunchUrl, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
                 VerticalContentAlignment="Center"
-                Content="Launch _URL:"/>
+                Content="{x:Static Member=local:PropertyPageResources.LaunchURL}"/>
             <local:WatermarkTextBox 
                 Grid.Row="6"
                 Grid.Column="1"
@@ -266,7 +265,7 @@
                 IsTabStop="False"
                 VerticalAlignment="Top"
                 Visibility="{Binding Path=SupportsEnvironmentVariables, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
-                Content="Environment variables:"/>
+                Content="{x:Static Member=local:PropertyPageResources.EnvironmentVariables}"/>
             <DataGrid
                 x:Name="dataGridEnvironmentVariables"
                 Grid.Row="7"
@@ -301,7 +300,7 @@
                     </Style>
                 </DataGrid.CellStyle>
                 <DataGrid.Columns>
-                    <local:EnvironmentDataGridTemplateColumn x:Uid="HeaderName" Header="Name" MinWidth="80">
+                    <local:EnvironmentDataGridTemplateColumn x:Uid="HeaderName" Header="{x:Static Member=local:PropertyPageResources.NameHeader}" MinWidth="80">
                         <local:EnvironmentDataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <Border Padding="4,0,4,0">
@@ -323,7 +322,7 @@
                             </DataTemplate>
                         </local:EnvironmentDataGridTemplateColumn.CellEditingTemplate>
                     </local:EnvironmentDataGridTemplateColumn>
-                    <local:EnvironmentDataGridTemplateColumn x:Uid="HeaderValue" Header="Value" MinWidth="255">
+                    <local:EnvironmentDataGridTemplateColumn x:Uid="HeaderValue" Header="{x:Static Member=local:PropertyPageResources.ValueHeader}" MinWidth="255">
                         <local:EnvironmentDataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <Border Padding="4,0,4,0">
@@ -356,27 +355,27 @@
                     Margin="0,8,0,10" 
                     MinWidth="80"
                     MinHeight="23"
-                    Command="{Binding Path=AddEnvironmentVariableRowCommand}">
+                    Command="{Binding Path=AddEnvironmentVariableRowCommand}"
+                    Content="{x:Static Member=local:PropertyPageResources.AddBtn}">
                     <Button.IsEnabled>
                         <MultiBinding Converter="{StaticResource MultiValueBoolToBoolAnd}">
                             <Binding Path="EnvironmentVariablesValid" Mode="OneWay"/>
                             <Binding Path="IsProfileSelected" Mode="OneWay"/>
                         </MultiBinding>
                     </Button.IsEnabled>
-                    A_dd
                 </Button>
                 <Button 
                     x:Uid="RemoveEnvironmentVariableButton" 
                     MinWidth="80"
                     MinHeight="23"
-                    Command="{Binding Path=RemoveEnvironmentVariableRowCommand}">
+                    Command="{Binding Path=RemoveEnvironmentVariableRowCommand}"
+                    Content="{x:Static Member=local:PropertyPageResources.RemoveBtn}">
                     <Button.IsEnabled>
                         <MultiBinding Converter="{StaticResource MultiValueBoolToBoolAnd}">
                             <Binding Path="RemoveEnvironmentVariablesRow" Mode="OneWay"/>
                             <Binding Path="IsProfileSelected" Mode="OneWay"/>
                         </MultiBinding>
                     </Button.IsEnabled>
-                    Remo_ve
                 </Button>
             </StackPanel>
             <!-- Where the custom control is placed for the active provider -->

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.Designer.cs
@@ -61,11 +61,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add.
+        /// </summary>
+        public static string AddBtn {
+            get {
+                return ResourceManager.GetString("AddBtn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to All files.
         /// </summary>
         public static string AllFiles {
             get {
                 return ResourceManager.GetString("AllFiles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Application arguments:.
+        /// </summary>
+        public static string ApplicationArguments {
+            get {
+                return ResourceManager.GetString("ApplicationArguments", resourceCulture);
             }
         }
         
@@ -79,6 +97,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Browse....
+        /// </summary>
+        public static string BrowseBtn {
+            get {
+                return ResourceManager.GetString("BrowseBtn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Debug.
         /// </summary>
         public static string DebugPropertyPageTitle {
@@ -88,11 +115,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Delete.
+        /// </summary>
+        public static string DeleteBtn {
+            get {
+                return ResourceManager.GetString("DeleteBtn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Duplicate Key.
         /// </summary>
         public static string DuplicateKey {
             get {
                 return ResourceManager.GetString("DuplicateKey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Environment variables:.
+        /// </summary>
+        public static string EnvironmentVariables {
+            get {
+                return ResourceManager.GetString("EnvironmentVariables", resourceCulture);
             }
         }
         
@@ -124,6 +169,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Executable.
+        /// </summary>
+        public static string Executable {
+            get {
+                return ResourceManager.GetString("Executable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Executable files.
         /// </summary>
         public static string ExecutableFiles {
@@ -138,6 +192,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         public static string ExecutablePathWatermark {
             get {
                 return ResourceManager.GetString("ExecutablePathWatermark", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Launch:.
+        /// </summary>
+        public static string Launch {
+            get {
+                return ResourceManager.GetString("Launch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Launch URL:.
+        /// </summary>
+        public static string LaunchURL {
+            get {
+                return ResourceManager.GetString("LaunchURL", resourceCulture);
             }
         }
         
@@ -160,6 +232,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Name.
+        /// </summary>
+        public static string NameHeader {
+            get {
+                return ResourceManager.GetString("NameHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to New....
+        /// </summary>
+        public static string NewBtn {
+            get {
+                return ResourceManager.GetString("NewBtn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to New profile.
         /// </summary>
         public static string NewProfileCaption {
@@ -174,6 +264,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         public static string NewProfileSeedName {
             get {
                 return ResourceManager.GetString("NewProfileSeedName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Profile:.
+        /// </summary>
+        public static string Profile {
+            get {
+                return ResourceManager.GetString("Profile", resourceCulture);
             }
         }
         
@@ -232,11 +331,38 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove.
+        /// </summary>
+        public static string RemoveBtn {
+            get {
+                return ResourceManager.GetString("RemoveBtn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Value cannot be empty..
         /// </summary>
         public static string ValueCannotBeEmpty {
             get {
                 return ResourceManager.GetString("ValueCannotBeEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Value.
+        /// </summary>
+        public static string ValueHeader {
+            get {
+                return ResourceManager.GetString("ValueHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Working directory:.
+        /// </summary>
+        public static string WorkingDirectory {
+            get {
+                return ResourceManager.GetString("WorkingDirectory", resourceCulture);
             }
         }
         

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.cs.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.cs.resx
@@ -180,4 +180,46 @@
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
     <value>Před uložením změn je potřeba opravit chyby na stránce.</value>
   </data>
+  <data name="AddBtn" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="ApplicationArguments" xml:space="preserve">
+    <value>Application arguments:</value>
+  </data>
+  <data name="BrowseBtn" xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="DeleteBtn" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="EnvironmentVariables" xml:space="preserve">
+    <value>Environment variables:</value>
+  </data>
+  <data name="Executable" xml:space="preserve">
+    <value>Executable</value>
+  </data>
+  <data name="Launch" xml:space="preserve">
+    <value>Launch:</value>
+  </data>
+  <data name="LaunchURL" xml:space="preserve">
+    <value>Launch URL:</value>
+  </data>
+  <data name="NameHeader" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="NewBtn" xml:space="preserve">
+    <value>New...</value>
+  </data>
+  <data name="Profile" xml:space="preserve">
+    <value>Profile:</value>
+  </data>
+  <data name="RemoveBtn" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="ValueHeader" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="WorkingDirectory" xml:space="preserve">
+    <value>Working directory:</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.de.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.de.resx
@@ -180,4 +180,46 @@
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
     <value>Die Fehler auf der Seite müssen vor dem Speichern Ihrer Änderungen korrigiert werden.</value>
   </data>
+  <data name="AddBtn" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="ApplicationArguments" xml:space="preserve">
+    <value>Application arguments:</value>
+  </data>
+  <data name="BrowseBtn" xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="DeleteBtn" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="EnvironmentVariables" xml:space="preserve">
+    <value>Environment variables:</value>
+  </data>
+  <data name="Executable" xml:space="preserve">
+    <value>Executable</value>
+  </data>
+  <data name="Launch" xml:space="preserve">
+    <value>Launch:</value>
+  </data>
+  <data name="LaunchURL" xml:space="preserve">
+    <value>Launch URL:</value>
+  </data>
+  <data name="NameHeader" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="NewBtn" xml:space="preserve">
+    <value>New...</value>
+  </data>
+  <data name="Profile" xml:space="preserve">
+    <value>Profile:</value>
+  </data>
+  <data name="RemoveBtn" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="ValueHeader" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="WorkingDirectory" xml:space="preserve">
+    <value>Working directory:</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.es.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.es.resx
@@ -180,4 +180,46 @@
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
     <value>Deben corregirse los errores de la página antes de guardar los cambios.</value>
   </data>
+  <data name="AddBtn" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="ApplicationArguments" xml:space="preserve">
+    <value>Application arguments:</value>
+  </data>
+  <data name="BrowseBtn" xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="DeleteBtn" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="EnvironmentVariables" xml:space="preserve">
+    <value>Environment variables:</value>
+  </data>
+  <data name="Executable" xml:space="preserve">
+    <value>Executable</value>
+  </data>
+  <data name="Launch" xml:space="preserve">
+    <value>Launch:</value>
+  </data>
+  <data name="LaunchURL" xml:space="preserve">
+    <value>Launch URL:</value>
+  </data>
+  <data name="NameHeader" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="NewBtn" xml:space="preserve">
+    <value>New...</value>
+  </data>
+  <data name="Profile" xml:space="preserve">
+    <value>Profile:</value>
+  </data>
+  <data name="RemoveBtn" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="ValueHeader" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="WorkingDirectory" xml:space="preserve">
+    <value>Working directory:</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.fr.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.fr.resx
@@ -180,4 +180,46 @@
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
     <value>Les erreurs de la page doivent être corrigées avant d’enregistrer vos modifications.</value>
   </data>
+  <data name="AddBtn" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="ApplicationArguments" xml:space="preserve">
+    <value>Application arguments:</value>
+  </data>
+  <data name="BrowseBtn" xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="DeleteBtn" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="EnvironmentVariables" xml:space="preserve">
+    <value>Environment variables:</value>
+  </data>
+  <data name="Executable" xml:space="preserve">
+    <value>Executable</value>
+  </data>
+  <data name="Launch" xml:space="preserve">
+    <value>Launch:</value>
+  </data>
+  <data name="LaunchURL" xml:space="preserve">
+    <value>Launch URL:</value>
+  </data>
+  <data name="NameHeader" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="NewBtn" xml:space="preserve">
+    <value>New...</value>
+  </data>
+  <data name="Profile" xml:space="preserve">
+    <value>Profile:</value>
+  </data>
+  <data name="RemoveBtn" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="ValueHeader" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="WorkingDirectory" xml:space="preserve">
+    <value>Working directory:</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.it.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.it.resx
@@ -180,4 +180,46 @@
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
     <value>Prima di salvare le modifiche, è necessario correggere gli errori presenti nella pagina.</value>
   </data>
+  <data name="AddBtn" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="ApplicationArguments" xml:space="preserve">
+    <value>Application arguments:</value>
+  </data>
+  <data name="BrowseBtn" xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="DeleteBtn" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="EnvironmentVariables" xml:space="preserve">
+    <value>Environment variables:</value>
+  </data>
+  <data name="Executable" xml:space="preserve">
+    <value>Executable</value>
+  </data>
+  <data name="Launch" xml:space="preserve">
+    <value>Launch:</value>
+  </data>
+  <data name="LaunchURL" xml:space="preserve">
+    <value>Launch URL:</value>
+  </data>
+  <data name="NameHeader" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="NewBtn" xml:space="preserve">
+    <value>New...</value>
+  </data>
+  <data name="Profile" xml:space="preserve">
+    <value>Profile:</value>
+  </data>
+  <data name="RemoveBtn" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="ValueHeader" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="WorkingDirectory" xml:space="preserve">
+    <value>Working directory:</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.ja.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.ja.resx
@@ -180,4 +180,46 @@
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
     <value>ページ上のエラーは変更を保存する前に修正する必要があります。</value>
   </data>
+  <data name="AddBtn" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="ApplicationArguments" xml:space="preserve">
+    <value>Application arguments:</value>
+  </data>
+  <data name="BrowseBtn" xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="DeleteBtn" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="EnvironmentVariables" xml:space="preserve">
+    <value>Environment variables:</value>
+  </data>
+  <data name="Executable" xml:space="preserve">
+    <value>Executable</value>
+  </data>
+  <data name="Launch" xml:space="preserve">
+    <value>Launch:</value>
+  </data>
+  <data name="LaunchURL" xml:space="preserve">
+    <value>Launch URL:</value>
+  </data>
+  <data name="NameHeader" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="NewBtn" xml:space="preserve">
+    <value>New...</value>
+  </data>
+  <data name="Profile" xml:space="preserve">
+    <value>Profile:</value>
+  </data>
+  <data name="RemoveBtn" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="ValueHeader" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="WorkingDirectory" xml:space="preserve">
+    <value>Working directory:</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.ko.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.ko.resx
@@ -180,4 +180,46 @@
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
     <value>페이지의 오류는 변경 내용을 저장하기 전에 수정해야 합니다.</value>
   </data>
+  <data name="AddBtn" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="ApplicationArguments" xml:space="preserve">
+    <value>Application arguments:</value>
+  </data>
+  <data name="BrowseBtn" xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="DeleteBtn" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="EnvironmentVariables" xml:space="preserve">
+    <value>Environment variables:</value>
+  </data>
+  <data name="Executable" xml:space="preserve">
+    <value>Executable</value>
+  </data>
+  <data name="Launch" xml:space="preserve">
+    <value>Launch:</value>
+  </data>
+  <data name="LaunchURL" xml:space="preserve">
+    <value>Launch URL:</value>
+  </data>
+  <data name="NameHeader" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="NewBtn" xml:space="preserve">
+    <value>New...</value>
+  </data>
+  <data name="Profile" xml:space="preserve">
+    <value>Profile:</value>
+  </data>
+  <data name="RemoveBtn" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="ValueHeader" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="WorkingDirectory" xml:space="preserve">
+    <value>Working directory:</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.pl.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.pl.resx
@@ -180,4 +180,46 @@
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
     <value>Przed zapisaniem zmian należy poprawić błędy na stronie.</value>
   </data>
+  <data name="AddBtn" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="ApplicationArguments" xml:space="preserve">
+    <value>Application arguments:</value>
+  </data>
+  <data name="BrowseBtn" xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="DeleteBtn" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="EnvironmentVariables" xml:space="preserve">
+    <value>Environment variables:</value>
+  </data>
+  <data name="Executable" xml:space="preserve">
+    <value>Executable</value>
+  </data>
+  <data name="Launch" xml:space="preserve">
+    <value>Launch:</value>
+  </data>
+  <data name="LaunchURL" xml:space="preserve">
+    <value>Launch URL:</value>
+  </data>
+  <data name="NameHeader" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="NewBtn" xml:space="preserve">
+    <value>New...</value>
+  </data>
+  <data name="Profile" xml:space="preserve">
+    <value>Profile:</value>
+  </data>
+  <data name="RemoveBtn" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="ValueHeader" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="WorkingDirectory" xml:space="preserve">
+    <value>Working directory:</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.pt-BR.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.pt-BR.resx
@@ -180,4 +180,46 @@
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
     <value>Os erros na página devem ser corrigidos antes de salvar suas mudanças.</value>
   </data>
+  <data name="AddBtn" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="ApplicationArguments" xml:space="preserve">
+    <value>Application arguments:</value>
+  </data>
+  <data name="BrowseBtn" xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="DeleteBtn" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="EnvironmentVariables" xml:space="preserve">
+    <value>Environment variables:</value>
+  </data>
+  <data name="Executable" xml:space="preserve">
+    <value>Executable</value>
+  </data>
+  <data name="Launch" xml:space="preserve">
+    <value>Launch:</value>
+  </data>
+  <data name="LaunchURL" xml:space="preserve">
+    <value>Launch URL:</value>
+  </data>
+  <data name="NameHeader" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="NewBtn" xml:space="preserve">
+    <value>New...</value>
+  </data>
+  <data name="Profile" xml:space="preserve">
+    <value>Profile:</value>
+  </data>
+  <data name="RemoveBtn" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="ValueHeader" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="WorkingDirectory" xml:space="preserve">
+    <value>Working directory:</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.resx
@@ -179,4 +179,47 @@
   </data>
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
     <value>The errors on the page must be corrected prior to saving your changes.</value>
-  </data></root>
+  </data>
+  <data name="AddBtn" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="ApplicationArguments" xml:space="preserve">
+    <value>Application arguments:</value>
+  </data>
+  <data name="BrowseBtn" xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="DeleteBtn" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="EnvironmentVariables" xml:space="preserve">
+    <value>Environment variables:</value>
+  </data>
+  <data name="Executable" xml:space="preserve">
+    <value>Executable</value>
+  </data>
+  <data name="Launch" xml:space="preserve">
+    <value>Launch:</value>
+  </data>
+  <data name="LaunchURL" xml:space="preserve">
+    <value>Launch URL:</value>
+  </data>
+  <data name="NameHeader" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="NewBtn" xml:space="preserve">
+    <value>New...</value>
+  </data>
+  <data name="Profile" xml:space="preserve">
+    <value>Profile:</value>
+  </data>
+  <data name="RemoveBtn" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="ValueHeader" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="WorkingDirectory" xml:space="preserve">
+    <value>Working directory:</value>
+  </data>
+</root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.ru.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.ru.resx
@@ -180,4 +180,46 @@
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
     <value>Устраните ошибки на странице перед тем, как сохранять изменения.</value>
   </data>
+  <data name="AddBtn" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="ApplicationArguments" xml:space="preserve">
+    <value>Application arguments:</value>
+  </data>
+  <data name="BrowseBtn" xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="DeleteBtn" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="EnvironmentVariables" xml:space="preserve">
+    <value>Environment variables:</value>
+  </data>
+  <data name="Executable" xml:space="preserve">
+    <value>Executable</value>
+  </data>
+  <data name="Launch" xml:space="preserve">
+    <value>Launch:</value>
+  </data>
+  <data name="LaunchURL" xml:space="preserve">
+    <value>Launch URL:</value>
+  </data>
+  <data name="NameHeader" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="NewBtn" xml:space="preserve">
+    <value>New...</value>
+  </data>
+  <data name="Profile" xml:space="preserve">
+    <value>Profile:</value>
+  </data>
+  <data name="RemoveBtn" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="ValueHeader" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="WorkingDirectory" xml:space="preserve">
+    <value>Working directory:</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.tr.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.tr.resx
@@ -180,4 +180,46 @@
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
     <value>Değişiklikleriniz kaydedilmeden önce bu sayfadaki hataların düzeltilmesi gerekiyor.</value>
   </data>
+  <data name="AddBtn" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="ApplicationArguments" xml:space="preserve">
+    <value>Application arguments:</value>
+  </data>
+  <data name="BrowseBtn" xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="DeleteBtn" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="EnvironmentVariables" xml:space="preserve">
+    <value>Environment variables:</value>
+  </data>
+  <data name="Executable" xml:space="preserve">
+    <value>Executable</value>
+  </data>
+  <data name="Launch" xml:space="preserve">
+    <value>Launch:</value>
+  </data>
+  <data name="LaunchURL" xml:space="preserve">
+    <value>Launch URL:</value>
+  </data>
+  <data name="NameHeader" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="NewBtn" xml:space="preserve">
+    <value>New...</value>
+  </data>
+  <data name="Profile" xml:space="preserve">
+    <value>Profile:</value>
+  </data>
+  <data name="RemoveBtn" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="ValueHeader" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="WorkingDirectory" xml:space="preserve">
+    <value>Working directory:</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.zh-Hans.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.zh-Hans.resx
@@ -180,4 +180,46 @@
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
     <value>保存更改前必须更正页面上的错误。</value>
   </data>
+  <data name="AddBtn" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="ApplicationArguments" xml:space="preserve">
+    <value>Application arguments:</value>
+  </data>
+  <data name="BrowseBtn" xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="DeleteBtn" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="EnvironmentVariables" xml:space="preserve">
+    <value>Environment variables:</value>
+  </data>
+  <data name="Executable" xml:space="preserve">
+    <value>Executable</value>
+  </data>
+  <data name="Launch" xml:space="preserve">
+    <value>Launch:</value>
+  </data>
+  <data name="LaunchURL" xml:space="preserve">
+    <value>Launch URL:</value>
+  </data>
+  <data name="NameHeader" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="NewBtn" xml:space="preserve">
+    <value>New...</value>
+  </data>
+  <data name="Profile" xml:space="preserve">
+    <value>Profile:</value>
+  </data>
+  <data name="RemoveBtn" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="ValueHeader" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="WorkingDirectory" xml:space="preserve">
+    <value>Working directory:</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.zh-Hant.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.zh-Hant.resx
@@ -180,4 +180,46 @@
   <data name="ErrorsMustBeCorrectedPriorToSaving" xml:space="preserve">
     <value>必須先修正頁面上的錯誤，才能儲存您的變更。</value>
   </data>
+  <data name="AddBtn" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="ApplicationArguments" xml:space="preserve">
+    <value>Application arguments:</value>
+  </data>
+  <data name="BrowseBtn" xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="DeleteBtn" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="EnvironmentVariables" xml:space="preserve">
+    <value>Environment variables:</value>
+  </data>
+  <data name="Executable" xml:space="preserve">
+    <value>Executable</value>
+  </data>
+  <data name="Launch" xml:space="preserve">
+    <value>Launch:</value>
+  </data>
+  <data name="LaunchURL" xml:space="preserve">
+    <value>Launch URL:</value>
+  </data>
+  <data name="NameHeader" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="NewBtn" xml:space="preserve">
+    <value>New...</value>
+  </data>
+  <data name="Profile" xml:space="preserve">
+    <value>Profile:</value>
+  </data>
+  <data name="RemoveBtn" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="ValueHeader" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="WorkingDirectory" xml:space="preserve">
+    <value>Working directory:</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.cs.xlf
@@ -108,6 +108,76 @@
         <target state="translated">Před uložením změn je potřeba opravit chyby na stránce.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddBtn">
+        <source>Add</source>
+        <target state="new">Add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ApplicationArguments">
+        <source>Application arguments:</source>
+        <target state="new">Application arguments:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BrowseBtn">
+        <source>Browse...</source>
+        <target state="new">Browse...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeleteBtn">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariables">
+        <source>Environment variables:</source>
+        <target state="new">Environment variables:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Executable">
+        <source>Executable</source>
+        <target state="new">Executable</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Launch">
+        <source>Launch:</source>
+        <target state="new">Launch:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LaunchURL">
+        <source>Launch URL:</source>
+        <target state="new">Launch URL:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NameHeader">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NewBtn">
+        <source>New...</source>
+        <target state="new">New...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Profile">
+        <source>Profile:</source>
+        <target state="new">Profile:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveBtn">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ValueHeader">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WorkingDirectory">
+        <source>Working directory:</source>
+        <target state="new">Working directory:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.de.xlf
@@ -108,6 +108,76 @@
         <target state="translated">Die Fehler auf der Seite müssen vor dem Speichern Ihrer Änderungen korrigiert werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddBtn">
+        <source>Add</source>
+        <target state="new">Add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ApplicationArguments">
+        <source>Application arguments:</source>
+        <target state="new">Application arguments:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BrowseBtn">
+        <source>Browse...</source>
+        <target state="new">Browse...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeleteBtn">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariables">
+        <source>Environment variables:</source>
+        <target state="new">Environment variables:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Executable">
+        <source>Executable</source>
+        <target state="new">Executable</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Launch">
+        <source>Launch:</source>
+        <target state="new">Launch:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LaunchURL">
+        <source>Launch URL:</source>
+        <target state="new">Launch URL:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NameHeader">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NewBtn">
+        <source>New...</source>
+        <target state="new">New...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Profile">
+        <source>Profile:</source>
+        <target state="new">Profile:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveBtn">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ValueHeader">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WorkingDirectory">
+        <source>Working directory:</source>
+        <target state="new">Working directory:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.es.xlf
@@ -108,6 +108,76 @@
         <target state="translated">Deben corregirse los errores de la página antes de guardar los cambios.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddBtn">
+        <source>Add</source>
+        <target state="new">Add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ApplicationArguments">
+        <source>Application arguments:</source>
+        <target state="new">Application arguments:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BrowseBtn">
+        <source>Browse...</source>
+        <target state="new">Browse...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeleteBtn">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariables">
+        <source>Environment variables:</source>
+        <target state="new">Environment variables:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Executable">
+        <source>Executable</source>
+        <target state="new">Executable</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Launch">
+        <source>Launch:</source>
+        <target state="new">Launch:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LaunchURL">
+        <source>Launch URL:</source>
+        <target state="new">Launch URL:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NameHeader">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NewBtn">
+        <source>New...</source>
+        <target state="new">New...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Profile">
+        <source>Profile:</source>
+        <target state="new">Profile:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveBtn">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ValueHeader">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WorkingDirectory">
+        <source>Working directory:</source>
+        <target state="new">Working directory:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.fr.xlf
@@ -108,6 +108,76 @@
         <target state="translated">Les erreurs de la page doivent être corrigées avant d’enregistrer vos modifications.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddBtn">
+        <source>Add</source>
+        <target state="new">Add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ApplicationArguments">
+        <source>Application arguments:</source>
+        <target state="new">Application arguments:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BrowseBtn">
+        <source>Browse...</source>
+        <target state="new">Browse...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeleteBtn">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariables">
+        <source>Environment variables:</source>
+        <target state="new">Environment variables:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Executable">
+        <source>Executable</source>
+        <target state="new">Executable</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Launch">
+        <source>Launch:</source>
+        <target state="new">Launch:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LaunchURL">
+        <source>Launch URL:</source>
+        <target state="new">Launch URL:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NameHeader">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NewBtn">
+        <source>New...</source>
+        <target state="new">New...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Profile">
+        <source>Profile:</source>
+        <target state="new">Profile:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveBtn">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ValueHeader">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WorkingDirectory">
+        <source>Working directory:</source>
+        <target state="new">Working directory:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.it.xlf
@@ -108,6 +108,76 @@
         <target state="translated">Prima di salvare le modifiche, è necessario correggere gli errori presenti nella pagina.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddBtn">
+        <source>Add</source>
+        <target state="new">Add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ApplicationArguments">
+        <source>Application arguments:</source>
+        <target state="new">Application arguments:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BrowseBtn">
+        <source>Browse...</source>
+        <target state="new">Browse...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeleteBtn">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariables">
+        <source>Environment variables:</source>
+        <target state="new">Environment variables:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Executable">
+        <source>Executable</source>
+        <target state="new">Executable</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Launch">
+        <source>Launch:</source>
+        <target state="new">Launch:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LaunchURL">
+        <source>Launch URL:</source>
+        <target state="new">Launch URL:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NameHeader">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NewBtn">
+        <source>New...</source>
+        <target state="new">New...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Profile">
+        <source>Profile:</source>
+        <target state="new">Profile:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveBtn">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ValueHeader">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WorkingDirectory">
+        <source>Working directory:</source>
+        <target state="new">Working directory:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ja.xlf
@@ -108,6 +108,76 @@
         <target state="translated">ページ上のエラーは変更を保存する前に修正する必要があります。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddBtn">
+        <source>Add</source>
+        <target state="new">Add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ApplicationArguments">
+        <source>Application arguments:</source>
+        <target state="new">Application arguments:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BrowseBtn">
+        <source>Browse...</source>
+        <target state="new">Browse...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeleteBtn">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariables">
+        <source>Environment variables:</source>
+        <target state="new">Environment variables:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Executable">
+        <source>Executable</source>
+        <target state="new">Executable</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Launch">
+        <source>Launch:</source>
+        <target state="new">Launch:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LaunchURL">
+        <source>Launch URL:</source>
+        <target state="new">Launch URL:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NameHeader">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NewBtn">
+        <source>New...</source>
+        <target state="new">New...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Profile">
+        <source>Profile:</source>
+        <target state="new">Profile:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveBtn">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ValueHeader">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WorkingDirectory">
+        <source>Working directory:</source>
+        <target state="new">Working directory:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ko.xlf
@@ -108,6 +108,76 @@
         <target state="translated">페이지의 오류는 변경 내용을 저장하기 전에 수정해야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddBtn">
+        <source>Add</source>
+        <target state="new">Add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ApplicationArguments">
+        <source>Application arguments:</source>
+        <target state="new">Application arguments:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BrowseBtn">
+        <source>Browse...</source>
+        <target state="new">Browse...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeleteBtn">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariables">
+        <source>Environment variables:</source>
+        <target state="new">Environment variables:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Executable">
+        <source>Executable</source>
+        <target state="new">Executable</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Launch">
+        <source>Launch:</source>
+        <target state="new">Launch:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LaunchURL">
+        <source>Launch URL:</source>
+        <target state="new">Launch URL:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NameHeader">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NewBtn">
+        <source>New...</source>
+        <target state="new">New...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Profile">
+        <source>Profile:</source>
+        <target state="new">Profile:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveBtn">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ValueHeader">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WorkingDirectory">
+        <source>Working directory:</source>
+        <target state="new">Working directory:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pl.xlf
@@ -108,6 +108,76 @@
         <target state="translated">Przed zapisaniem zmian należy poprawić błędy na stronie.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddBtn">
+        <source>Add</source>
+        <target state="new">Add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ApplicationArguments">
+        <source>Application arguments:</source>
+        <target state="new">Application arguments:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BrowseBtn">
+        <source>Browse...</source>
+        <target state="new">Browse...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeleteBtn">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariables">
+        <source>Environment variables:</source>
+        <target state="new">Environment variables:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Executable">
+        <source>Executable</source>
+        <target state="new">Executable</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Launch">
+        <source>Launch:</source>
+        <target state="new">Launch:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LaunchURL">
+        <source>Launch URL:</source>
+        <target state="new">Launch URL:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NameHeader">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NewBtn">
+        <source>New...</source>
+        <target state="new">New...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Profile">
+        <source>Profile:</source>
+        <target state="new">Profile:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveBtn">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ValueHeader">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WorkingDirectory">
+        <source>Working directory:</source>
+        <target state="new">Working directory:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pt-BR.xlf
@@ -108,6 +108,76 @@
         <target state="translated">Os erros na página devem ser corrigidos antes de salvar suas mudanças.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddBtn">
+        <source>Add</source>
+        <target state="new">Add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ApplicationArguments">
+        <source>Application arguments:</source>
+        <target state="new">Application arguments:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BrowseBtn">
+        <source>Browse...</source>
+        <target state="new">Browse...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeleteBtn">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariables">
+        <source>Environment variables:</source>
+        <target state="new">Environment variables:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Executable">
+        <source>Executable</source>
+        <target state="new">Executable</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Launch">
+        <source>Launch:</source>
+        <target state="new">Launch:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LaunchURL">
+        <source>Launch URL:</source>
+        <target state="new">Launch URL:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NameHeader">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NewBtn">
+        <source>New...</source>
+        <target state="new">New...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Profile">
+        <source>Profile:</source>
+        <target state="new">Profile:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveBtn">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ValueHeader">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WorkingDirectory">
+        <source>Working directory:</source>
+        <target state="new">Working directory:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ru.xlf
@@ -108,6 +108,76 @@
         <target state="translated">Устраните ошибки на странице перед тем, как сохранять изменения.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddBtn">
+        <source>Add</source>
+        <target state="new">Add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ApplicationArguments">
+        <source>Application arguments:</source>
+        <target state="new">Application arguments:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BrowseBtn">
+        <source>Browse...</source>
+        <target state="new">Browse...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeleteBtn">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariables">
+        <source>Environment variables:</source>
+        <target state="new">Environment variables:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Executable">
+        <source>Executable</source>
+        <target state="new">Executable</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Launch">
+        <source>Launch:</source>
+        <target state="new">Launch:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LaunchURL">
+        <source>Launch URL:</source>
+        <target state="new">Launch URL:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NameHeader">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NewBtn">
+        <source>New...</source>
+        <target state="new">New...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Profile">
+        <source>Profile:</source>
+        <target state="new">Profile:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveBtn">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ValueHeader">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WorkingDirectory">
+        <source>Working directory:</source>
+        <target state="new">Working directory:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.tr.xlf
@@ -108,6 +108,76 @@
         <target state="translated">Değişiklikleriniz kaydedilmeden önce bu sayfadaki hataların düzeltilmesi gerekiyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddBtn">
+        <source>Add</source>
+        <target state="new">Add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ApplicationArguments">
+        <source>Application arguments:</source>
+        <target state="new">Application arguments:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BrowseBtn">
+        <source>Browse...</source>
+        <target state="new">Browse...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeleteBtn">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariables">
+        <source>Environment variables:</source>
+        <target state="new">Environment variables:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Executable">
+        <source>Executable</source>
+        <target state="new">Executable</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Launch">
+        <source>Launch:</source>
+        <target state="new">Launch:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LaunchURL">
+        <source>Launch URL:</source>
+        <target state="new">Launch URL:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NameHeader">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NewBtn">
+        <source>New...</source>
+        <target state="new">New...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Profile">
+        <source>Profile:</source>
+        <target state="new">Profile:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveBtn">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ValueHeader">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WorkingDirectory">
+        <source>Working directory:</source>
+        <target state="new">Working directory:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.xlf
@@ -87,6 +87,62 @@
         <source>The errors on the page must be corrected prior to saving your changes.</source>
         <note />
       </trans-unit>
+      <trans-unit id="AddBtn">
+        <source>Add</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ApplicationArguments">
+        <source>Application arguments:</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BrowseBtn">
+        <source>Browse...</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeleteBtn">
+        <source>Delete</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariables">
+        <source>Environment variables:</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Executable">
+        <source>Executable</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Launch">
+        <source>Launch:</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LaunchURL">
+        <source>Launch URL:</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NameHeader">
+        <source>Name</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NewBtn">
+        <source>New...</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Profile">
+        <source>Profile:</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveBtn">
+        <source>Remove</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ValueHeader">
+        <source>Value</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WorkingDirectory">
+        <source>Working directory:</source>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hans.xlf
@@ -108,6 +108,76 @@
         <target state="translated">保存更改前必须更正页面上的错误。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddBtn">
+        <source>Add</source>
+        <target state="new">Add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ApplicationArguments">
+        <source>Application arguments:</source>
+        <target state="new">Application arguments:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BrowseBtn">
+        <source>Browse...</source>
+        <target state="new">Browse...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeleteBtn">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariables">
+        <source>Environment variables:</source>
+        <target state="new">Environment variables:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Executable">
+        <source>Executable</source>
+        <target state="new">Executable</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Launch">
+        <source>Launch:</source>
+        <target state="new">Launch:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LaunchURL">
+        <source>Launch URL:</source>
+        <target state="new">Launch URL:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NameHeader">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NewBtn">
+        <source>New...</source>
+        <target state="new">New...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Profile">
+        <source>Profile:</source>
+        <target state="new">Profile:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveBtn">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ValueHeader">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WorkingDirectory">
+        <source>Working directory:</source>
+        <target state="new">Working directory:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hant.xlf
@@ -108,6 +108,76 @@
         <target state="translated">必須先修正頁面上的錯誤，才能儲存您的變更。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddBtn">
+        <source>Add</source>
+        <target state="new">Add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ApplicationArguments">
+        <source>Application arguments:</source>
+        <target state="new">Application arguments:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BrowseBtn">
+        <source>Browse...</source>
+        <target state="new">Browse...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeleteBtn">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentVariables">
+        <source>Environment variables:</source>
+        <target state="new">Environment variables:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Executable">
+        <source>Executable</source>
+        <target state="new">Executable</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Launch">
+        <source>Launch:</source>
+        <target state="new">Launch:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LaunchURL">
+        <source>Launch URL:</source>
+        <target state="new">Launch URL:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NameHeader">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NewBtn">
+        <source>New...</source>
+        <target state="new">New...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Profile">
+        <source>Profile:</source>
+        <target state="new">Profile:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveBtn">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ValueHeader">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WorkingDirectory">
+        <source>Working directory:</source>
+        <target state="new">Working directory:</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/NuGetRestore.xaml
@@ -36,7 +36,12 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Version" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/NuGetRestore.xaml
@@ -36,7 +36,12 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Version" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/NuGetRestore.xaml
@@ -36,7 +36,12 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Version" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/NuGetRestore.xaml
@@ -36,7 +36,12 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Version" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/NuGetRestore.xaml
@@ -36,7 +36,12 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Version" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/NuGetRestore.xaml
@@ -36,7 +36,12 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Version" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/NuGetRestore.xaml
@@ -36,7 +36,12 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Version" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/NuGetRestore.xaml
@@ -36,7 +36,12 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Version" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/NuGetRestore.xaml
@@ -36,7 +36,12 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Version" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/NuGetRestore.xaml
@@ -36,7 +36,12 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Version" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/NuGetRestore.xaml
@@ -36,7 +36,12 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Version" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/NuGetRestore.xaml
@@ -36,7 +36,12 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Version" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/NuGetRestore.xaml
@@ -36,7 +36,12 @@
   </StringProperty>
   <StringProperty Name="BaseIntermediateOutputPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Version" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
 </Rule>


### PR DESCRIPTION
This change takes a loc handback and adds strings for debug property page and xUnit test project template

**Customer scenario**

* Certain UI elements are not localized
  * Most of .NET Core debug property page 
  * xUnit test project template name and description

<br>

* Certain hotkeys (accelerators) are duplicated or missing

**Bugs this fixes:**

* #1286 
  * [371431](https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=371431&triage=true)
  * Extracts strings, but another handoff/handback will be needed to resolve completely
<br>

* Fix #1331, which is GitHub tracking issue for VSO items below:
  * [368010](https://devdiv.visualstudio.com/DevDiv/_workitems?id=368010)
  * [368022](https://devdiv.visualstudio.com/DevDiv/_workitems?id=368022)
  * [368870](https://devdiv.visualstudio.com/DevDiv/_workitems?id=368870)
  * [368872](https://devdiv.visualstudio.com/DevDiv/_workitems?id=368872)
  * [368875](https://devdiv.visualstudio.com/DevDiv/_workitems?id=368875)
  * [368881](https://devdiv.visualstudio.com/DevDiv/_workitems?id=368881)

**Workarounds, if any**
None

**Risk**
Low 

**Performance impact**
Low

**Is this a regression from a previous update?**
No for debug property page or xunit template.
Yes for hot keys

**Root cause analysis:**

* Debug Page was copied over from xproj  and we missed that it had some hard-coded strings.
* Hotkey duplication was caused by the loc recycling from old system to new system not preserving hot keys

**How was the bug found?**
Directed testing

@srivatsn @jinujoseph @dotnet/project-system 
