### PR TITLE
Upgrade build tools to fix deployment on new builds

### DIFF
--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -105,7 +105,7 @@
   </Choose>
 
   <PropertyGroup>
-    <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.25929-RC2</VisualStudioBuildToolsNuGetPackagePath>
+    <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.26124-RC3</VisualStudioBuildToolsNuGetPackagePath>
   </PropertyGroup>
   <Import Project="$(VisualStudioBuildToolsNuGetPackagePath)\build\Microsoft.VsSDK.BuildTools.props"
           Condition="'$(OS)' == 'Windows_NT' And Exists('$(VisualStudioBuildToolsNuGetPackagePath)\build\Microsoft.VsSDK.BuildTools.props')" />

--- a/src/Dependencies/Toolset/project.json
+++ b/src/Dependencies/Toolset/project.json
@@ -16,7 +16,7 @@
       "exclude": "build"
     },
     "Microsoft.VSSDK.BuildTools": {
-      "version": "15.0.25929-RC2",
+      "version": "15.0.26124-RC3",
       "exclude": "build"
     }
   },

--- a/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
+++ b/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
@@ -30,7 +30,6 @@
     <ProjectSystemLayer>VisualStudio</ProjectSystemLayer>
     <ProducingSignedVsix>true</ProducingSignedVsix>
     <IsProductComponent>true</IsProductComponent>
-    <InstallRoot>Default</InstallRoot>
     <Ngen>true</Ngen>
     <NgenArchitecture>All</NgenArchitecture>
     <NgenPriority>3</NgenPriority>


### PR DESCRIPTION
On newer builds of VS, our repo is failing to deploy to VS with:

VSSDK1043: There was a problem finding the extension with a VSIX identifier of "F6B5EACA-7FA1-4591-8D40-A38234763621". Value does not fall within the expected range.

Upgrading our build tools version to a build that contains this fix.