### PR TITLE
Disable the ReferencePaths property page

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Properties/CSharpProjectDesignerPageProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Properties/CSharpProjectDesignerPageProviderTests.cs
@@ -21,14 +21,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         {
             var provider = CreateInstance();
             var pages = await provider.GetPagesAsync();
+            ProjectDesignerPageMetadata[] expectedPages = new ProjectDesignerPageMetadata[]
+            {
+                CSharpProjectDesignerPage.Application,
+                CSharpProjectDesignerPage.Build,
+                CSharpProjectDesignerPage.BuildEvents,
+                CSharpProjectDesignerPage.Debug,
+                CSharpProjectDesignerPage.Signing,
+            };
 
-            Assert.Equal(pages.Count(), 6);
-            Assert.Same(pages.ElementAt(0), CSharpProjectDesignerPage.Application);
-            Assert.Same(pages.ElementAt(1), CSharpProjectDesignerPage.Build);
-            Assert.Same(pages.ElementAt(2), CSharpProjectDesignerPage.BuildEvents);
-            Assert.Same(pages.ElementAt(3), CSharpProjectDesignerPage.Debug);
-            Assert.Same(pages.ElementAt(4), CSharpProjectDesignerPage.ReferencePaths);
-            Assert.Same(pages.ElementAt(5), CSharpProjectDesignerPage.Signing);
+            Assert.Equal(expectedPages.Length, pages.Count());
+            for (int i = 0; i < pages.Count; i++)
+                Assert.Same(expectedPages[i], pages.ElementAt(i));
         }
 
         [Fact]
@@ -37,14 +41,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             var provider = CreateInstance(ProjectCapability.Pack);
             var pages = await provider.GetPagesAsync();
 
-            Assert.Equal(pages.Count(), 7);
-            Assert.Same(pages.ElementAt(0), CSharpProjectDesignerPage.Application);
-            Assert.Same(pages.ElementAt(1), CSharpProjectDesignerPage.Build);
-            Assert.Same(pages.ElementAt(2), CSharpProjectDesignerPage.BuildEvents);
-            Assert.Same(pages.ElementAt(3), CSharpProjectDesignerPage.Package);
-            Assert.Same(pages.ElementAt(4), CSharpProjectDesignerPage.Debug);
-            Assert.Same(pages.ElementAt(5), CSharpProjectDesignerPage.ReferencePaths);
-            Assert.Same(pages.ElementAt(6), CSharpProjectDesignerPage.Signing);
+            ProjectDesignerPageMetadata[] expectedPages = new ProjectDesignerPageMetadata[]
+            {
+                CSharpProjectDesignerPage.Application,
+                CSharpProjectDesignerPage.Build,
+                CSharpProjectDesignerPage.BuildEvents,
+                CSharpProjectDesignerPage.Package,
+                CSharpProjectDesignerPage.Debug,
+                CSharpProjectDesignerPage.Signing,
+            };
+
+            Assert.Equal(expectedPages.Length, pages.Count());
+            for (int i = 0; i < pages.Count; i++)
+                Assert.Same(expectedPages[i], pages.ElementAt(i));
         }
 
         private static CSharpProjectDesignerPageProvider CreateInstance(params string[] capabilities)

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Properties/CSharpProjectDesignerPageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Properties/CSharpProjectDesignerPageProvider.cs
@@ -36,10 +36,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             }
 
             builder.Add(CSharpProjectDesignerPage.Debug);
-
-            // Removed until the page is revamped, see: https://github.com/dotnet/roslyn-project-system/issues/1397.
-            // builder.Add(CSharpProjectDesignerPage.ReferencePaths);
-
             builder.Add(CSharpProjectDesignerPage.Signing);
 
             return Task.FromResult<IReadOnlyCollection<IPageMetadata>>(builder.ToImmutable());

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Properties/CSharpProjectDesignerPageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Properties/CSharpProjectDesignerPageProvider.cs
@@ -36,7 +36,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             }
 
             builder.Add(CSharpProjectDesignerPage.Debug);
-            builder.Add(CSharpProjectDesignerPage.ReferencePaths);
+
+            // Removed until the page is revamped, see: https://github.com/dotnet/roslyn-project-system/issues/1397.
+            // builder.Add(CSharpProjectDesignerPage.ReferencePaths);
+
             builder.Add(CSharpProjectDesignerPage.Signing);
 
             return Task.FromResult<IReadOnlyCollection<IPageMetadata>>(builder.ToImmutable());


### PR DESCRIPTION
Customer scenario

Editing values in this page can lead up to broken builds across multiple machines as the paths are saved on the .user file and are hardcoded to the paths in the machine.

Bugs this fixes:
#1071 

Workarounds, if any
 No workarounds, currently the page will always show.

Risk
 Low Risk - This only affects property pages

Performance impact
 Low - This removes the page altogether so there's no initialization for it

Is this a regression from a previous update?
 Not a regression.

Root cause analysis:
 See above.

How was the bug found?
 Dogfooding
