### PR TITLE
Show properties window for shared projects

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Properties/CSharpProjectDesignerPageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Properties/CSharpProjectDesignerPageProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
     ///     Provides project designer property pages.
     /// </summary>
     [Export(typeof(IVsProjectDesignerPageProvider))]
-    [AppliesTo(ProjectCapability.CSharp)]
+    [AppliesTo(ProjectCapability.CSharpAppDesigner)]
     internal class CSharpProjectDesignerPageProvider : IVsProjectDesignerPageProvider
     {
         private readonly IProjectCapabilitiesService _capabilities;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
@@ -10,7 +10,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public const string AlwaysAvailable = ProjectCapabilities.AlwaysApplicable;
         public const string CSharp = ProjectCapabilities.CSharp;
         public const string VisualBasic = ProjectCapabilities.VB;
+        public const string VisualBasicAppDesigner = ProjectCapabilities.VB + " & " + AppDesigner;
         public const string VisualBasicLanguageService = ProjectCapabilities.VB + " & " + ProjectCapabilities.LanguageService;
+        public const string CSharpAppDesigner = ProjectCapabilities.CSharp + " & " + AppDesigner;
         public const string CSharpLanguageService = ProjectCapabilities.CSharp + " & " + ProjectCapabilities.LanguageService;
         public const string CSharpOrVisualBasic = ProjectCapabilities.CSharp + " | " + ProjectCapabilities.VB;
         public const string CSharpOrVisualBasicLanguageService = "(" + ProjectCapabilities.CSharp + " | " + ProjectCapabilities.VB + ") & " + ProjectCapabilities.LanguageService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Properties/VisualBasicProjectDesignerPageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Properties/VisualBasicProjectDesignerPageProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
     ///     Provides project designer property pages.
     /// </summary>
     [Export(typeof(IVsProjectDesignerPageProvider))]
-    [AppliesTo(ProjectCapability.VisualBasic)]
+    [AppliesTo(ProjectCapability.VisualBasicAppDesigner)]
     internal class VisualBasicProjectDesignerPageProvider : IVsProjectDesignerPageProvider
     {
         private readonly IProjectCapabilitiesService _capabilities;


### PR DESCRIPTION
**Customer scenario**
Opening the properties page of a C# or VB Shared Projects, opens the AppDesigner and displays an error.

**Bugs this fixes:**
Fixes: #833
Fixes: #1325

**Workarounds, if any**
You can change properties by opening the Properties Window tool window itself and selecting the Shared Project in Solution Explorer.

**Risk**
Low

**Performance impact**
None

**Is this a regression from a previous update?**
Yes

**Root cause analysis:**
Shared Projects and .NET Core share the same code base. A component was incorrectly marked as applying to all "C#" and "VB" projects, when it really only applied to C#/VB projects that support the Application Designer.

With this change, shared projects revert to their VS 2015 behavior which is to display the Project Properties tool window.

**How was the bug found?**
Customer via VS Feedback.

**Dev Notes**
Show the properties window instead of the AppDesigner for shared projects to be consistent with what we did in VS 2015.

CPS uses the presence of any property pages to decided whether to show AppDesigner or not.