### PR TITLE
Fix for 954 Adding/removing a Shared Project does not update the dependency node

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesSubTreeProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesSubTreeProviderBase.cs
@@ -304,9 +304,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 });
 
                 dependenciesChange.AddedNodes.ForEach(RootNode.AddChild);
-            }
 
-            OnDependenciesChanged(dependenciesChange.GetDiff(), e, handlerType);
+                OnDependenciesChanged(dependenciesChange.GetDiff(), e, handlerType);
+            }
         }
 
         public virtual IDependencyNode GetDependencyNode(DependencyNodeId nodeId)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesSubTreeProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesSubTreeProviderBase.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.Threading;
@@ -50,6 +51,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         private List<IDisposable> _projectSyncLinks;
 
         private object _rootNodeSync = new object();
+
+        /// <summary>
+        /// Stores latest data sources versions sent from DesignTimeBuild
+        /// </summary>
+        private IImmutableDictionary<NamedIdentity, IComparable> _latestDataSourceVersions = null;
 
         /// <summary>
         /// Gets the project asynchronous tasks service.
@@ -195,7 +201,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                 suppressVersionOnlyUpdates: false,
                                 linkOptions: new DataflowLinkOptions { PropagateCompletion = true }));
 
-                            var actionBlock = new ActionBlock<
+                            var actionBlockDesignTimeBuild = new ActionBlock<
                                                     IProjectVersionedValue<
                                                         Tuple<IProjectSubscriptionUpdate,
                                                                IProjectCatalogSnapshot,
@@ -204,25 +210,41 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                                         IProjectVersionedValue<
                                                             Tuple<IProjectSubscriptionUpdate,
                                                                   IProjectCatalogSnapshot,
-                                                                  IProjectSharedFoldersSnapshot>>>(
-                                                        ProjectSubscriptionService_Changed),
+                                                                  IProjectSharedFoldersSnapshot>>>(e => 
+                                                        ProjectSubscriptionService_Changed(e, RuleHandlerType.DesignTimeBuild)),
                                                    new ExecutionDataflowBlockOptions()
                                                    {
-                                                       NameFormat = "DependenciesSubTree Input: {1}"
+                                                       NameFormat = "DependenciesSubTree DesignTime Input: {1}"
+                                                   });
+
+                            var actionBlockEvaluation = new ActionBlock<
+                                                    IProjectVersionedValue<
+                                                        Tuple<IProjectSubscriptionUpdate,
+                                                               IProjectCatalogSnapshot,
+                                                               IProjectSharedFoldersSnapshot>>>
+                                                  (new Action<
+                                                        IProjectVersionedValue<
+                                                            Tuple<IProjectSubscriptionUpdate,
+                                                                  IProjectCatalogSnapshot,
+                                                                  IProjectSharedFoldersSnapshot>>>(e =>
+                                                        ProjectSubscriptionService_Changed(e, RuleHandlerType.Evaluation)),
+                                                   new ExecutionDataflowBlockOptions()
+                                                   {
+                                                       NameFormat = "DependenciesSubTree Evaluation Input: {1}"
                                                    });
 
                             _projectSyncLinks.Add(ProjectDataSources.SyncLinkTo(
                                 intermediateBlockDesignTime.SyncLinkOptions(),
                                 ProjectSubscriptionService.ProjectCatalogSource.SourceBlock.SyncLinkOptions(),
                                 ProjectSubscriptionService.SharedFoldersSource.SourceBlock.SyncLinkOptions(),
-                                actionBlock,
+                                actionBlockDesignTimeBuild,
                                 linkOptions: new DataflowLinkOptions { PropagateCompletion = true }));
 
                             _projectSyncLinks.Add(ProjectDataSources.SyncLinkTo(
                                 intermediateBlockEvaluation.SyncLinkOptions(),
                                 ProjectSubscriptionService.ProjectCatalogSource.SourceBlock.SyncLinkOptions(),
                                 ProjectSubscriptionService.SharedFoldersSource.SourceBlock.SyncLinkOptions(),
-                                actionBlock,
+                                actionBlockEvaluation,
                                 linkOptions: new DataflowLinkOptions { PropagateCompletion = true }));
                         }
                     },
@@ -249,10 +271,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// Handles changes to the references items in the project and updates the project tree.
         /// </summary>
         /// <param name="e">A description of the changes made to the project.</param>
+        /// <param name="handlerType">Specifies type of the event: DesignTimeBuild or Evaluation.</param>
         private void ProjectSubscriptionService_Changed(IProjectVersionedValue<
                                                             Tuple<IProjectSubscriptionUpdate,
                                                                   IProjectCatalogSnapshot,
-                                                                  IProjectSharedFoldersSnapshot>> e)
+                                                                  IProjectSharedFoldersSnapshot>> e,
+                                                        RuleHandlerType handlerType)
         {
             DependenciesChange dependenciesChange;
 
@@ -282,7 +306,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 dependenciesChange.AddedNodes.ForEach(RootNode.AddChild);
             }
 
-            OnDependenciesChanged(dependenciesChange.GetDiff(), e);
+            OnDependenciesChanged(dependenciesChange.GetDiff(), e, handlerType);
         }
 
         public virtual IDependencyNode GetDependencyNode(DependencyNodeId nodeId)
@@ -552,14 +576,34 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                              IProjectVersionedValue<
                                                 Tuple<IProjectSubscriptionUpdate,
                                                         IProjectCatalogSnapshot,
-                                                        IProjectSharedFoldersSnapshot>> e)
+                                                        IProjectSharedFoldersSnapshot>> e,
+                                             RuleHandlerType handlerType)
         {
+            IImmutableDictionary<NamedIdentity, IComparable> dataSourceVersions = null;
+            lock (_syncObject)
+            {
+                if (_latestDataSourceVersions == null)
+                {
+                    // very first time send some versions even for Evaluation
+                    dataSourceVersions = e?.DataSourceVersions;
+                }
+
+                _latestDataSourceVersions = e?.DataSourceVersions;
+                if (handlerType == RuleHandlerType.DesignTimeBuild)
+                {
+                    // Only update versions after DesignTimeBuild events, since they would bring resolved 
+                    // dependencies and if some components would want to known when tree latest state changed,
+                    // DesignTimeBuild events are the ones that bring final state.
+                    dataSourceVersions = _latestDataSourceVersions;
+                }
+            }
+
             DependenciesChanged(this,
                                 new DependenciesChangedEventArgs(
                                         this,
                                         changes,
                                         e?.Value?.Item2,
-                                        e?.DataSourceVersions));
+                                        dataSourceVersions));
         }
 
         /// <summary>


### PR DESCRIPTION
**Customer scenario**

There are multiple reports of issues with the dependencies node where it doesn't show all the nodes or shows stale\wrong data. 
Also, when an user adds a Shared project reference to core app it did was not added to Dependencies\Projects sub tree node. 

This fix improves overall tree events data flow which appeared to be flacky and could produce some random missing data according to @lifengl. Now we:

- using suppressVersionOnlyUpdates: false, to allow all kinds of events to be send to SynkLink 
- PropagateCompletion = true for our data blocks to allow failures to be propagated to us
- merging data source versions accross all sub tree providers using CPS helper API and posting consistent merged sets of data sources versions after each tree update
- added NameFormat for each data block to simplify analysis later

#1295
#1405 
#1423
#954 

**Risk**

Minimal
