### PR TITLE
Remove unused Alias of Microsoft.VisualStudio.Shell.14

### DIFF
--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -258,15 +258,4 @@
     </When>
   </Choose>
 
-  <!-- Alias Microsoft.VisualStudio.Shell.14.0, so that the types don't clash with Microsoft.VisualStudio.Shell.15.0.
-       See: https://github.com/dotnet/roslyn-project-system/issues/142
-  -->
-  <Target Name="AliasShell14" AfterTargets="ResolveNuGetPackageAssets">
-    <ItemGroup>
-      <Reference Condition="'%(Reference.NuGetPackageId)' == 'Microsoft.VisualStudio.Shell.14.0'">
-        <Aliases>Shell14</Aliases>
-      </Reference>
-    </ItemGroup>
-  </Target>
-
 </Project>


### PR DESCRIPTION
#450b7a64 removed the Shell.14 reference, this removes the unused alias.

Fixes: #142