### PR TITLE
Ap/hide implicit packages

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Mocks\IDebugLaunchProviderMetadataViewFactory.cs" />
     <Compile Include="Mocks\IDteServicesFactory.cs" />
     <Compile Include="Mocks\ExportFactoryFactory.cs" />
+    <Compile Include="Mocks\INuGetPackagesDataProviderFactory.cs" />
     <Compile Include="Mocks\IVsHiearchyItemFactory.cs" />
     <Compile Include="Mocks\IProjectFileEditorPresenterFactory.cs" />
     <Compile Include="Mocks\IFrameOpenCloseListenerFactory.cs" />
@@ -157,6 +158,7 @@
     <Compile Include="ProjectSystem\VS\SpecialFileProviders\VsProjectSpecialFilesManagerTests.cs" />
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\DependenciesGraphProviderTests.cs" />
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\DependenciesSubTreeProviderBaseTests.cs" />
+    <Compile Include="ProjectSystem\VS\Tree\Dependencies\SdkDependenciesSubTreeProviderTests.cs" />
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\ProjectDependenciesSubTreeProviderTests.cs" />
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\NuGetDependenciesSubTreeProviderTests.cs" />
     <Compile Include="ProjectSystem\VS\UI\MultiChoiceMsgBoxViewModelTests.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/INuGetPackagesDataProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/INuGetPackagesDataProviderFactory.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    internal static class INuGetPackagesDataProviderFactory
+    {
+        public static INuGetPackagesDataProvider Create()
+        {
+            return Mock.Of<INuGetPackagesDataProvider>();
+        }
+
+        public static INuGetPackagesDataProvider ImplementUpdateNodeChildren(string itemSpec,
+                                                                IDependencyNode node,
+                                                                IDependencyNode[] childrenToAdd,
+                                                                MockBehavior? mockBehavior = null)
+        {
+            var behavior = mockBehavior ?? MockBehavior.Default;
+            var mock = new Mock<INuGetPackagesDataProvider>(behavior);
+            mock.Setup(x => x.UpdateNodeChildren(itemSpec, node));
+
+            node.Children.AddRange(childrenToAdd);
+            return mock.Object;
+        }
+
+        public static INuGetPackagesDataProvider ImplementSearchAsync(string itemSpec,
+                                                                      string searchTerm,
+                                                                      IEnumerable<IDependencyNode> resultNodes,
+                                                                      MockBehavior? mockBehavior = null)
+        {
+            var behavior = mockBehavior ?? MockBehavior.Default;
+            var mock = new Mock<INuGetPackagesDataProvider>(behavior);
+            mock.Setup(x => x.SearchAsync(itemSpec, searchTerm)).Returns(Task.FromResult(resultNodes));
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/NuGetDependenciesSubTreeProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/NuGetDependenciesSubTreeProviderTests.cs
@@ -272,12 +272,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 ""Items"": {
                     ""package1"": {
                         ""Version"": ""1.0.0""
+                    },
+                    ""ImplicitPackage2"": {
+                        ""Version"": ""1.0.0"",
+                        ""IsImplicitlyDefined"":""true""
                     }
                 },
                 ""RuleName"": ""PackageReference""
             },
             ""Difference"": {
-                ""AddedItems"": [ ""package1"" ],
+                ""AddedItems"": [ ""package1"", ""ImplicitPackage2"" ],
                 ""ChangedItems"": [ ],
                 ""RemovedItems"": [ ],
                 ""AnyChanges"": ""true""
@@ -300,12 +304,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                         ""Path"":""SomePath"",
                         ""Resolved"":""true"",
                         ""Dependencies"":""""
+                    },
+                    ""tfm1/ImplicitPackage/1.0.0"": {
+                        ""Name"": ""ImplicitPackage"",
+                        ""Version"": ""1.0.0"",
+                        ""Type"":""Package"",
+                        ""Path"":""SomePath"",
+                        ""Resolved"":""true"",
+                        ""Dependencies"":"""",
+                        ""IsImplicitlyDefined"":""true""
                     }
                 },
                 ""RuleName"": ""ResolvedPackageReference""
             },
             ""Difference"": {
-                ""AddedItems"": [ ""tfm1"", ""tfm1/package1/1.0.0"" ],
+                ""AddedItems"": [ ""tfm1"", ""tfm1/package1/1.0.0"", ""tfm1/ImplicitPackage/1.0.0"" ],
                 ""ChangedItems"": [ ],
                 ""RemovedItems"": [ ],
                 ""AnyChanges"": ""true""
@@ -707,7 +720,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 ""Type"": ""Package"",
                 ""Path"": ""SomePath"",
                 ""Resolved"": ""true"",
-                ""Dependencies"": """"
+                ""Dependencies"": """",
+                ""IsImplicitlyDefined"":""true""
             }
         },
         {
@@ -766,6 +780,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var currentSnapshotTargets = provider.GetCurrentSnapshotTargets();
 
             Assert.True(currentSnapshotTargets.Contains("tfm1"));
+
+            Assert.Equal("True", provider.GetCurrentSnapshotDependencyProperty("tfm1/Package3/2.0.0", "IsImplicitlyDefined"));
         }
 
         [Fact]
@@ -1110,6 +1126,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 if (propertyName.Equals("Version"))
                 {
                     return metadata.Version;
+                }
+                else if (propertyName.Equals("IsImplicitlyDefined"))
+                {
+                    return metadata.IsImplicitlyDefined.ToString();
                 }
 
                 return null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/SdkDependenciesSubTreeProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/SdkDependenciesSubTreeProviderTests.cs
@@ -1,0 +1,230 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Imaging;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
+{
+    [ProjectSystemTrait]
+    public class SdkDependenciesSubTreeProviderTests
+    {
+        [Fact]
+        public void SdkDependenciesSubTreeProvider_GetDependencyNode()
+        {
+            // Arrange
+            const string packageItemSpec = "MyPackage1";
+
+            var rootNode = IDependencyNodeFactory.FromJson(@"
+{
+    ""Id"": {
+        ""ProviderType"": ""MyProvider"",
+        ""ItemSpec"": ""MyRootNode""
+    }
+}");
+            var existingNode1 = IDependencyNodeFactory.FromJson(@"
+{
+    ""Id"": {
+        ""ProviderType"": ""MyProvider"",
+        ""ItemSpec"": ""MyNodeItemSpec1""
+    },
+    ""Properties"": {
+        ""SDKPackageItemSpec"": ""MyPackage1""
+    }
+}");
+
+            var existingNode2 = IDependencyNodeFactory.FromJson(@"
+{
+    ""Id"": {
+        ""ProviderType"": ""MyProvider"",
+        ""ItemSpec"": ""MyNodeItemSpec2""
+    },
+    ""Properties"": {
+    }
+}");
+
+            var childNode1 = IDependencyNodeFactory.FromJson(@"
+{
+    ""Id"": {
+        ""ProviderType"": ""MyProvider"",
+        ""ItemSpec"": ""MyChildNodeItemSpec1""
+    }   
+}");
+
+            var childNode2 = IDependencyNodeFactory.FromJson(@"
+{
+    ""Id"": {
+        ""ProviderType"": ""MyProvider"",
+        ""ItemSpec"": ""MyChildNodeItemSpec2""
+    },
+    ""Properties"": {
+        ""SDKPackageItemSpec"": ""SomeUnknownPackage""
+    }
+}");
+            rootNode.AddChild(existingNode1);
+            rootNode.AddChild(existingNode2);
+
+            var childrenToAdd = new[] { childNode1, childNode2 };
+
+            var nugetPackagesDataProvider =
+                INuGetPackagesDataProviderFactory.ImplementUpdateNodeChildren(packageItemSpec, existingNode1, childrenToAdd);
+
+            var provider = new TestableSdkDependenciesSubTreeProvider(nugetPackagesDataProvider);
+            provider.SetRootNode(rootNode);
+
+            // Successful scenario 
+            // Act
+            var resultNode = provider.GetDependencyNode(existingNode1.Id);
+            // Assert
+            Assert.Equal(2, existingNode1.Children.Count);
+
+            // node does not exist in root
+            // Act
+            resultNode = provider.GetDependencyNode(childNode1.Id);
+            // Assert
+            Assert.Null(resultNode);
+
+            // node does not have proprty SDKPackageItemSpecProperty
+            // Act
+            resultNode = provider.GetDependencyNode(existingNode2.Id);
+            // Assert
+            Assert.Equal(existingNode2, resultNode);
+        }
+
+        [Fact]
+        public async Task SdkDependenciesSubTreeProvider_SearchAsync()
+        {
+            // Arrange
+            const string packageItemSpec = "MyPackage1";
+
+            var existingNode1 = IDependencyNodeFactory.FromJson(@"
+{
+    ""Id"": {
+        ""ProviderType"": ""MyProvider"",
+        ""ItemSpec"": ""MyNodeItemSpec1""
+    },
+    ""Properties"": {
+        ""SDKPackageItemSpec"": ""MyPackage1""
+    }
+}");
+
+            var existingNode2 = IDependencyNodeFactory.FromJson(@"
+{
+    ""Id"": {
+        ""ProviderType"": ""MyProvider"",
+        ""ItemSpec"": ""MyNodeItemSpec2""
+    },
+    ""Properties"": {
+    }
+}");
+
+            var searchResultNode1 = IDependencyNodeFactory.FromJson(@"
+{
+    ""Id"": {
+        ""ProviderType"": ""MyProvider"",
+        ""ItemSpec"": ""MyChildNodeItemSpec1""
+    }   
+}");
+
+            var searchResultNode2 = IDependencyNodeFactory.FromJson(@"
+{
+    ""Id"": {
+        ""ProviderType"": ""MyProvider"",
+        ""ItemSpec"": ""MyChildNodeItemSpec2""
+    },
+    ""Properties"": {
+        ""SDKPackageItemSpec"": ""SomeUnknownPackage""
+    }
+}");
+
+            var searchResults = new[] { searchResultNode1, searchResultNode2 };
+
+            var nugetPackagesDataProvider =
+                INuGetPackagesDataProviderFactory.ImplementSearchAsync(packageItemSpec, "xxx", searchResults);
+
+            var provider = new TestableSdkDependenciesSubTreeProvider(nugetPackagesDataProvider);
+
+            // Successful scenario 
+            // Act
+            var resultNodes = await provider.SearchAsync(existingNode1, "xxx");
+            // Assert
+            Assert.Equal(2, resultNodes.Count());
+
+            // node does not have proprty SDKPackageItemSpecProperty
+            // Act
+            resultNodes = await provider.SearchAsync(existingNode2, "xxx");
+            // Assert
+            Assert.Null(resultNodes);
+        }
+
+        [Fact]
+        public void SdkDependenciesSubTreeProvider_CreateRootNode()
+        {
+            var provider = new TestableSdkDependenciesSubTreeProvider(null);
+
+            var rootNode = provider.TestCreateRootNode();
+
+            Assert.True(rootNode is SubTreeRootDependencyNode);
+            Assert.True(rootNode.Flags.Contains(SdkDependenciesSubTreeProvider.SdkSubTreeRootNodeFlags));
+            Assert.Equal("SDK", rootNode.Caption);
+            Assert.Equal(KnownMonikers.BrowserSDK, rootNode.Icon);
+            Assert.Equal(SdkDependenciesSubTreeProvider.ProviderTypeString, rootNode.Id.ProviderType);
+        }
+
+        [Fact]
+        public void SdkDependenciesSubTreeProvider_CreateDependencyNode()
+        {
+            const string itemSpec = "myItemSpec";
+            const string itemType = "myItemType";
+            const int priority = 15;
+            var properties = new Dictionary<string, string>
+            {
+                { "myproPerty", "myValue" }
+            };
+            const bool resolved = true;
+
+            var provider = new TestableSdkDependenciesSubTreeProvider(null);
+
+            var node = provider.TestCreateDependencyNode(itemSpec, itemType, priority, properties, resolved);
+
+            Assert.True(node is SdkDependencyNode);
+            Assert.True(node.Flags.Contains(SdkDependenciesSubTreeProvider.SdkSubTreeNodeFlags));
+            Assert.Equal(itemSpec, node.Caption);
+            Assert.Equal(KnownMonikers.BrowserSDK, node.Icon);
+            Assert.Equal(SdkDependenciesSubTreeProvider.ProviderTypeString, node.Id.ProviderType);
+            Assert.Equal(DependencyNode.SdkNodePriority, node.Priority);
+            Assert.Equal(1, node.Properties.Count);
+            Assert.Equal("myValue", node.Properties["myproPerty"]);
+        }
+
+        private class TestableSdkDependenciesSubTreeProvider : SdkDependenciesSubTreeProvider
+        {
+            public TestableSdkDependenciesSubTreeProvider(INuGetPackagesDataProvider nuGetPackagesSnapshotProvider)
+                : base(nuGetPackagesSnapshotProvider)
+            {
+            }
+
+            public IDependencyNode TestCreateRootNode()
+            {
+                return CreateRootNode();
+            }
+
+            public IDependencyNode TestCreateDependencyNode(string itemSpec,
+                                                            string itemType,
+                                                            int priority,
+                                                            IDictionary<string, string> properties,
+                                                            bool resolved)
+            {
+                return CreateDependencyNode(itemSpec, itemType, priority, properties.ToImmutableDictionary(), resolved);
+            }
+
+            public void SetRootNode(IDependencyNode node)
+            {
+                RootNode = node;
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -162,6 +162,7 @@
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\AnalyzerDependencyNode.cs" />
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\DependencyNodeResolvedStateComparer.cs" />
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\IDependencyNodeExtensions.cs" />
+    <Compile Include="ProjectSystem\VS\Tree\Dependencies\INuGetPackagesDataProvider.cs" />
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\PackageAnalyzerAssemblyDependencyNode.cs" />
     <Compile Include="ProjectSystem\VS\UI\DialogServices.cs" />
     <Compile Include="ProjectSystem\VS\UI\IDialogServices.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/INuGetPackagesDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/INuGetPackagesDataProvider.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
+{
+    /// <summary>
+    /// </summary>
+    internal interface INuGetPackagesDataProvider
+    {
+        void UpdateNodeChildren(string packageItemSpec, IDependencyNode originalNode);
+        Task<IEnumerable<IDependencyNode>> SearchAsync(string packageItemSpec, string searchTerm);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/INuGetPackagesDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/INuGetPackagesDataProvider.cs
@@ -6,10 +6,29 @@ using System.Threading.Tasks;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
     /// <summary>
+    /// This contract allows other tree providers to reuse package nodes from Nuget nodes provider.
+    /// See <see cref="SdkDependenciesSubTreeProvider"/> for example.
     /// </summary>
     internal interface INuGetPackagesDataProvider
     {
+        /// <summary>
+        /// For given node tries to find matching nuget package and adds direct package dependencies
+        /// nodes to given node's children collection. Use case is, when other provider has a node,
+        /// that is actually a package, it would call this method when GraphProvider is about to 
+        /// check if node has children or not.
+        /// </summary>
+        /// <param name="packageItemSpec">Package reference items spec that is supposed to be associated 
+        /// with the given node</param>
+        /// <param name="originalNode">Node to fill children for, if it's is a package</param>
         void UpdateNodeChildren(string packageItemSpec, IDependencyNode originalNode);
+
+        /// <summary>
+        /// Allows to other providers to use nuget package dependencies search on a given node if it 
+        /// turns out to be a nuget package.
+        /// </summary>
+        /// <param name="packageItemSpec">Package reference items spec for which we need to do a search</param>
+        /// <param name="searchTerm"></param>
+        /// <returns></returns>
         Task<IEnumerable<IDependencyNode>> SearchAsync(string packageItemSpec, string searchTerm);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/NuGetDependenciesSubTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/NuGetDependenciesSubTreeProvider.cs
@@ -559,6 +559,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
         // INuGetPackagesDataProvider methods
 
+        /// <summary>
+        /// Allows to other providers to use nuget package dependencies search on a given node if it 
+        /// turns out to be a nuget package.
+        /// </summary>
+        /// <param name="packageItemSpec">Package reference items spec for which we need to do a search</param>
+        /// <param name="searchTerm">String to be searched</param>
+        /// <returns></returns>
         public Task<IEnumerable<IDependencyNode>> SearchAsync(string packageItemSpec, string searchTerm)
         {
             lock (_snapshotLock)
@@ -588,6 +595,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             }
         }
 
+        /// <summary>
+        /// For given node tries to find matching nuget package and adds direct package dependencies
+        /// nodes to given node's children collection. Use case is, when other provider has a node,
+        /// that is actually a package, it would call this method when GraphProvider is about to 
+        /// check if node has children or not.
+        /// </summary>
+        /// <param name="packageItemSpec">Package reference items spec that is supposed to be associated 
+        /// with the given node</param>
+        /// <param name="originalNode">Node to fill children for, if it's is a package</param>
         public void UpdateNodeChildren(string packageItemSpec, IDependencyNode originalNode)
         {
             lock (_snapshotLock)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SdkDependenciesSubTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SdkDependenciesSubTreeProvider.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
+using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
@@ -23,8 +24,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         public readonly ProjectTreeFlags SdkSubTreeNodeFlags
                             = ProjectTreeFlags.Create("SdkSubTreeNode");
 
-        public SdkDependenciesSubTreeProvider()
+        [ImportingConstructor]
+        public SdkDependenciesSubTreeProvider(INuGetPackagesDataProvider nuGetPackagesSnapshotProvider)
         {
+            NuGetPackagesDataProvider = nuGetPackagesSnapshotProvider;
+
             // subscribe to design time build to get corresponding items
             UnresolvedReferenceRuleNames = Empty.OrdinalIgnoreCaseStringSet
                 .Add(SdkReference.SchemaName);
@@ -32,6 +36,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             ResolvedReferenceRuleNames = Empty.OrdinalIgnoreCaseStringSet
                 .Add(ResolvedSdkReference.SchemaName);
         }
+
+        private INuGetPackagesDataProvider NuGetPackagesDataProvider { get; }
 
         public override string ProviderType
         {
@@ -88,6 +94,36 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                          priority: priority,
                                          properties: properties,
                                          resolved: resolved);
+        }
+
+        public override IDependencyNode GetDependencyNode(DependencyNodeId id)
+        {
+            var node = base.GetDependencyNode(id);
+            if (node == null)
+            {
+                return null;
+            }
+
+            if (!node.Properties.TryGetValue(SdkReference.SDKPackageItemSpecProperty, out string packageItemSpec)
+               || string.IsNullOrEmpty(packageItemSpec))
+            {
+                return node;
+            }
+
+            NuGetPackagesDataProvider.UpdateNodeChildren(packageItemSpec, node);
+
+            return node;
+        }
+
+        public override Task<IEnumerable<IDependencyNode>> SearchAsync(IDependencyNode node, string searchTerm)
+        {
+            if (!node.Properties.TryGetValue(SdkReference.SDKPackageItemSpecProperty, out string packageItemSpec)
+               || string.IsNullOrEmpty(packageItemSpec))
+            {
+                return base.SearchAsync(node, searchTerm);
+            }
+
+            return NuGetPackagesDataProvider.SearchAsync(packageItemSpec, searchTerm);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SdkDependenciesSubTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SdkDependenciesSubTreeProvider.cs
@@ -3,9 +3,9 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
-using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
@@ -18,10 +18,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     {
         public const string ProviderTypeString = "SdkDependency";
 
-        public readonly ProjectTreeFlags SdkSubTreeRootNodeFlags
+        public static readonly ProjectTreeFlags SdkSubTreeRootNodeFlags
                             = ProjectTreeFlags.Create("SdkSubTreeRootNode");
 
-        public readonly ProjectTreeFlags SdkSubTreeNodeFlags
+        public static readonly ProjectTreeFlags SdkSubTreeNodeFlags
                             = ProjectTreeFlags.Create("SdkSubTreeNode");
 
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
@@ -74,4 +74,8 @@
     <StringProperty Name="FrameworkVersion" 
                     Visible="False" 
                     ReadOnly="True" />
+
+    <StringProperty Name="IsImplicitlyDefined" 
+                    Visible="False" 
+                    ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
@@ -70,4 +70,7 @@
             <DataSource Persistence="ResolvedReference" ItemType="PackageReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
         </StringListProperty.DataSource>
     </StringListProperty>
+    <BoolProperty Name="IsTopLevelDependency" 
+                  Visible="False"
+                  ReadOnly="True"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
@@ -53,6 +53,10 @@
                     Visible="False" 
                     ReadOnly="True" />
 
+    <StringProperty Name="IsImplicitlyDefined" 
+                    Visible="False" 
+                    ReadOnly="True" />
+    
     <StringProperty Name="FrameworkVersion" 
                     Visible="False" 
                     ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.xaml
@@ -8,13 +8,14 @@
     xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
         <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False"
-                    SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime" />
+                    SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
     </Rule.DataSource>
     <StringProperty Name="AppXLocation" DisplayName="App Package Location" />
     <!-- This property should be the same as the one for the ResolvedReference item -->
     <StringProperty Name="OriginalItemSpec" Visible="false" />
     <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
     <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
+	<StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False"/>
     <StringProperty Name="Name" DisplayName="Name"/>
     <StringProperty Name="Version" DisplayName="Version"/>
     <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.xaml
@@ -8,16 +8,18 @@
     xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
         <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False"
-                    SourceType="TargetResults" MSBuildTarget="ResolveSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
+                    SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime" />
     </Rule.DataSource>
     <StringProperty Name="AppXLocation" DisplayName="App Package Location" />
 
     <!-- This property should be the same as the one for the ResolvedReference item -->
     <StringProperty Name="OriginalItemSpec" Visible="false" />
-
     <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-
     <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False"/>
+    <StringProperty Name="Name" DisplayName="Name"/>
+    <StringProperty Name="Version" DisplayName="Version"/>
+    <StringProperty Name="Path" DisplayName="Path"/>
+    <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
     <BoolProperty Name="CopyPayload" DisplayName="Copy Payload" />
     <BoolProperty Name="ExpandContent" DisplayName="Expand Content" />
     <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expand Reference Assemblies" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.xaml
@@ -15,10 +15,10 @@
     <StringProperty Name="OriginalItemSpec" Visible="false" />
     <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
     <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-	<StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False"/>
+    <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False"/>
     <StringProperty Name="Name" DisplayName="Name"/>
     <StringProperty Name="Version" DisplayName="Version"/>
-    <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+    <StringProperty Name="SDKPackageItemSpec" Visible="False"/>
     <BoolProperty Name="CopyPayload" DisplayName="Copy Payload" />
     <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />    
     <BoolProperty Name="ExpandContent" DisplayName="Expand Content" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.xaml
@@ -11,16 +11,15 @@
                     SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime" />
     </Rule.DataSource>
     <StringProperty Name="AppXLocation" DisplayName="App Package Location" />
-
     <!-- This property should be the same as the one for the ResolvedReference item -->
     <StringProperty Name="OriginalItemSpec" Visible="false" />
+    <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
     <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-    <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False"/>
     <StringProperty Name="Name" DisplayName="Name"/>
     <StringProperty Name="Version" DisplayName="Version"/>
-    <StringProperty Name="Path" DisplayName="Path"/>
     <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
     <BoolProperty Name="CopyPayload" DisplayName="Copy Payload" />
+    <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />    
     <BoolProperty Name="ExpandContent" DisplayName="Expand Content" />
     <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expand Reference Assemblies" />
     <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copy Local Expanded Reference Assemblies" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml
@@ -8,11 +8,12 @@
 	xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
         <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False"
-                    SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" />        
+                    SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />        
     </Rule.DataSource>
     <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
     <StringProperty Name="AppXLocation" DisplayName="App Package Location" />
     <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
+	<StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False"/>
     <StringProperty Name="Name" DisplayName="Name"/>
     <StringProperty Name="Version" DisplayName="Version"/>
     <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml
@@ -15,7 +15,6 @@
     <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
     <StringProperty Name="Name" DisplayName="Name"/>
     <StringProperty Name="Version" DisplayName="Version"/>
-    <StringProperty Name="Path" DisplayName="Path"/>
     <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
     <BoolProperty Name="CopyPayload" DisplayName="Copy Payload" />
     <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml
@@ -7,11 +7,16 @@
 	Description="SDK reference properties"
 	xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
-        <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False"
+                    SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" />        
     </Rule.DataSource>
     <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
     <StringProperty Name="AppXLocation" DisplayName="App Package Location" />
     <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
+    <StringProperty Name="Name" DisplayName="Name"/>
+    <StringProperty Name="Version" DisplayName="Version"/>
+    <StringProperty Name="Path" DisplayName="Path"/>
+    <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
     <BoolProperty Name="CopyPayload" DisplayName="Copy Payload" />
     <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
     <BoolProperty Name="ExpandContent" DisplayName="Expand Content" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml
@@ -13,10 +13,10 @@
     <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
     <StringProperty Name="AppXLocation" DisplayName="App Package Location" />
     <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-	<StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False"/>
+    <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False"/>
     <StringProperty Name="Name" DisplayName="Name"/>
     <StringProperty Name="Version" DisplayName="Version"/>
-    <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+    <StringProperty Name="SDKPackageItemSpec" Visible="False"/>
     <BoolProperty Name="CopyPayload" DisplayName="Copy Payload" />
     <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
     <BoolProperty Name="ExpandContent" DisplayName="Expand Content" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/PackageReference.xaml
@@ -21,4 +21,5 @@
   <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ResolvedPackageReference.xaml
@@ -19,4 +19,6 @@
       <DataSource Persistence="ResolvedReference" ItemType="PackageReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
     </StringListProperty.DataSource>
   </StringListProperty>
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ResolvedSdkReference.xaml
@@ -16,6 +16,6 @@
   <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/>
   <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ResolvedSdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="ResolvedSdkReference" DisplayName="Vyřešený odkaz na SDK" PageTemplate="generic" Description="Vyřešený odkaz na SDK" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="ResolveSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="AppXLocation" DisplayName="Umístění balíčku aplikace" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
@@ -13,4 +13,9 @@
   <BoolProperty Name="ExpandContent" DisplayName="Rozbalit obsah" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Rozbalit referenční sestavení" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Zkopírovat místní rozbalená referenční sestavení" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/SdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="SdkReference" DisplayName="Odkaz na SDK" PageTemplate="generic" Description="Vlastnosti odkazu na SDK" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="SDKRootFolder" DisplayName="Kořen SDK" />
   <StringProperty Name="AppXLocation" DisplayName="Umístění balíčku aplikace" />
@@ -12,4 +12,8 @@
   <BoolProperty Name="ExpandContent" DisplayName="Rozbalit obsah" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Rozbalit referenční sestavení" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Zkopírovat místní rozbalená referenční sestavení" />
+  <StringProperty Name="DisplayName" DisplayName="Zobrazený název" Visible="False" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/SdkReference.xaml
@@ -15,5 +15,5 @@
   <StringProperty Name="DisplayName" DisplayName="Zobrazený název" Visible="False" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/PackageReference.xaml
@@ -21,4 +21,5 @@
   <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ResolvedPackageReference.xaml
@@ -19,4 +19,6 @@
       <DataSource Persistence="ResolvedReference" ItemType="PackageReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
     </StringListProperty.DataSource>
   </StringListProperty>
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ResolvedSdkReference.xaml
@@ -16,6 +16,6 @@
   <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/>
   <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ResolvedSdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="ResolvedSdkReference" DisplayName="Aufgelöster SDK-Verweis" PageTemplate="generic" Description="Aufgelöster SDK-Verweis" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="ResolveSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="AppXLocation" DisplayName="Speicherort des App-Pakets" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
@@ -13,4 +13,9 @@
   <BoolProperty Name="ExpandContent" DisplayName="Inhalt erweitern" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Verweisassemblys erweitern" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Lokale erweiterte Verweisassemblys kopieren" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/SdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="SdkReference" DisplayName="SDK-Verweis" PageTemplate="generic" Description="SDK-Verweiseigenschaften" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="SDKRootFolder" DisplayName="SDK-Stamm" />
   <StringProperty Name="AppXLocation" DisplayName="Speicherort des App-Pakets" />
@@ -12,4 +12,8 @@
   <BoolProperty Name="ExpandContent" DisplayName="Inhalt erweitern" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Verweisassemblys erweitern" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Lokale erweiterte Verweisassemblys kopieren" />
+  <StringProperty Name="DisplayName" DisplayName="Anzeigename" Visible="False" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/SdkReference.xaml
@@ -15,5 +15,5 @@
   <StringProperty Name="DisplayName" DisplayName="Anzeigename" Visible="False" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/PackageReference.xaml
@@ -21,4 +21,5 @@
   <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ResolvedPackageReference.xaml
@@ -19,4 +19,6 @@
       <DataSource Persistence="ResolvedReference" ItemType="PackageReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
     </StringListProperty.DataSource>
   </StringListProperty>
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ResolvedSdkReference.xaml
@@ -16,6 +16,6 @@
   <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/>
   <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ResolvedSdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="ResolvedSdkReference" DisplayName="Referencia de SDK resuelta" PageTemplate="generic" Description="Referencia de SDK resuelta" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="ResolveSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime"  SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="AppXLocation" DisplayName="Ubicación del paquete de la aplicación" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
@@ -13,4 +13,9 @@
   <BoolProperty Name="ExpandContent" DisplayName="Expandir contenido" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expandir ensamblados de referencia" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copia local de ensamblados de referencia expandidos" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/SdkReference.xaml
@@ -15,5 +15,5 @@
   <StringProperty Name="DisplayName" DisplayName="Nombre para mostrar" Visible="False" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>  
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/>  
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/SdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="SdkReference" DisplayName="Referencia de SDK" PageTemplate="generic" Description="Propiedades de la referencia de SDK" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="SDKRootFolder" DisplayName="Raíz del SDK" />
   <StringProperty Name="AppXLocation" DisplayName="Ubicación del paquete de la aplicación" />
@@ -12,4 +12,8 @@
   <BoolProperty Name="ExpandContent" DisplayName="Expandir contenido" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expandir ensamblados de referencia" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copia local de ensamblados de referencia expandidos" />
+  <StringProperty Name="DisplayName" DisplayName="Nombre para mostrar" Visible="False" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>  
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/PackageReference.xaml
@@ -21,4 +21,5 @@
   <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedPackageReference.xaml
@@ -19,4 +19,6 @@
       <DataSource Persistence="ResolvedReference" ItemType="PackageReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
     </StringListProperty.DataSource>
   </StringListProperty>
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedSdkReference.xaml
@@ -16,6 +16,6 @@
   <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/>
   <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedSdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="ResolvedSdkReference" DisplayName="Référence SDK résolue" PageTemplate="generic" Description="Référence SDK résolue" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="ResolveSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime"  SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="AppXLocation" DisplayName="Emplacement du package d'application" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
@@ -13,4 +13,9 @@
   <BoolProperty Name="ExpandContent" DisplayName="Développer le contenu" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Développer les assemblys de référence" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copier les assemblys de référence développés locaux" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/SdkReference.xaml
@@ -15,5 +15,5 @@
   <StringProperty Name="DisplayName" DisplayName="Nom complet" Visible="False" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/SdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="SdkReference" DisplayName="Référence SDK" PageTemplate="generic" Description="Propriétés de référence SDK" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="SDKRootFolder" DisplayName="Racine du SDK" />
   <StringProperty Name="AppXLocation" DisplayName="Emplacement du package d'application" />
@@ -12,4 +12,8 @@
   <BoolProperty Name="ExpandContent" DisplayName="Développer le contenu" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Développer les assemblys de référence" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copier les assemblys de référence développés locaux" />
+  <StringProperty Name="DisplayName" DisplayName="Nom complet" Visible="False" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/PackageReference.xaml
@@ -21,4 +21,5 @@
   <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedPackageReference.xaml
@@ -19,4 +19,6 @@
       <DataSource Persistence="ResolvedReference" ItemType="PackageReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
     </StringListProperty.DataSource>
   </StringListProperty>
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedSdkReference.xaml
@@ -16,6 +16,6 @@
   <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/>
   <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedSdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="ResolvedSdkReference" DisplayName="Riferimento a SDK risolto" PageTemplate="generic" Description="Riferimento a SDK risolto" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="ResolveSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime"  SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="AppXLocation" DisplayName="Percorso pacchetto dell'app" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
@@ -13,4 +13,9 @@
   <BoolProperty Name="ExpandContent" DisplayName="Espandi contenuto" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Espandi assembly di riferimento" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copia assembly di riferimento espansi locali" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/SdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="SdkReference" DisplayName="Riferimento a SDK" PageTemplate="generic" Description="Proprietà del riferimento a SDK" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="SDKRootFolder" DisplayName="Radice SDK" />
   <StringProperty Name="AppXLocation" DisplayName="Percorso pacchetto dell'app" />
@@ -12,4 +12,8 @@
   <BoolProperty Name="ExpandContent" DisplayName="Espandi contenuto" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Espandi assembly di riferimento" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copia assembly di riferimento espansi locali" />
+  <StringProperty Name="DisplayName" DisplayName="Nome visualizzato" Visible="False" />  
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/SdkReference.xaml
@@ -15,5 +15,5 @@
   <StringProperty Name="DisplayName" DisplayName="Nome visualizzato" Visible="False" />  
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/PackageReference.xaml
@@ -21,4 +21,5 @@
   <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ResolvedPackageReference.xaml
@@ -19,4 +19,6 @@
       <DataSource Persistence="ResolvedReference" ItemType="PackageReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
     </StringListProperty.DataSource>
   </StringListProperty>
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ResolvedSdkReference.xaml
@@ -16,6 +16,6 @@
   <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/>
   <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ResolvedSdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="ResolvedSdkReference" DisplayName="解決された SDK 参照" PageTemplate="generic" Description="解決された SDK 参照" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="ResolveSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime"  SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="AppXLocation" DisplayName="アプリ パッケージの場所" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
@@ -13,4 +13,9 @@
   <BoolProperty Name="ExpandContent" DisplayName="コンテンツの展開" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="参照アセンブリの展開" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="ローカルに展開された参照アセンブリのコピー" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/SdkReference.xaml
@@ -15,5 +15,5 @@
   <StringProperty Name="DisplayName" DisplayName="表示名" Visible="False" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/> 
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/> 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/SdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="SdkReference" DisplayName="SDK 参照" PageTemplate="generic" Description="SDK 参照のプロパティ" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="SDKRootFolder" DisplayName="SDK ルート" />
   <StringProperty Name="AppXLocation" DisplayName="アプリ パッケージの場所" />
@@ -12,4 +12,8 @@
   <BoolProperty Name="ExpandContent" DisplayName="コンテンツの展開" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="参照アセンブリの展開" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="ローカルに展開された参照アセンブリのコピー" />
+  <StringProperty Name="DisplayName" DisplayName="表示名" Visible="False" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/> 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/PackageReference.xaml
@@ -21,4 +21,5 @@
   <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ResolvedPackageReference.xaml
@@ -19,4 +19,6 @@
       <DataSource Persistence="ResolvedReference" ItemType="PackageReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
     </StringListProperty.DataSource>
   </StringListProperty>
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ResolvedSdkReference.xaml
@@ -16,6 +16,6 @@
   <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/>
   <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ResolvedSdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="ResolvedSdkReference" DisplayName="확인된 SDK 참조" PageTemplate="generic" Description="확인된 SDK 참조" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="ResolveSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime"  SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="AppXLocation" DisplayName="앱 패키지 위치" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
@@ -13,4 +13,9 @@
   <BoolProperty Name="ExpandContent" DisplayName="콘텐츠 확장" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="참조 어셈블리 확장" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="확장된 로컬 참조 어셈블리 복사" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/SdkReference.xaml
@@ -15,5 +15,5 @@
   <StringProperty Name="DisplayName" DisplayName="표시 이름" Visible="False" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/> 
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/> 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/SdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="SdkReference" DisplayName="SDK 참조" PageTemplate="generic" Description="SDK 참조 속성" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="SDKRootFolder" DisplayName="SDK 루트" />
   <StringProperty Name="AppXLocation" DisplayName="앱 패키지 위치" />
@@ -12,4 +12,8 @@
   <BoolProperty Name="ExpandContent" DisplayName="콘텐츠 확장" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="참조 어셈블리 확장" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="확장된 로컬 참조 어셈블리 복사" />
+  <StringProperty Name="DisplayName" DisplayName="표시 이름" Visible="False" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/> 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/PackageReference.xaml
@@ -21,4 +21,5 @@
   <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ResolvedPackageReference.xaml
@@ -19,4 +19,6 @@
       <DataSource Persistence="ResolvedReference" ItemType="PackageReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
     </StringListProperty.DataSource>
   </StringListProperty>
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ResolvedSdkReference.xaml
@@ -16,6 +16,6 @@
   <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/>
   <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ResolvedSdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="ResolvedSdkReference" DisplayName="Rozpoznane odwołanie SDK" PageTemplate="generic" Description="Rozpoznane odwołanie SDK" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="ResolveSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime"  SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="AppXLocation" DisplayName="Lokalizacja pakietu aplikacji" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
@@ -13,4 +13,9 @@
   <BoolProperty Name="ExpandContent" DisplayName="Rozwiń zawartość" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Rozwiń zestawy odwołań" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Kopiuj lokalne rozwinięte zestawy referencyjne" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/SdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="SdkReference" DisplayName="Odwołanie SDK" PageTemplate="generic" Description="Właściwości odwołania SDK" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="SDKRootFolder" DisplayName="Główny zestaw SDK" />
   <StringProperty Name="AppXLocation" DisplayName="Lokalizacja pakietu aplikacji" />
@@ -12,4 +12,8 @@
   <BoolProperty Name="ExpandContent" DisplayName="Rozwiń zawartość" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Rozwiń zestawy odwołań" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Kopiuj lokalne rozwinięte zestawy referencyjne" />
+  <StringProperty Name="DisplayName" DisplayName="Wyświetl nazwę" Visible="False" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/> 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/SdkReference.xaml
@@ -15,5 +15,5 @@
   <StringProperty Name="DisplayName" DisplayName="Wyświetl nazwę" Visible="False" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/> 
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/> 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/PackageReference.xaml
@@ -21,4 +21,5 @@
   <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ResolvedPackageReference.xaml
@@ -19,4 +19,6 @@
       <DataSource Persistence="ResolvedReference" ItemType="PackageReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
     </StringListProperty.DataSource>
   </StringListProperty>
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ResolvedSdkReference.xaml
@@ -16,6 +16,6 @@
   <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/>
   <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ResolvedSdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="ResolvedSdkReference" DisplayName="Referência do SDK Resolvida" PageTemplate="generic" Description="Referência do SDK resolvida" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="ResolveSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime"  SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="AppXLocation" DisplayName="Local do Pacote do Aplicativo" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
@@ -13,4 +13,9 @@
   <BoolProperty Name="ExpandContent" DisplayName="Expandir Conteúdo" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expandir Assemblies de Referência" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Assemblies de Referência Expandidos do Local da Cópia" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/SdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="SdkReference" DisplayName="Referência do SDK" PageTemplate="generic" Description="Propriedades da referência do SDK" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="SDKRootFolder" DisplayName="Raiz do SDK" />
   <StringProperty Name="AppXLocation" DisplayName="Local do Pacote do Aplicativo" />
@@ -12,4 +12,8 @@
   <BoolProperty Name="ExpandContent" DisplayName="Expandir Conteúdo" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expandir Assemblies de Referência" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Assemblies de Referência Expandidos do Local da Cópia" />
+  <StringProperty Name="DisplayName" DisplayName="Nome de Exibição" Visible="False" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/SdkReference.xaml
@@ -15,5 +15,5 @@
   <StringProperty Name="DisplayName" DisplayName="Nome de Exibição" Visible="False" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/PackageReference.xaml
@@ -21,4 +21,5 @@
   <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ResolvedPackageReference.xaml
@@ -19,4 +19,6 @@
       <DataSource Persistence="ResolvedReference" ItemType="PackageReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
     </StringListProperty.DataSource>
   </StringListProperty>
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ResolvedSdkReference.xaml
@@ -16,6 +16,6 @@
   <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/>
   <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ResolvedSdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="ResolvedSdkReference" DisplayName="Разрешенная ссылка на пакет SDK" PageTemplate="generic" Description="Разрешенная ссылка на пакет SDK" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="ResolveSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime"  SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="AppXLocation" DisplayName="Расположение пакета приложения" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
@@ -13,4 +13,9 @@
   <BoolProperty Name="ExpandContent" DisplayName="Расширить содержимое" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Расширить эталонные сборки" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Копировать локальные расширенные ссылочные сборки" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/SdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="SdkReference" DisplayName="Ссылка на пакет SDK" PageTemplate="generic" Description="Свойства ссылки на пакет SDK" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="SDKRootFolder" DisplayName="Корень пакета SDK" />
   <StringProperty Name="AppXLocation" DisplayName="Расположение пакета приложения" />
@@ -12,4 +12,8 @@
   <BoolProperty Name="ExpandContent" DisplayName="Расширить содержимое" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Расширить эталонные сборки" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Копировать локальные расширенные ссылочные сборки" />
+  <StringProperty Name="DisplayName" DisplayName="Отображаемое имя" Visible="False" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/SdkReference.xaml
@@ -15,5 +15,5 @@
   <StringProperty Name="DisplayName" DisplayName="Отображаемое имя" Visible="False" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/PackageReference.xaml
@@ -21,4 +21,5 @@
   <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ResolvedPackageReference.xaml
@@ -19,4 +19,6 @@
       <DataSource Persistence="ResolvedReference" ItemType="PackageReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
     </StringListProperty.DataSource>
   </StringListProperty>
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ResolvedSdkReference.xaml
@@ -16,6 +16,6 @@
   <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/>
   <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ResolvedSdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="ResolvedSdkReference" DisplayName="Çözümlenen SDK Başvurusu" PageTemplate="generic" Description="Çözümlenen SDK başvurusu" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="ResolveSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime"  SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="AppXLocation" DisplayName="Uygulama Paketi Konumu" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
@@ -13,4 +13,9 @@
   <BoolProperty Name="ExpandContent" DisplayName="İçeriği Genişlet" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Başvuru Bütünleştirilmiş Kodlarını Genişlet" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Yerel Genişletilmiş Başvuru Derlemelerini Kopyala" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/SdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="SdkReference" DisplayName="SDK Başvurusu" PageTemplate="generic" Description="SDK başvurusu özellikleri" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="SDKRootFolder" DisplayName="SDK Kökü" />
   <StringProperty Name="AppXLocation" DisplayName="Uygulama Paketi Konumu" />
@@ -12,4 +12,8 @@
   <BoolProperty Name="ExpandContent" DisplayName="İçeriği Genişlet" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Başvuru Bütünleştirilmiş Kodlarını Genişlet" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Yerel Genişletilmiş Başvuru Derlemelerini Kopyala" />
+  <StringProperty Name="DisplayName" DisplayName="Görünen Ad" Visible="False" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/> 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/SdkReference.xaml
@@ -15,5 +15,5 @@
   <StringProperty Name="DisplayName" DisplayName="Görünen Ad" Visible="False" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/> 
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/> 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.cs.xlf
@@ -48,6 +48,26 @@
         <target state="translated">Zkopírovat místní rozbalená referenční sestavení</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SDKRootFolder|DisplayName">
+        <source>SDK Root</source>
+        <target state="new">SDK Root</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CopyPayloadToSubDirectory|DisplayName">
+        <source>Copy Payload to Subdirectory</source>
+        <target state="new">Copy Payload to Subdirectory</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.de.xlf
@@ -48,6 +48,26 @@
         <target state="translated">Lokale erweiterte Verweisassemblys kopieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SDKRootFolder|DisplayName">
+        <source>SDK Root</source>
+        <target state="new">SDK Root</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CopyPayloadToSubDirectory|DisplayName">
+        <source>Copy Payload to Subdirectory</source>
+        <target state="new">Copy Payload to Subdirectory</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.es.xlf
@@ -48,6 +48,26 @@
         <target state="translated">Copia local de ensamblados de referencia expandidos</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SDKRootFolder|DisplayName">
+        <source>SDK Root</source>
+        <target state="new">SDK Root</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CopyPayloadToSubDirectory|DisplayName">
+        <source>Copy Payload to Subdirectory</source>
+        <target state="new">Copy Payload to Subdirectory</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.fr.xlf
@@ -48,6 +48,26 @@
         <target state="translated">Copier les assemblys de référence développés locaux</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SDKRootFolder|DisplayName">
+        <source>SDK Root</source>
+        <target state="new">SDK Root</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CopyPayloadToSubDirectory|DisplayName">
+        <source>Copy Payload to Subdirectory</source>
+        <target state="new">Copy Payload to Subdirectory</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.it.xlf
@@ -48,6 +48,26 @@
         <target state="translated">Copia assembly di riferimento espansi locali</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SDKRootFolder|DisplayName">
+        <source>SDK Root</source>
+        <target state="new">SDK Root</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CopyPayloadToSubDirectory|DisplayName">
+        <source>Copy Payload to Subdirectory</source>
+        <target state="new">Copy Payload to Subdirectory</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.ja.xlf
@@ -48,6 +48,26 @@
         <target state="translated">ローカルに展開された参照アセンブリのコピー</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SDKRootFolder|DisplayName">
+        <source>SDK Root</source>
+        <target state="new">SDK Root</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CopyPayloadToSubDirectory|DisplayName">
+        <source>Copy Payload to Subdirectory</source>
+        <target state="new">Copy Payload to Subdirectory</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.ko.xlf
@@ -48,6 +48,26 @@
         <target state="translated">확장된 로컬 참조 어셈블리 복사</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SDKRootFolder|DisplayName">
+        <source>SDK Root</source>
+        <target state="new">SDK Root</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CopyPayloadToSubDirectory|DisplayName">
+        <source>Copy Payload to Subdirectory</source>
+        <target state="new">Copy Payload to Subdirectory</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.pl.xlf
@@ -48,6 +48,26 @@
         <target state="translated">Kopiuj lokalne rozwinięte zestawy referencyjne</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SDKRootFolder|DisplayName">
+        <source>SDK Root</source>
+        <target state="new">SDK Root</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CopyPayloadToSubDirectory|DisplayName">
+        <source>Copy Payload to Subdirectory</source>
+        <target state="new">Copy Payload to Subdirectory</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.pt-BR.xlf
@@ -48,6 +48,26 @@
         <target state="translated">Assemblies de Referência Expandidos do Local da Cópia</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SDKRootFolder|DisplayName">
+        <source>SDK Root</source>
+        <target state="new">SDK Root</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CopyPayloadToSubDirectory|DisplayName">
+        <source>Copy Payload to Subdirectory</source>
+        <target state="new">Copy Payload to Subdirectory</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.ru.xlf
@@ -48,6 +48,26 @@
         <target state="translated">Копировать локальные расширенные ссылочные сборки</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SDKRootFolder|DisplayName">
+        <source>SDK Root</source>
+        <target state="new">SDK Root</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CopyPayloadToSubDirectory|DisplayName">
+        <source>Copy Payload to Subdirectory</source>
+        <target state="new">Copy Payload to Subdirectory</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.tr.xlf
@@ -48,6 +48,26 @@
         <target state="translated">Yerel Genişletilmiş Başvuru Derlemelerini Kopyala</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SDKRootFolder|DisplayName">
+        <source>SDK Root</source>
+        <target state="new">SDK Root</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CopyPayloadToSubDirectory|DisplayName">
+        <source>Copy Payload to Subdirectory</source>
+        <target state="new">Copy Payload to Subdirectory</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.xlf
@@ -39,6 +39,22 @@
         <source>Copy Local Expanded Reference Assemblies</source>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SDKRootFolder|DisplayName">
+        <source>SDK Root</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CopyPayloadToSubDirectory|DisplayName">
+        <source>Copy Payload to Subdirectory</source>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.zh-Hans.xlf
@@ -48,6 +48,26 @@
         <target state="translated">复制本地扩展的引用程序集</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SDKRootFolder|DisplayName">
+        <source>SDK Root</source>
+        <target state="new">SDK Root</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CopyPayloadToSubDirectory|DisplayName">
+        <source>Copy Payload to Subdirectory</source>
+        <target state="new">Copy Payload to Subdirectory</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedSdkReference.xaml.zh-Hant.xlf
@@ -48,6 +48,26 @@
         <target state="translated">複製展開的參考組件到本機</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SDKRootFolder|DisplayName">
+        <source>SDK Root</source>
+        <target state="new">SDK Root</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|CopyPayloadToSubDirectory|DisplayName">
+        <source>Copy Payload to Subdirectory</source>
+        <target state="new">Copy Payload to Subdirectory</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.cs.xlf
@@ -53,6 +53,21 @@
         <target state="translated">Zkopírovat místní rozbalená referenční sestavení</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DisplayName|DisplayName">
+        <source>Display Name</source>
+        <target state="new">Display Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.de.xlf
@@ -53,6 +53,21 @@
         <target state="translated">Lokale erweiterte Verweisassemblys kopieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DisplayName|DisplayName">
+        <source>Display Name</source>
+        <target state="new">Display Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.es.xlf
@@ -53,6 +53,21 @@
         <target state="translated">Copia local de ensamblados de referencia expandidos</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DisplayName|DisplayName">
+        <source>Display Name</source>
+        <target state="new">Display Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.fr.xlf
@@ -53,6 +53,21 @@
         <target state="translated">Copier les assemblys de référence développés locaux</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DisplayName|DisplayName">
+        <source>Display Name</source>
+        <target state="new">Display Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.it.xlf
@@ -53,6 +53,21 @@
         <target state="translated">Copia assembly di riferimento espansi locali</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DisplayName|DisplayName">
+        <source>Display Name</source>
+        <target state="new">Display Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.ja.xlf
@@ -53,6 +53,21 @@
         <target state="translated">ローカルに展開された参照アセンブリのコピー</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DisplayName|DisplayName">
+        <source>Display Name</source>
+        <target state="new">Display Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.ko.xlf
@@ -53,6 +53,21 @@
         <target state="translated">확장된 로컬 참조 어셈블리 복사</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DisplayName|DisplayName">
+        <source>Display Name</source>
+        <target state="new">Display Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.pl.xlf
@@ -53,6 +53,21 @@
         <target state="translated">Kopiuj lokalne rozwinięte zestawy referencyjne</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DisplayName|DisplayName">
+        <source>Display Name</source>
+        <target state="new">Display Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.pt-BR.xlf
@@ -53,6 +53,21 @@
         <target state="translated">Assemblies de Referência Expandidos do Local da Cópia</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DisplayName|DisplayName">
+        <source>Display Name</source>
+        <target state="new">Display Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.ru.xlf
@@ -53,6 +53,21 @@
         <target state="translated">Копировать локальные расширенные ссылочные сборки</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DisplayName|DisplayName">
+        <source>Display Name</source>
+        <target state="new">Display Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.tr.xlf
@@ -53,6 +53,21 @@
         <target state="translated">Yerel Genişletilmiş Başvuru Derlemelerini Kopyala</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DisplayName|DisplayName">
+        <source>Display Name</source>
+        <target state="new">Display Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.xlf
@@ -43,6 +43,18 @@
         <source>Copy Local Expanded Reference Assemblies</source>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DisplayName|DisplayName">
+        <source>Display Name</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.zh-Hans.xlf
@@ -53,6 +53,21 @@
         <target state="translated">复制本地扩展的引用程序集</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DisplayName|DisplayName">
+        <source>Display Name</source>
+        <target state="new">Display Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SdkReference.xaml.zh-Hant.xlf
@@ -53,6 +53,21 @@
         <target state="translated">複製展開的參考組件到本機</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DisplayName|DisplayName">
+        <source>Display Name</source>
+        <target state="new">Display Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|Version|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/PackageReference.xaml
@@ -21,4 +21,5 @@
   <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ResolvedPackageReference.xaml
@@ -19,4 +19,6 @@
       <DataSource Persistence="ResolvedReference" ItemType="PackageReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
     </StringListProperty.DataSource>
   </StringListProperty>
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ResolvedSdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="ResolvedSdkReference" DisplayName="解析的 SDK 引用" PageTemplate="generic" Description="解析的 SDK 引用" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="ResolveSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime"  SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="AppXLocation" DisplayName="应用包位置" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
@@ -13,4 +13,9 @@
   <BoolProperty Name="ExpandContent" DisplayName="扩展内容" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="扩展引用程序集" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="复制本地扩展的引用程序集" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ResolvedSdkReference.xaml
@@ -16,6 +16,6 @@
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/>
   <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/SdkReference.xaml
@@ -15,5 +15,5 @@
   <StringProperty Name="DisplayName" DisplayName="显示名称" Visible="False" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/> 
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/> 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/SdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="SdkReference" DisplayName="SDK 引用" PageTemplate="generic" Description="SDK 引用属性" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="SDKRootFolder" DisplayName="SDK 根" />
   <StringProperty Name="AppXLocation" DisplayName="应用包位置" />
@@ -12,4 +12,8 @@
   <BoolProperty Name="ExpandContent" DisplayName="扩展内容" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="扩展引用程序集" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="复制本地扩展的引用程序集" />
+  <StringProperty Name="DisplayName" DisplayName="显示名称" Visible="False" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/> 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/PackageReference.xaml
@@ -21,4 +21,5 @@
   <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ResolvedPackageReference.xaml
@@ -19,4 +19,6 @@
       <DataSource Persistence="ResolvedReference" ItemType="PackageReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
     </StringListProperty.DataSource>
   </StringListProperty>
+  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ResolvedSdkReference.xaml
@@ -16,6 +16,6 @@
   <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/>
   <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ResolvedSdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="ResolvedSdkReference" DisplayName="已解析的 SDK 參考" PageTemplate="generic" Description="已解析的 SDK 參考" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="ResolveSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime"  SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="AppXLocation" DisplayName="應用程式套件位置" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
@@ -13,4 +13,9 @@
   <BoolProperty Name="ExpandContent" DisplayName="展開內容" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="展開參考組件" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="複製展開的參考組件到本機" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/>
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/SdkReference.xaml
@@ -15,5 +15,5 @@
   <StringProperty Name="DisplayName" DisplayName="顯示名稱" Visible="False" />
   <StringProperty Name="Name" DisplayName="Name"/>
   <StringProperty Name="Version" DisplayName="Version"/>
-  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/> 
+  <StringProperty Name="SDKPackageItemSpec" Visible="False"/> 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/SdkReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="SdkReference" DisplayName="SDK 參考" PageTemplate="generic" Description="SDK 參考屬性" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
   <StringProperty Name="SDKRootFolder" DisplayName="SDK 根" />
   <StringProperty Name="AppXLocation" DisplayName="應用程式套件位置" />
@@ -12,4 +12,8 @@
   <BoolProperty Name="ExpandContent" DisplayName="展開內容" />
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="展開參考組件" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="複製展開的參考組件到本機" />
+  <StringProperty Name="DisplayName" DisplayName="顯示名稱" Visible="False" />
+  <StringProperty Name="Name" DisplayName="Name"/>
+  <StringProperty Name="Version" DisplayName="Version"/>
+  <StringProperty Name="SDKPackageItemSpec" DisplayName="Path" Visible="False"/> 
 </Rule>

--- a/src/Targets/Microsoft.Managed.DesignTime.targets
+++ b/src/Targets/Microsoft.Managed.DesignTime.targets
@@ -160,7 +160,7 @@
 
     <!-- Sdk references -->
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)SdkReference.xaml">
-      <Context>;BrowseObject</Context>
+      <Context>Project;ProjectSubscriptionService;BrowseObject</Context>
     </PropertyPageSchema>
 
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)ResolvedSdkReference.xaml">
@@ -202,6 +202,8 @@
        target, that is available only after restoring the .Net Core SDK targets. This No-op target will satisfy the check and will get overriden
        once the actual targets are available after package restore-->
   <Target Name="ResolvePackageDependenciesDesignTime" />
+  <Target Name="CollectSDKReferencesDesignTime" />
+  <Target Name="CollectResolvedSDKReferencesDesignTime" />
 
   <!-- This target is used to collect the PackageReferences in the project. This target can be overriden to add\remove packagereferences before they are
        sent to NuGet to be restored.-->


### PR DESCRIPTION
**Customer scenario**

The implicit references to NetStandard and NetCoreApp packages show up in solution explorer under NuGet packages and this causes confusion since the version of those packages are not tied to the TFM.

This change hides the implicit package references form Nuget dependencies sub node and show it under SDK node instead (without version, version should be specified via Properties of the node)

**Bugs this fixes:**

https://github.com/dotnet/sdk/issues/701

**Risk**

Risk low to moderate, only dependencies tree is affected

**Performance impact**

It should not be worse than, what we already have for Nuget packages.

**Is this a regression from a previous update?**

**Root cause analysis:**

**How was the bug found?**

