### PR TITLE
Pass UnloadCancellationToken to Solution Restore Service

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
@@ -138,7 +138,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
                     .RegisterCriticalAsyncTask(JoinableFactory.RunAsync(async () =>
                     {
                         await _solutionRestoreService
-                               .NominateProjectAsync(_projectVsServices.Project.FullPath, projectRestoreInfo, CancellationToken.None)
+                               .NominateProjectAsync(_projectVsServices.Project.FullPath, projectRestoreInfo,
+                                    _projectVsServices.Project.Services.ProjectAsynchronousTasks.UnloadCancellationToken)
                                .ConfigureAwait(false);
 
                         Microsoft.Internal.Performance.CodeMarkers.Instance.CodeMarker(perfPackageRestoreEnd);


### PR DESCRIPTION
**Customer scenario**

Customers may experience a hang when closing a .NET Core solution if auto restore is running in the background.

This change was requested by NuGet team as part of their efforts to resolve this hang in https://github.com/NuGet/NuGet.Client/pull/1154. This change passes a CPS cancellation token that is cancelled when a project is unloaded to NuGet's solution restore service, which in turn passes it down to core algorithms.

**Bugs this fixes:**

https://github.com/NuGet/Home/issues/4257

**Workarounds, if any**

None

**Risk**

Project System side of this fix is low risk, since we are just passing a CPS cancellation token to an existing API.

**Performance impact**

None

**Is this a regression from a previous update?**

No

**Root cause analysis:**

Part of ongoing investigations into hangs

**How was the bug found?**

Dogfooding

/cc @dotnet/project-system 
/cc NuGet team @rrelyea @alpaix 

/cc @MattGertz for Escrow approval
