### PR TITLE
Fix for 865, when broken references changes did not have correct icons

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependenciesSubTreeProviderBaseTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependenciesSubTreeProviderBaseTests.cs
@@ -140,7 +140,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 ""Items"": {
                     ""resolvedItemTobeRemoved"": {
                         ""OriginalItemSpec"":""unresolvedItemTobeAddedInsteadOfRemovedResolvedItem""
-                    }
+                    },
+                    ""resolvedItemTobeRemovedWithNonExistentOriginalItemSpec"": {
+                        ""OriginalItemSpec"":""nonExistentUnresolvedOriginalItemSpec""
+                    },
                 },
                 ""RuleName"":""rulenameResolved""
             },
@@ -148,7 +151,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 ""AddedItems"": [ ""item21"", ""item22"", ""itemWithoutOriginalItemSpec"", ""itemWithoutPropertiesInAfter"", 
                                   ""unresolvedItemTobeRemoved"" ],
                 ""ChangedItems"": [ ],
-                ""RemovedItems"": [ ""resolvedItemTobeRemoved"" ],
+                ""RemovedItems"": [ ""resolvedItemTobeRemoved"", ""resolvedItemTobeRemovedWithNonExistentOriginalItemSpec"" ],
                 ""AnyChanges"": ""true""
             },
         },
@@ -213,7 +216,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
     ""Id"": {
         ""ProviderType"": ""MyProvider"",
-        ""ItemSpec"": ""resolvedItemTobeRemoved"",
+        ""ItemSpec"": ""unresolvedItemTobeAddedInsteadOfRemovedResolvedItem"",
         ""ItemType"": ""myUnresolvedItemType""
     }
 }");
@@ -226,16 +229,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         ""ItemType"": ""myUnresolvedItemType""
     }
 }");
+
+            var unresolvedItemTobeRemovedNodeWithNonExistentOriginalItemSpecNode = IDependencyNodeFactory.FromJson(@"
+{
+    ""Id"": {
+        ""ProviderType"": ""MyProvider"",
+        ""ItemSpec"": ""resolvedItemTobeRemovedWithNonExistentOriginalItemSpec"",
+        ""ItemType"": ""myUnresolvedItemType""
+    }
+}");
             rootNode.AddChild(item4Node);
             rootNode.AddChild(resolvedItemTobeRemovedNode);
             rootNode.AddChild(unresolvedItemTobeRemovedNode);
+            rootNode.AddChild(unresolvedItemTobeRemovedNodeWithNonExistentOriginalItemSpecNode);
 
             var catalogs = IProjectCatalogSnapshotFactory.ImplementRulesWithItemTypes(
                 new Dictionary<string, string>
                 {
                     { "rulenameResolved", "myResolvedItemType" },
                     { "rulenameUnresolved", "myUnresolvedItemType" },
-                    { "unresolvedItemTobeRemoved", "myUnresolvedItemType" }
+                    { "unresolvedItemTobeRemoved", "myUnresolvedItemType" },
+                    { "unresolvedItemTobeAddedInsteadOfRemovedResolvedItem", "myUnresolvedItemType" }
                 });
 
             var provider = new TestableDependenciesSubTreeProviderBase();
@@ -273,13 +287,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.True(addedNodesArray[4].Resolved);
             Assert.Equal("unresolvedItemTobeRemoved", addedNodesArray[4].Caption);
 
-            Assert.Equal(3, resultChanges.RemovedNodes.Count);
+            Assert.Equal(4, resultChanges.RemovedNodes.Count);
 
             var removedNodesArray = resultChanges.RemovedNodes.ToArray();
 
             Assert.Equal(item4Node.Id, removedNodesArray[0].Id);
             Assert.Equal(resolvedItemTobeRemovedNode.Id, removedNodesArray[1].Id);
-            Assert.Equal(unresolvedItemTobeRemovedNode.Id, removedNodesArray[2].Id);
+            Assert.Equal(unresolvedItemTobeRemovedNodeWithNonExistentOriginalItemSpecNode.Id, removedNodesArray[2].Id);
+            Assert.Equal(unresolvedItemTobeRemovedNode.Id, removedNodesArray[3].Id);
         }
 
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IEnumerableExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IEnumerableExtensions.cs
@@ -15,5 +15,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                             x => x.Id.ItemSpec.Equals(itemSpec, StringComparison.OrdinalIgnoreCase)
                                  && x.Id.ItemType.Equals(itemType, StringComparison.OrdinalIgnoreCase));
         }
+
+        internal static T FindNode<T>(this IEnumerable<T> nodes, string itemSpec)
+            where T : IDependencyNode
+        {
+            return nodes.FirstOrDefault(
+                            x => x.Id.ItemSpec.Equals(itemSpec, StringComparison.OrdinalIgnoreCase));
+        }
+
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/INuGetPackagesDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/INuGetPackagesDataProvider.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// turns out to be a nuget package.
         /// </summary>
         /// <param name="packageItemSpec">Package reference items spec for which we need to do a search</param>
-        /// <param name="searchTerm"></param>
+        /// <param name="searchTerm">String to be searched</param>
         /// <returns></returns>
         Task<IEnumerable<IDependencyNode>> SearchAsync(string packageItemSpec, string searchTerm);
     }


### PR DESCRIPTION
**Customer scenario**

When user changes dependency in project file , if dependency became unknown , icon did not reflect that.

**Bugs this fixes:**

https://github.com/dotnet/roslyn-project-system/issues/865

**Workarounds, if any**

**Risk**

Minimal
