### PR TITLE
Fix for launch settings failing to load

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -87,6 +87,7 @@
     <Compile Include="ProjectSystem\LanguageServices\LanguageServiceHost.cs" />
     <Compile Include="ProjectSystem\LanguageServices\UnconfiguredProjectContextProvider.cs" />
     <Compile Include="ProjectSystem\PhysicalProjectTreeStorage.cs" />
+    <Compile Include="ProjectSystem\DataflowUtilities.cs" />
     <Compile Include="ProjectSystem\ProjectTreeProviderExtensions.cs" />
     <Compile Include="ProjectSystem\Properties\DelegatedProjectPropertiesProviderBase.cs" />
     <Compile Include="ProjectSystem\Properties\DelegatedProjectPropertiesBase.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DataFlowUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DataFlowUtilities.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    /// <summary>
+    ///     Provides common well-known project flags.
+    /// </summary>
+    internal static class DataflowUtilities
+    {
+        /// <summary>
+        /// Wraps a delegate in a repeatably executable delegate that runs within an ExecutionContext captured at the time of *this* method call.
+        /// </summary>
+        /// <typeparam name="TInput">The type of input parameter that is taken by the delegate.</typeparam>
+        /// <param name="function">The delegate to invoke when the returned delegate is invoked.</param>
+        /// <returns>The wrapper delegate.</returns>
+        /// <remarks>
+        /// This is useful because Dataflow doesn't capture or apply ExecutionContext for its delegates,
+        /// so the delegate runs in whatever ExecutionContext happened to call ITargetBlock.Post, which is
+        /// never the behavior we actually want. We've been bitten several times by bugs due to this.
+        /// Ironically, in Dataflow's early days it *did* have the desired behavior but they removed it
+        /// when they pulled it out of the Framework so it could be 'security transparent'.
+        /// By passing block delegates through this wrapper, we can reattain the old behavior.
+        /// </remarks>
+        internal static Func<TInput, Task> CaptureAndApplyExecutionContext<TInput>(Func<TInput, Task> function)
+        {
+            var context = ExecutionContext.Capture();
+            return input =>
+            {
+                var currentSynchronizationContext = SynchronizationContext.Current;
+                using (var copy = context.CreateCopy())
+                {
+                    Task result = null;
+                    ExecutionContext.Run(
+                        copy,
+                        state =>
+                        {
+                            SynchronizationContext.SetSynchronizationContext(currentSynchronizationContext);
+                            result = function(input);
+                        },
+                        null);
+                    return result;
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
**Customer scenario**
Sometimes when opening or creating an asp.net core project the launch settings don't appear in the debug dropdown. 

**Bugs this fixes:**
https://github.com/dotnet/roslyn-project-system/issues/1395
and is a work around for https://devdiv.visualstudio.com/DevDiv/_workitems?id=375276


**Workarounds, if any**
Close and re-open the project

**Risk**
Low. Captures the execution context at the time the dataflow connection is established, and reapplies this context  when changes to the dataflow are received. This avoids leakage of execution state across the dataflow boundary.

**Performance impact**
Simple change with no extra allocations

**Is this a regression from a previous update?**
No

**Root cause analysis:**
This is an intermittent problem so difficult to catch in unit or integration tests.
How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**
Add hoc testing and customer reported