### PR TITLE
Specify the project.json to migrate explicitly to address #1399

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         private static readonly string BackupLocation = Path.Combine(SlnLocation, "Backup");
         private static readonly string CsprojLocation = Path.Combine(RootLocation, $"{ProjectName}.csproj");
         private static readonly string LogFileLocation = Path.Combine(RootLocation, "asdf.1234");
-        private static readonly string MigrateCommand = $"dotnet migrate --skip-backup -s -x \"{XprojLocation}\" \"{RootLocation}\" -r \"{LogFileLocation}\" --format-report-file-json";
+        private static readonly string MigrateCommand = $"dotnet migrate --skip-backup -s -x \"{XprojLocation}\" \"{ProjectJsonLocation}\" -r \"{LogFileLocation}\" --format-report-file-json";
         private static readonly string GlobalJsonLocation = Path.Combine(SlnLocation, "global.json");
 
         [Fact]
@@ -471,7 +471,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         private void ProcessVerifier(ProcessStartInfo info)
         {
             Assert.Equal("dotnet.exe", info.FileName);
-            Assert.Equal($"migrate --skip-backup -s -x \"{XprojLocation}\" \"{RootLocation}\" -r \"{LogFileLocation}\" --format-report-file-json", info.Arguments);
+            Assert.Equal($"migrate --skip-backup -s -x \"{XprojLocation}\" \"{ProjectJsonLocation}\" -r \"{LogFileLocation}\" --format-report-file-json", info.Arguments);
             Assert.True(info.EnvironmentVariables.ContainsKey("DOTNET_SKIP_FIRST_TIME_EXPERIENCE"));
             Assert.Equal("true", info.EnvironmentVariables["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"]);
             Assert.Equal(SlnLocation, info.WorkingDirectory);

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
@@ -315,7 +315,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         }
 
         private string GetDotnetArguments(string xprojLocation, string projectDirectory, string logFile) =>
-            $"migrate --skip-backup -s -x \"{xprojLocation}\" \"{projectDirectory}\" -r \"{logFile}\" --format-report-file-json";
+            $"migrate --skip-backup -s -x \"{xprojLocation}\" \"{projectDirectory}\\project.json\" -r \"{logFile}\" --format-report-file-json";
 
         private string GetDotnetGeneralErrorString(string projectName, string xprojLocation, string projectDirectory, string logFile, int exitCode) =>
             string.Format(VSResources.XprojMigrationGeneralFailure,


### PR DESCRIPTION
Tagging @dotnet/project-system for review. FYI @livarcocc.

**Customer scenario**

If a customer has a solution file and a project file in the same directory, we fail migration. This is because the Backup directory is put in the same locations as the project files, and when we ask migration to migrate the directory it will migrate both the actual project and the backed up project.

**Bugs this fixes:**

https://github.com/dotnet/roslyn-project-system/issues/1399

**Workarounds, if any**

Migrate from the command line. The reason I believe this is worth the fix is that the error is completely silent: nothing appears in the log that would indicate a migration failure, but the solution does not load.

**Risk**

Very low. We just specify the project.json explicitly, which causes the CLI to only migrate the specific project in question.

**Performance impact**

None. This is a command-format change only.

**Is this a regression from a previous update?**

No. Bug in initial implementation.

**Root cause analysis:**

This is a very rare format, as the solution file is usually not in the same directory as the project file.

**How was the bug found?**

Internal testing.