### PR TITLE
Force full project reload when TargetFramework or TargetFrameworks pr…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Reload/ProjectReloadInterceptorTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Reload/ProjectReloadInterceptorTests.cs
@@ -31,6 +31,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         [InlineData(null, "invalid target frameworks", null, null)]
         [InlineData(null, null, "netcoreapp1.0", "net45;netcoreapp1.0")]
         [InlineData("netcoreapp1.0", "net45;netcoreapp1.0", null, null)]
+        // User edits the value of current TF/TFs.
+        [InlineData("net45", null, "net46", null)]
+        [InlineData(null, "net45;netcoreapp1.0", null, "net45")]
+        [InlineData(null, "net45", null, "net45;netcoreapp1.0")]
+        [InlineData("invalid;target;framework", null, "net46", null)]
+        [InlineData(null, "invalid target frameworks", null, "net45;netcoreapp1.0")]
         public void Test_ProjectNeedsReload(string oldTargetFramework, string oldTargetFrameworks, string newTargetFramework, string newTargetFrameworks)
         {
             var oldProperties = CreatePropertiesCollection(oldTargetFramework, oldTargetFrameworks);
@@ -45,12 +51,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         [InlineData(null, null, null, null)]
         [InlineData(null, "net45", null, "net45")]
         [InlineData(null, "net45;netcoreapp1.0", null, "net45;netcoreapp1.0")]
-        // User edits the value of current TF/TFs.
-        [InlineData("net45", null, "net46", null)]
-        [InlineData(null, "net45;netcoreapp1.0", null, "net45")]
-        [InlineData(null, "net45", null, "net45;netcoreapp1.0")]
-        [InlineData("invalid;target;framework", null, "net46", null)]
-        [InlineData(null, "invalid target frameworks", null, "net45;netcoreapp1.0")]
+        // Change only in case of TF/TFs.
+        [InlineData(null, "net45", null, "NET45")]
+        [InlineData(null, "net45;netcoreapp1.0", null, "Net45;NetCoreApp1.0")]
         public void Test_ProjectDoesntNeedReload(string oldTargetFramework, string oldTargetFrameworks, string newTargetFramework, string newTargetFrameworks)
         {
             var oldProperties = CreatePropertiesCollection(oldTargetFramework, oldTargetFrameworks);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Reload/ProjectReloadManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Reload/ProjectReloadManager.cs
@@ -304,8 +304,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 }
                 else
                 {
-                    Assumes.True(failure.Item2 == ProjectReloadResult.ReloadFailed || failure.Item2 == ProjectReloadResult.NeedsForceReload);
-
                     if (ignoreAll)
                     {   
                         // do nothing
@@ -316,7 +314,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                     }
                     else
                     {
-                        ProcessProjectWhichFailedReload(failure.Item1, out ignoreAll, out reloadAll);
+                        ProcessProjectWhichFailedReload(failure.Item1, failure.Item2, out ignoreAll, out reloadAll);
                     }
                 }
             }
@@ -326,8 +324,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// Puts up a prompt appropriate for project which failed the autoload. ignoreAll or reloadAll will be set
         /// to true if the user selected those options
         /// </summary>
-        private void ProcessProjectWhichFailedReload(IReloadableProject project, out bool ignoreAll, out bool reloadAll)
+        private void ProcessProjectWhichFailedReload(IReloadableProject project, ProjectReloadResult reloadResult, out bool ignoreAll, out bool reloadAll)
         {
+            Assumes.True(reloadResult == ProjectReloadResult.ReloadFailed || reloadResult == ProjectReloadResult.NeedsForceReload);
+
             ignoreAll = false;
             reloadAll = false;
             var buttons = new string[] {VSResources.IgnoreAll,
@@ -335,8 +335,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                                         VSResources.ReloadAll,
                                         VSResources.Reload};
 
-            // TODO: Consider showing different messages for reload failed and needs forced reload.
-            var msgText = string.Format(VSResources.ProjectModificationsPrompt, Path.GetFileNameWithoutExtension(project.ProjectFile));
+            var formatText = reloadResult == ProjectReloadResult.NeedsForceReload ? VSResources.ProjectForceReloadPrompt : VSResources.ProjectModificationsPrompt;
+            var msgText = string.Format(formatText, Path.GetFileNameWithoutExtension(project.ProjectFile));
             switch (_dialogServices.ShowMultiChoiceMsgBox(VSResources.ProjectModificationDlgTitle, msgText, buttons))
             {
                 case MultiChoiceMsgBoxResult.Cancel:

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -373,6 +373,19 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The project &apos;{0}&apos; needs to be reloaded as certain critical properties have changed.
+        ///
+        ///Press Reload to load the updated project.
+        ///Press Ignore to ignore the project changes. The changes will be used the next time you open the project.
+        ///    .
+        /// </summary>
+        internal static string ProjectForceReloadPrompt {
+            get {
+                return ResourceManager.GetString("ProjectForceReloadPrompt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Project Modification Detected.
         /// </summary>
         internal static string ProjectModificationDlgTitle {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -127,6 +127,13 @@ Press Reload to load the updated project from disk.
 Press Ignore to ignore the external changes. The changes will be used the next time you open the project.
     </value>
   </data>
+  <data name="ProjectForceReloadPrompt" xml:space="preserve">
+    <value>The project '{0}' needs to be reloaded as certain critical properties have changed.
+
+Press Reload to load the updated project.
+Press Ignore to ignore the project changes. The changes will be used the next time you open the project.
+    </value>
+  </data>
   <data name="ConflictingModificationsPrompt" xml:space="preserve">
     <value>The project '{0}' has been modified outside the environment, and there are unsaved changes to the project.
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Reload/ProjectReloadInterceptor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Reload/ProjectReloadInterceptor.cs
@@ -31,27 +31,28 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         private static bool NeedsForcedReload(ImmutableArray<ProjectPropertyElement> oldProperties, ImmutableArray<ProjectPropertyElement> newProperties)
         {
-            // If user added or removed TargetFramework/TargetFrameworks property, then force a full project reload.
+            // If user added/removed/edited TargetFramework/TargetFrameworks property, then force a full project reload.
             var oldTargets = ComputeProjectTargets(oldProperties);
             var newTargets = ComputeProjectTargets(newProperties);
 
-            return oldTargets.HasTargetFramework != newTargets.HasTargetFramework || oldTargets.HasTargetFrameworks != newTargets.HasTargetFrameworks;
+            return !StringComparers.PropertyValues.Equals(oldTargets.TargetFramework, newTargets.TargetFramework) ||
+                !StringComparers.PropertyValues.Equals(oldTargets.TargetFrameworks, newTargets.TargetFrameworks);
         }
 
-        private static (bool HasTargetFramework, bool HasTargetFrameworks) ComputeProjectTargets(ImmutableArray<ProjectPropertyElement> properties)
+        private static (string TargetFramework, string TargetFrameworks) ComputeProjectTargets(ImmutableArray<ProjectPropertyElement> properties)
         {
-            (bool HasTargetFramework, bool HasTargetFrameworks) targets = (false, false);
+            (string TargetFramework, string TargetFrameworks) targets = (null, null);
 
             foreach (var property in properties)
             {
                 if (property.Name.Equals(ConfigurationGeneral.TargetFrameworkProperty, StringComparison.OrdinalIgnoreCase))
                 {
-                    targets.HasTargetFramework = true;
+                    targets.TargetFramework = property.Value;
                 }
 
                 if (property.Name.Equals(ConfigurationGeneral.TargetFrameworksProperty, StringComparison.OrdinalIgnoreCase))
                 {
-                    targets.HasTargetFrameworks = true;
+                    targets.TargetFrameworks = property.Value;
                 }
             }
 


### PR DESCRIPTION
…operty is changed.

**Customer scenario**

User edits the TargetFramework or TargetFrameworks property in the csproj and gets numerous errors:

1. Duplicate references for system assemblies from both the prior and new value of the target framework
2. Design time build failures and MSBuild errors in the error list
3. Unit test discovery fails due to incorrect output path
4. Dependencies node doesn't get updated with current framework's references.

**Bugs this fixes:**

Fixes #1252, #1159 and VSO #[375688](https://devdiv.visualstudio.com/DevDiv/_workitems?id=375688&_a=edit)

**Workarounds, if any**

User has to close and re-open the solution for everything to start working again.

**Risk**

This is a tactical low risk for the bunch of issues noted above. Ideally, we would fix each of these issues (and we should in fact fix them post-Dev15), but given that editing the TargetFramework or TargetFrameworks in not that common an operation, forcing a reload seems a reasonable approach.

**Performance impact**

Low. We are already forcing reload if user adds or remove either of these properties. We are just extending that check so we force reload even when the property is edited.

**Is this a regression from a previous update?**

One of more of the above issues are likely regressions, and some were probably broken before as well.

**Root cause analysis:**

We need more testing to catch such issues.

**How was the bug found?**

Customer reports and dogfooding.