### PR TITLE
Don't crash when intermediate output isn't set

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ProjectLockFileWatcherTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ProjectLockFileWatcherTests.cs
@@ -25,12 +25,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\foo.proj""
             var fileChangeService = IVsFileChangeExFactory.CreateWithAdviseUnadviseFileChange(adviseCookie);
             spMock.AddService(typeof(IVsFileChangeEx), typeof(SVsFileChangeEx), fileChangeService);
 
-            var propertyData = new PropertyPageData
-            {
-                Category = ConfigurationGeneral.SchemaName,
-                PropertyName = ConfigurationGeneral.BaseIntermediateOutputPathProperty,
-                Value = "obj\\"
-            };
+            var propertyData = CreateBaseIntermediateOutputPathProperty("obj\\");
             var unconfiguredProject = UnconfiguredProjectFactory.Create(filePath: @"C:\Foo\foo.proj");
             var watcher = new ProjectLockFileWatcher(spMock,
                                                      IProjectTreeProviderFactory.Create(),
@@ -85,12 +80,8 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\foo.proj""
             var fileChangeService = IVsFileChangeExFactory.CreateWithAdviseUnadviseFileChange(adviseCookie);
             spMock.AddService(typeof(IVsFileChangeEx), typeof(SVsFileChangeEx), fileChangeService);
 
-            var propertyData = new PropertyPageData
-            {
-                Category = ConfigurationGeneral.SchemaName,
-                PropertyName = ConfigurationGeneral.BaseIntermediateOutputPathProperty,
-                Value = "obj\\"
-            };
+            var propertyData = CreateBaseIntermediateOutputPathProperty("obj\\");
+
             var unconfiguredProject = UnconfiguredProjectFactory.Create(filePath: @"C:\Foo\foo.proj");
             var watcher = new ProjectLockFileWatcher(spMock,
                                                      IProjectTreeProviderFactory.Create(),
@@ -107,9 +98,21 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\foo.proj""
 
             // If fileToWatch is null then we expect to not register any filewatcher.
             Mock<IVsFileChangeEx> fileChangeServiceMock = Mock.Get(fileChangeService);
-            fileChangeServiceMock.Verify(s => s.AdviseFileChange(It.IsAny<string>(), It.IsAny<uint>(), watcher, out adviseCookie), 
+            fileChangeServiceMock.Verify(s => s.AdviseFileChange(It.IsAny<string>(), It.IsAny<uint>(), watcher, out adviseCookie),
                                          Times.Exactly(numRegisterCalls));
             fileChangeServiceMock.Verify(s => s.UnadviseFileChange(adviseCookie), Times.Exactly(numUnregisterCalls));
+        }
+
+
+
+        private PropertyPageData CreateBaseIntermediateOutputPathProperty(object baseIntermediateOutputPath)
+        {
+            return new PropertyPageData
+            {
+                Category = ConfigurationGeneral.SchemaName,
+                PropertyName = ConfigurationGeneral.BaseIntermediateOutputPathProperty,
+                Value = baseIntermediateOutputPath
+            };
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectLockFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectLockFileWatcher.cs
@@ -124,6 +124,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         
         private void RegisterFileWatcherAsync(string projectLockJsonFilePath)
         {
+            // Note file change service is free-threaded
             if (_fileChangeService != null)
             {
                 int hr = _fileChangeService.AdviseFileChange(projectLockJsonFilePath, (uint)(_VSFILECHANGEFLAGS.VSFILECHG_Time | _VSFILECHANGEFLAGS.VSFILECHG_Size | _VSFILECHANGEFLAGS.VSFILECHG_Add | _VSFILECHANGEFLAGS.VSFILECHG_Del), this, out _filechangeCookie);
@@ -133,6 +134,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         private void UnregisterFileWatcherIfAny()
         {
+            // Note file change service is free-threaded
             if (_filechangeCookie != VSConstants.VSCOOKIE_NIL && _fileChangeService != null)
             {
                 // There's nothing for us to do if this fails. So ignore the return value.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectLockFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectLockFileWatcher.cs
@@ -77,7 +77,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             var projectLockFilePath = await GetProjectLockFilePathAsync(newTree).ConfigureAwait(false);
 
-            // project.json may have been renamed to {projectName}.project.json. In that case change the file watcher.
+            // project.json may have been renamed to {projectName}.project.json or in the case of the project.assets.json, 
+            // the immediate path could have changed. In either case, change the file watcher.
             if (!PathHelper.IsSamePath(projectLockFilePath, _fileBeingWatched))
             {
                 UnregisterFileWatcherIfAny();


### PR DESCRIPTION
**Customer scenario**

Two main scenarios:

- Opening a Shared Project without the following import, crashes Visual Studio.

``` XML
<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
```

- Opening a .NET Core project with an empty or malformed "SDK" attribute crashes Visual Studio.

This can also occur while the project is already open by editing the SDK attribute and saving it with malformed contents.

**Bugs this fixes:**

#1129

**Workarounds, if any**

**Risk**

Low

**Performance impact**

None

**Is this a regression from a previous update?**

No

**Root cause analysis:**

We made assumptions about the values of certain properties (in this case, intermediate path) that they always contains a value. This is incorrect assumption, as the user can set it to whatever they want, or remove the targets where they are set by default.

**How was the bug found?**

Adhoc testing.

**Dev Notes**
This component shouldn't actually be running under Shared Projects, https://github.com/dotnet/roslyn-project-system/issues/1128 is tracking that.