### PR TITLE
Hide "Resources" part of the application page for .Net Core projects

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
@@ -682,6 +682,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             If ProjectHierarchy.IsCapabilityMatch(Pack) Then
                 AssemblyInfoButton.Visible = False
             End If
+
+            If IsTargetingDotNetCore(ProjectHierarchy) Then
+                ResourcesGroupBox.Visible = False
+            End If
         End Sub
 
         ''' <summary>


### PR DESCRIPTION
**Customer scenario**
When editing project properties some of the pages should not be showing up for .Net Core apps. There's been reports of customers running into crashes or broken experience issues when trying to make edits to the unsupported pages. This removes displaying the resource/manifest block of the property application property page for .NetCore projects.

**Bugs this fixes:**
#1069 

Risk
 Low Risk - This only affects the Application property page

Performance impact
 Low - This is only hit when opening the property page and it's checking the TFM in the project which is inexpensive.

Is this a regression from a previous update?
 Not a regression, previously the section of the page applied to all projects which isn't true anymore.

Root cause analysis:
 See above.

How was the bug found?
Customer reported
