### PR TITLE
Defer removal of global.json until after migration has been completed…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests.csproj
@@ -78,6 +78,7 @@
     <None Include="..\Common\Test\App.config">
       <Link>App.config</Link>
     </None>
+    <Compile Include="Mocks\GlobalJsonSetupFactory.cs" />
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="..\..\build\Targets\VSL.Imports.targets" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Mocks/GlobalJsonSetupFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Mocks/GlobalJsonSetupFactory.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.IO;
+using Microsoft.VisualStudio.Shell.Interop;
+using Moq;
+using System;
+using static Microsoft.VisualStudio.ProjectSystem.VS.Xproj.GlobalJsonRemover;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
+{
+    internal static class GlobalJsonSetupFactory
+    {
+        public static GlobalJsonSetup Create(bool retVal = false)
+        {
+            var mock = new Mock<GlobalJsonSetup>();
+            mock.Setup(g => g.SetupRemoval(It.IsAny<IVsSolution>(), It.IsAny<IServiceProvider>(), It.IsAny<IFileSystem>())).Returns(retVal);
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/GlobalJsonRemoverTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/GlobalJsonRemoverTests.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 using Microsoft.VisualStudio.Shell.Interop;
 using Moq;
 using Xunit;
+using Microsoft.VisualStudio.IO;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
 {
@@ -19,18 +20,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         [Fact]
         public void GlobalJsonRemover_InvalidServiceProvider_Throws()
         {
-            Assert.Throws<ArgumentNullException>("serviceProvider", () => new GlobalJsonRemover(null));
+            Assert.Throws<ArgumentNullException>("serviceProvider", () => new GlobalJsonRemover(null, IFileSystemFactory.Create()));
+        }
+
+        [Fact]
+        public void GlobalJsonRemover_NullFileSystem_Throws()
+        {
+            Assert.Throws<ArgumentNullException>("fileSystem", () => new GlobalJsonRemover(IServiceProviderFactory.Create(), null));
         }
 
         [Fact]
         public void GlobalJsonRemover_RemovesJson_WhenExists()
         {
             UnitTestHelper.IsRunningUnitTests = true;
+            var globalJsonPath = Path.Combine(Directory, "global.json");
             var solution = IVsSolutionFactory.CreateWithSolutionDirectory(DirectoryInfoCallback);
             var projectItem = ProjectItemFactory.Create();
             var dteSolution = SolutionFactory.ImplementFindProjectItem(path =>
             {
-                Assert.Equal(Path.Combine(Directory, "global.json"), path);
+                Assert.Equal(globalJsonPath, path);
                 return projectItem;
             });
             var dte = DteFactory.ImplementSolution(() => dteSolution);
@@ -51,9 +59,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
                 throw new InvalidOperationException();
             });
 
-            var remover = new GlobalJsonRemover(serviceProvider);
+            var fileSystem = IFileSystemFactory.Create();
+            fileSystem.Create(globalJsonPath);
+
+            var remover = new GlobalJsonRemover(serviceProvider, fileSystem);
+            GlobalJsonRemover.Remover = remover;
             Assert.Equal(VSConstants.S_OK, remover.OnAfterOpenSolution(null, 0));
-            Mock.Get(projectItem).Verify(p => p.Remove(), Times.Once);
+            Mock.Get(projectItem).Verify(p => p.Delete(), Times.Once);
+            Assert.False(fileSystem.FileExists(globalJsonPath));
         }
 
         [Fact]
@@ -84,7 +97,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
                 throw new InvalidOperationException();
             });
 
-            var remover = new GlobalJsonRemover(serviceProvider);
+            var remover = new GlobalJsonRemover(serviceProvider, IFileSystemFactory.Create());
+            GlobalJsonRemover.Remover = remover;
             Assert.Equal(VSConstants.S_OK, remover.OnAfterOpenSolution(null, 0));
         }
 
@@ -92,11 +106,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         public void GlobalJsonRemover_AfterRemoval_UnadvisesEvents()
         {
             UnitTestHelper.IsRunningUnitTests = true;
+            var globalJsonPath = Path.Combine(Directory, "global.json");
             var solution = IVsSolutionFactory.CreateWithSolutionDirectory(DirectoryInfoCallback);
             var projectItem = ProjectItemFactory.Create();
             var dteSolution = SolutionFactory.ImplementFindProjectItem(path =>
             {
-                Assert.Equal(Path.Combine(Directory, "global.json"), path);
+                Assert.Equal(globalJsonPath, path);
                 return projectItem;
             });
             var dte = DteFactory.ImplementSolution(() => dteSolution);
@@ -117,12 +132,39 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
                 throw new InvalidOperationException();
             });
 
-            var remover = new GlobalJsonRemover(serviceProvider)
+            var fileSystem = IFileSystemFactory.Create();
+            fileSystem.Create(globalJsonPath);
+
+            var remover = new GlobalJsonRemover(serviceProvider, fileSystem)
             {
                 SolutionCookie = 1234
             };
+            GlobalJsonRemover.Remover = remover;
             Assert.Equal(VSConstants.S_OK, remover.OnAfterOpenSolution(null, 0));
             Mock.Get(solution).Verify(s => s.UnadviseSolutionEvents(1234), Times.Once);
+        }
+
+        [Fact]
+        public void GlobaJsonSetup_NoExistingRemover_RegistersForAdvise()
+        {
+            UnitTestHelper.IsRunningUnitTests = true;
+            GlobalJsonRemover.Remover = null;
+
+            var solution = IVsSolutionFactory.CreateWithAdviseUnadviseSolutionEvents(1234);
+            var setupOccurred = new GlobalJsonRemover.GlobalJsonSetup().SetupRemoval(solution, IServiceProviderFactory.Create(), IFileSystemFactory.Create());
+            Assert.True(setupOccurred);
+            Assert.Equal(1234u, GlobalJsonRemover.Remover.SolutionCookie);
+        }
+
+        [Fact]
+        public void GlobalJsonSetup_ExistingRemover_ReturnsSameRemover()
+        {
+            UnitTestHelper.IsRunningUnitTests = true;
+            var remover = new GlobalJsonRemover(IServiceProviderFactory.Create(), IFileSystemFactory.Create());
+            GlobalJsonRemover.Remover = remover;
+            Assert.False(new GlobalJsonRemover.GlobalJsonSetup().SetupRemoval(IVsSolutionFactory.Create(),
+                IServiceProviderFactory.Create(), IFileSystemFactory.Create()));
+            Assert.True(ReferenceEquals(remover, GlobalJsonRemover.Remover));
         }
 
         private int DirectoryInfoCallback(out string directory, out string solutionFile, out string opts)

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
@@ -5,7 +5,6 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.Packaging;
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.ProjectSystem.VS;
 using Microsoft.VisualStudio.ProjectSystem.VS.Generators;
 using Microsoft.VisualStudio.ProjectSystem.VS.Xproj;
@@ -53,7 +52,10 @@ namespace Microsoft.VisualStudio.Packaging
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            _factory = new MigrateXprojProjectFactory(new ProcessRunner(), new Win32FileSystem(), ServiceProvider.GlobalProvider);
+            _factory = new MigrateXprojProjectFactory(new ProcessRunner(),
+                new Win32FileSystem(),
+                ServiceProvider.GlobalProvider,
+                new GlobalJsonRemover.GlobalJsonSetup());
             _factory.SetSite(new ServiceProviderToOleServiceProviderAdapter(ServiceProvider.GlobalProvider));
             RegisterProjectFactory(_factory);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/GlobalJsonRemover.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/GlobalJsonRemover.cs
@@ -6,17 +6,63 @@ using EnvDTE;
 using EnvDTE80;
 using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.IO;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
 {
     internal class GlobalJsonRemover : IVsSolutionEvents
     {
-        private readonly IServiceProvider _serviceProvider;
+        private static GlobalJsonRemover s_remover;
 
-        public GlobalJsonRemover(IServiceProvider serviceProvider)
+        /// <summary>
+        /// Testing-only getter/setter
+        /// </summary>
+        internal static GlobalJsonRemover Remover
+        {
+            get
+            {
+                Assumes.True(UnitTestHelper.IsRunningUnitTests);
+                return s_remover;
+            }
+            set
+            {
+                Assumes.True(UnitTestHelper.IsRunningUnitTests);
+                s_remover = value;
+            }
+        }
+
+        /// <summary>
+        /// Helper class for testing purposes, so we can verify calls.
+        /// </summary>
+        public class GlobalJsonSetup
+        {
+            /// <summary>
+            /// Initializes the <see cref="GlobalJsonRemover"/> if not already initialized. This method assumes that it will be called
+            /// from the UI thread, and will throw if this isn't true.
+            /// </summary>
+            /// <returns>True if the remover was set up for the first time. False otherwise.</returns>
+            public virtual bool SetupRemoval(IVsSolution solution, IServiceProvider provider, IFileSystem fileSystem)
+            {
+                UIThreadHelper.VerifyOnUIThread();
+                if (s_remover != null)
+                    return false;
+
+                s_remover = new GlobalJsonRemover(provider, fileSystem);
+                Verify.HResult(solution.AdviseSolutionEvents(s_remover, out uint cookie));
+                s_remover.SolutionCookie = cookie;
+                return true;
+            }
+        }
+
+        private readonly IServiceProvider _serviceProvider;
+        private readonly IFileSystem _fileSystem;
+
+        internal GlobalJsonRemover(IServiceProvider serviceProvider, IFileSystem fileSystem)
         {
             Requires.NotNull(serviceProvider, nameof(serviceProvider));
+            Requires.NotNull(fileSystem, nameof(fileSystem));
             _serviceProvider = serviceProvider;
+            _fileSystem = fileSystem;
         }
 
         public int OnAfterOpenSolution(object pUnkReserved, int fNewSolution)
@@ -27,13 +73,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
             try
             {
                 Verify.HResult(solution.GetSolutionInfo(out string directory, out string solutionFile, out string optsFile));
-                ProjectItem globalJson = dte.Solution.FindProjectItem(Path.Combine(directory, "global.json"));
-                globalJson?.Remove();
+                var globalJsonPath = Path.Combine(directory, "global.json");
+                ProjectItem globalJson = dte.Solution.FindProjectItem(globalJsonPath);
+                globalJson?.Delete();
+                try
+                {
+
+                    _fileSystem.RemoveFile(globalJsonPath);
+                }
+                catch (FileNotFoundException) { }
                 return VSConstants.S_OK;
             }
             finally
             {
                 Verify.HResult(solution.UnadviseSolutionEvents(SolutionCookie));
+                // Don't keep a static reference around to an object that won't be used again.
+                Assumes.True(ReferenceEquals(this, s_remover));
+                s_remover = null;
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/GlobalJsonRemover.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/GlobalJsonRemover.cs
@@ -12,6 +12,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
 {
     internal class GlobalJsonRemover : IVsSolutionEvents
     {
+        /// <summary>
+        /// Static GlobalJsonRemover instance. All interactions must occur on the UI thread.
+        /// </summary>
         private static GlobalJsonRemover s_remover;
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/GlobalJsonRemover.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/GlobalJsonRemover.cs
@@ -78,7 +78,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
                 globalJson?.Delete();
                 try
                 {
-
                     _fileSystem.RemoveFile(globalJsonPath);
                 }
                 catch (FileNotFoundException) { }

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 using Microsoft.VisualStudio.Shell.Flavor;
 using Microsoft.VisualStudio.Shell.Interop;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
 {
@@ -20,15 +21,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         private readonly ProcessRunner _runner;
         private readonly IFileSystem _fileSystem;
         private readonly IServiceProvider _serviceProvider;
+        private readonly GlobalJsonRemover.GlobalJsonSetup _globalJsonSetup;
 
-        public MigrateXprojProjectFactory(ProcessRunner runner, IFileSystem fileSystem, IServiceProvider serviceProvider)
+        public MigrateXprojProjectFactory(ProcessRunner runner,
+            IFileSystem fileSystem,
+            IServiceProvider serviceProvider,
+            GlobalJsonRemover.GlobalJsonSetup globalJsonSetup)
         {
             Requires.NotNull(runner, nameof(runner));
             Requires.NotNull(fileSystem, nameof(fileSystem));
             Requires.NotNull(serviceProvider, nameof(serviceProvider));
+            Requires.NotNull(globalJsonSetup, nameof(globalJsonSetup));
             _runner = runner;
             _fileSystem = fileSystem;
             _serviceProvider = serviceProvider;
+            _globalJsonSetup = globalJsonSetup;
         }
 
         public int UpgradeProject(string xprojLocation, uint upgradeFlags, string backupDirectory, out string migratedProjectFileLocation,
@@ -133,6 +140,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
             var globalJson = Path.Combine(solutionDirectory, "global.json");
             if (_fileSystem.FileExists(globalJson))
             {
+                // We want to set up the remover if it hasn't been set up already. If it has been set up already, then we can just return, as backup
+                // and parsing for the sdk element will already have occurred.
+                if (!_globalJsonSetup.SetupRemoval(solution, _serviceProvider, _fileSystem))
+                    return HResult.OK;
+
                 // We want to find the root backup directory that VS created for backup. We can't just assume it's solution/Backup, because VS will create
                 // a new directory if that already exists. So just iterate up until we find the correct directory.
                 solutionDirectory = solutionDirectory.TrimEnd(Path.DirectorySeparatorChar);
@@ -149,22 +161,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
                 pLogger.LogMessage((uint)__VSUL_ERRORLEVEL.VSUL_INFORMATIONAL, projectName, globalJson,
                     string.Format(VSResources.MigrationBackupFile, globalJson, globalJsonBackupPath));
                 _fileSystem.CopyFile(globalJson, globalJsonBackupPath, true);
-                try
-                {
-                    _fileSystem.RemoveFile(globalJson);
 
-                    var remover = new GlobalJsonRemover(_serviceProvider);
-                    HResult hr = solution.AdviseSolutionEvents(remover, out uint cookie);
-                    if (hr.Succeeded)
-                    {
-                        remover.SolutionCookie = cookie;
-                    }
-                }
-                catch (IOException e)
+                // Now parse the global.json, and remove the "sdk" element if it exists
+                var json = JsonConvert.DeserializeObject<JObject>(_fileSystem.ReadAllText(globalJson));
+                if (json.Remove("sdk"))
                 {
-                    pLogger.LogMessage((uint)__VSUL_ERRORLEVEL.VSUL_ERROR, projectName, globalJson,
-                        e.Message);
-                    return e.HResult;
+                    _fileSystem.WriteAllText(globalJson, JsonConvert.SerializeObject(json));
                 }
             }
             return VSConstants.S_OK;

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
@@ -166,7 +166,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
                 var json = JsonConvert.DeserializeObject<JObject>(_fileSystem.ReadAllText(globalJson));
                 if (json.Remove("sdk"))
                 {
-                    _fileSystem.WriteAllText(globalJson, JsonConvert.SerializeObject(json));
+                    try
+                    {
+                        _fileSystem.WriteAllText(globalJson, JsonConvert.SerializeObject(json));
+                    }
+                    catch (IOException ex)
+                    {
+                        pLogger.LogMessage((uint)__VSUL_ERRORLEVEL.VSUL_ERROR, projectName, globalJson, ex.Message);
+                        return ex.HResult;
+                    }
                 }
             }
             return VSConstants.S_OK;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsSolutionFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsSolutionFactory.cs
@@ -15,6 +15,8 @@ namespace Microsoft.VisualStudio.Shell.Interop
 
         public static Func<uint, int> DefaultUnadviseCallback => (uint cookie) => VSConstants.S_OK;
 
+        public static IVsSolution Create() => Mock.Of<IVsSolution>();
+
         public static IVsSolution CreateWithSolutionDirectory(FuncWithOutThreeArgs<string, string, string, int> func)
         {
             var mock = new Mock<IVsSolution>();


### PR DESCRIPTION
…. Remove sdk element from global.json when first discovered, to ensure that the sdk isn't inappropriately downgraded. Tagging @dotnet/project-system for review. /cc @eerhardt, @livarcocc.

**Customer scenario**

If a customer has a multi-root solution, projects in one root that reference projects in another root will be incorrectly migrated. This can result in migration failures (errors in the log, no csproj written) or subsequent build failures (project references are incorrectly added as package references). A very common example would be:
* `src\Library\Library.csproj`
* `test\LibraryTests\LibraryTests.csproj`
    * Depends on `src\Library`
    * Migration failure occurs.

**Bugs this fixes:**

Fixes https://github.com/dotnet/roslyn-project-system/issues/1376.

**Workarounds, if any**

Migrate the solution from the command line. We think that this is a common enough scenario to warrant a real fix, however.

**Risk**

This fix will cause https://github.com/dotnet/cli/issues/5519 to start impacting solutions migrated from VS. Working with @livarcocc on ensuring this all works correctly.

**Performance impact**

Minor. We're deserializing a JSON file and performing an additional write, but the global.json is almost always a very small file, and this will only affect migration scenarios.

**Is this a regression from a previous update?**

Yes. In fixing https://github.com/dotnet/roslyn-project-system/issues/1184, we started removing the global.json from the solution and the disk. I'll add a test scenario to our list of validation scenarios for this.

**How was the bug found?**

Customer reported.