### PR TITLE
Fix for 1406 and 1250, don't allow to remove implicit SDK dependency

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/SdkDependenciesSubTreeProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/SdkDependenciesSubTreeProviderTests.cs
@@ -192,6 +192,35 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             Assert.True(node is SdkDependencyNode);
             Assert.True(node.Flags.Contains(SdkDependenciesSubTreeProvider.SdkSubTreeNodeFlags));
+            Assert.False(node.Flags.Contains(DependencyNode.DoesNotSupportRemove));
+            Assert.Equal(itemSpec, node.Caption);
+            Assert.Equal(KnownMonikers.BrowserSDK, node.Icon);
+            Assert.Equal(SdkDependenciesSubTreeProvider.ProviderTypeString, node.Id.ProviderType);
+            Assert.Equal(DependencyNode.SdkNodePriority, node.Priority);
+            Assert.Equal(1, node.Properties.Count);
+            Assert.Equal("myValue", node.Properties["myproPerty"]);
+        }
+
+        [Fact]
+        public void SdkDependenciesSubTreeProvider_CreateDependencyNode_Implicit()
+        {
+            const string itemSpec = "myItemSpec";
+            const string itemType = "myItemType";
+            const int priority = 15;
+            var properties = new Dictionary<string, string>
+            {
+                { "myproPerty", "myValue" },
+                { SdkReference.SDKPackageItemSpecProperty, "somevalue" }
+            };
+            const bool resolved = true;
+
+            var provider = new TestableSdkDependenciesSubTreeProvider(null);
+
+            var node = provider.TestCreateDependencyNode(itemSpec, itemType, priority, properties, resolved);
+
+            Assert.True(node is SdkDependencyNode);
+            Assert.True(node.Flags.Contains(SdkDependenciesSubTreeProvider.SdkSubTreeNodeFlags));
+            Assert.True(node.Flags.Contains(DependencyNode.DoesNotSupportRemove));
             Assert.Equal(itemSpec, node.Caption);
             Assert.Equal(KnownMonikers.BrowserSDK, node.Icon);
             Assert.Equal(SdkDependenciesSubTreeProvider.ProviderTypeString, node.Id.ProviderType);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/SdkDependenciesSubTreeProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/SdkDependenciesSubTreeProviderTests.cs
@@ -225,8 +225,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(KnownMonikers.BrowserSDK, node.Icon);
             Assert.Equal(SdkDependenciesSubTreeProvider.ProviderTypeString, node.Id.ProviderType);
             Assert.Equal(DependencyNode.SdkNodePriority, node.Priority);
-            Assert.Equal(1, node.Properties.Count);
+            Assert.Equal(2, node.Properties.Count);
             Assert.Equal("myValue", node.Properties["myproPerty"]);
+            Assert.Equal("somevalue", node.Properties[SdkReference.SDKPackageItemSpecProperty]);
         }
 
         private class TestableSdkDependenciesSubTreeProvider : SdkDependenciesSubTreeProvider

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -133,9 +133,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 return false;
             }
 
-            return nodes.All(node => (node.Flags.Contains(DependencyNode.GenericDependencyFlags) 
-                                        && node.BrowseObjectProperties != null)
-                                     || node.Flags.Contains(ProjectTreeFlags.Common.SharedProjectImportReference));
+            return nodes.All(node => (node.Flags.Contains(DependencyNode.GenericDependencyFlags)
+                                        && node.BrowseObjectProperties != null
+                                        && !node.Flags.Contains(DependencyNode.DoesNotSupportRemove)));
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
@@ -67,6 +67,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         public static readonly ProjectTreeFlags CustomItemSpec
                 = ProjectTreeFlags.Create("CustomItemSpec");
 
+        public static readonly ProjectTreeFlags DoesNotSupportRemove
+                = ProjectTreeFlags.Create("DoesNotSupportRemove");
+
         /// <summary>
         /// These set of flags is internal and should be used only by standard known
         /// project item nodes, that come from design time build. This is important,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.xaml
@@ -10,18 +10,18 @@
         <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False"
                     SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
     </Rule.DataSource>
-    <StringProperty Name="AppXLocation" DisplayName="App Package Location" />
+    <StringProperty Name="AppXLocation" DisplayName="App Package Location" ReadOnly="True" />
     <!-- This property should be the same as the one for the ResolvedReference item -->
-    <StringProperty Name="OriginalItemSpec" Visible="false" />
-    <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
-    <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-    <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False"/>
-    <StringProperty Name="Name" DisplayName="Name"/>
-    <StringProperty Name="Version" DisplayName="Version"/>
-    <StringProperty Name="SDKPackageItemSpec" Visible="False"/>
-    <BoolProperty Name="CopyPayload" DisplayName="Copy Payload" />
-    <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />    
-    <BoolProperty Name="ExpandContent" DisplayName="Expand Content" />
-    <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expand Reference Assemblies" />
-    <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copy Local Expanded Reference Assemblies" />
+    <StringProperty Name="OriginalItemSpec" Visible="false" ReadOnly="True" />
+    <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" ReadOnly="True" />
+    <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+    <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" ReadOnly="True" />
+    <StringProperty Name="Name" DisplayName="Name" ReadOnly="True"/>
+    <StringProperty Name="Version" DisplayName="Version" ReadOnly="True"/>
+    <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True"/>
+    <BoolProperty Name="CopyPayload" DisplayName="Copy Payload" ReadOnly="True" />
+    <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" ReadOnly="True" />
+    <BoolProperty Name="ExpandContent" DisplayName="Expand Content" ReadOnly="True" />
+    <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expand Reference Assemblies" ReadOnly="True" />
+    <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copy Local Expanded Reference Assemblies" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml
@@ -10,16 +10,16 @@
         <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False"
                     SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />        
     </Rule.DataSource>
-    <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
-    <StringProperty Name="AppXLocation" DisplayName="App Package Location" />
-    <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-    <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False"/>
-    <StringProperty Name="Name" DisplayName="Name"/>
-    <StringProperty Name="Version" DisplayName="Version"/>
-    <StringProperty Name="SDKPackageItemSpec" Visible="False"/>
-    <BoolProperty Name="CopyPayload" DisplayName="Copy Payload" />
-    <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
-    <BoolProperty Name="ExpandContent" DisplayName="Expand Content" />
-    <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expand Reference Assemblies" />
-    <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copy Local Expanded Reference Assemblies" />
+    <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" ReadOnly="True" />
+    <StringProperty Name="AppXLocation" DisplayName="App Package Location" ReadOnly="True" />
+    <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+    <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" ReadOnly="True" />
+    <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+    <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+    <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+    <BoolProperty Name="CopyPayload" DisplayName="Copy Payload" ReadOnly="True" />
+    <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" ReadOnly="True" />
+    <BoolProperty Name="ExpandContent" DisplayName="Expand Content" ReadOnly="True" />
+    <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expand Reference Assemblies" ReadOnly="True" />
+    <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copy Local Expanded Reference Assemblies" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ResolvedSdkReference.xaml
@@ -4,18 +4,18 @@
   <Rule.DataSource>
     <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="AppXLocation" DisplayName="Umístění balíčku aplikace" />
+  <StringProperty Name="AppXLocation" DisplayName="Umístění balíčku aplikace" ReadOnly="True" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
-  <StringProperty Name="OriginalItemSpec" Visible="false" />
-  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="Zobrazený název" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="Kopírovat datovou část" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
-  <BoolProperty Name="ExpandContent" DisplayName="Rozbalit obsah" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Rozbalit referenční sestavení" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Zkopírovat místní rozbalená referenční sestavení" />
+  <StringProperty Name="OriginalItemSpec" Visible="false" ReadOnly="True" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="Zobrazený název" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="Kopírovat datovou část" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="Rozbalit obsah" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Rozbalit referenční sestavení" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Zkopírovat místní rozbalená referenční sestavení" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/SdkReference.xaml
@@ -4,16 +4,16 @@
   <Rule.DataSource>
     <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="SDKRootFolder" DisplayName="Kořen SDK" />
-  <StringProperty Name="AppXLocation" DisplayName="Umístění balíčku aplikace" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="Kopírovat datovou část" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Kopírovat datovou část do podadresáře" />
-  <BoolProperty Name="ExpandContent" DisplayName="Rozbalit obsah" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Rozbalit referenční sestavení" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Zkopírovat místní rozbalená referenční sestavení" />
+  <StringProperty Name="SDKRootFolder" DisplayName="Kořen SDK" ReadOnly="True" />
+  <StringProperty Name="AppXLocation" DisplayName="Umístění balíčku aplikace" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="Kopírovat datovou část" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Kopírovat datovou část do podadresáře" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="Rozbalit obsah" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Rozbalit referenční sestavení" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Zkopírovat místní rozbalená referenční sestavení" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ResolvedSdkReference.xaml
@@ -4,18 +4,18 @@
   <Rule.DataSource>
     <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="AppXLocation" DisplayName="Speicherort des App-Pakets" />
+  <StringProperty Name="AppXLocation" DisplayName="Speicherort des App-Pakets" ReadOnly="True" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
-  <StringProperty Name="OriginalItemSpec" Visible="false" />
-  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="Anzeigename" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="Nutzlast kopieren" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
-  <BoolProperty Name="ExpandContent" DisplayName="Inhalt erweitern" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Verweisassemblys erweitern" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Lokale erweiterte Verweisassemblys kopieren" />
+  <StringProperty Name="OriginalItemSpec" Visible="false" ReadOnly="True" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="Anzeigename" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="Nutzlast kopieren" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="Inhalt erweitern" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Verweisassemblys erweitern" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Lokale erweiterte Verweisassemblys kopieren" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/SdkReference.xaml
@@ -4,16 +4,16 @@
   <Rule.DataSource>
     <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="SDKRootFolder" DisplayName="SDK-Stamm" />
-  <StringProperty Name="AppXLocation" DisplayName="Speicherort des App-Pakets" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="Nutzlast kopieren" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Nutzlast in Unterverzeichnis kopieren" />
-  <BoolProperty Name="ExpandContent" DisplayName="Inhalt erweitern" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Verweisassemblys erweitern" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Lokale erweiterte Verweisassemblys kopieren" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK-Stamm" ReadOnly="True" />
+  <StringProperty Name="AppXLocation" DisplayName="Speicherort des App-Pakets" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="Nutzlast kopieren" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Nutzlast in Unterverzeichnis kopieren" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="Inhalt erweitern" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Verweisassemblys erweitern" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Lokale erweiterte Verweisassemblys kopieren" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ResolvedSdkReference.xaml
@@ -4,18 +4,18 @@
   <Rule.DataSource>
     <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="AppXLocation" DisplayName="Ubicación del paquete de la aplicación" />
+  <StringProperty Name="AppXLocation" DisplayName="Ubicación del paquete de la aplicación" ReadOnly="True" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
-  <StringProperty Name="OriginalItemSpec" Visible="false" />
-  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="Nombre para mostrar" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="Copiar carga útil" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
-  <BoolProperty Name="ExpandContent" DisplayName="Expandir contenido" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expandir ensamblados de referencia" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copia local de ensamblados de referencia expandidos" />
+  <StringProperty Name="OriginalItemSpec" Visible="false" ReadOnly="True" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="Nombre para mostrar" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="Copiar carga útil" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="Expandir contenido" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expandir ensamblados de referencia" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copia local de ensamblados de referencia expandidos" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/SdkReference.xaml
@@ -4,16 +4,16 @@
   <Rule.DataSource>
     <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="SDKRootFolder" DisplayName="Raíz del SDK" />
-  <StringProperty Name="AppXLocation" DisplayName="Ubicación del paquete de la aplicación" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="Copiar carga útil" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copiar carga útil en el subdirectorio" />
-  <BoolProperty Name="ExpandContent" DisplayName="Expandir contenido" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expandir ensamblados de referencia" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copia local de ensamblados de referencia expandidos" />
+  <StringProperty Name="SDKRootFolder" DisplayName="Raíz del SDK" ReadOnly="True" />
+  <StringProperty Name="AppXLocation" DisplayName="Ubicación del paquete de la aplicación" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="Copiar carga útil" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copiar carga útil en el subdirectorio" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="Expandir contenido" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expandir ensamblados de referencia" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copia local de ensamblados de referencia expandidos" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedSdkReference.xaml
@@ -4,18 +4,18 @@
   <Rule.DataSource>
     <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="AppXLocation" DisplayName="Emplacement du package d'application" />
+  <StringProperty Name="AppXLocation" DisplayName="Emplacement du package d'application" ReadOnly="True" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
-  <StringProperty Name="OriginalItemSpec" Visible="false" />
-  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="Nom complet" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="Copier la charge" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
-  <BoolProperty Name="ExpandContent" DisplayName="Développer le contenu" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Développer les assemblys de référence" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copier les assemblys de référence développés locaux" />
+  <StringProperty Name="OriginalItemSpec" Visible="false" ReadOnly="True" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="Nom complet" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="Copier la charge" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="Développer le contenu" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Développer les assemblys de référence" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copier les assemblys de référence développés locaux" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/SdkReference.xaml
@@ -4,16 +4,16 @@
   <Rule.DataSource>
     <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="SDKRootFolder" DisplayName="Racine du SDK" />
-  <StringProperty Name="AppXLocation" DisplayName="Emplacement du package d'application" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="Copier la charge" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copier la charge dans le sous-répertoire" />
-  <BoolProperty Name="ExpandContent" DisplayName="Développer le contenu" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Développer les assemblys de référence" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copier les assemblys de référence développés locaux" />
+  <StringProperty Name="SDKRootFolder" DisplayName="Racine du SDK" ReadOnly="True" />
+  <StringProperty Name="AppXLocation" DisplayName="Emplacement du package d'application" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="Copier la charge" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copier la charge dans le sous-répertoire" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="Développer le contenu" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Développer les assemblys de référence" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copier les assemblys de référence développés locaux" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedSdkReference.xaml
@@ -4,18 +4,18 @@
   <Rule.DataSource>
     <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="AppXLocation" DisplayName="Percorso pacchetto dell'app" />
+  <StringProperty Name="AppXLocation" DisplayName="Percorso pacchetto dell'app" ReadOnly="True" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
-  <StringProperty Name="OriginalItemSpec" Visible="false" />
-  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="Nome visualizzato" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="Copia payload" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
-  <BoolProperty Name="ExpandContent" DisplayName="Espandi contenuto" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Espandi assembly di riferimento" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copia assembly di riferimento espansi locali" />
+  <StringProperty Name="OriginalItemSpec" Visible="false" ReadOnly="True" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="Nome visualizzato" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="Copia payload" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="Espandi contenuto" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Espandi assembly di riferimento" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copia assembly di riferimento espansi locali" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/SdkReference.xaml
@@ -4,16 +4,16 @@
   <Rule.DataSource>
     <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="SDKRootFolder" DisplayName="Radice SDK" />
-  <StringProperty Name="AppXLocation" DisplayName="Percorso pacchetto dell'app" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="Copia payload" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copia payload nella sottodirectory" />
-  <BoolProperty Name="ExpandContent" DisplayName="Espandi contenuto" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Espandi assembly di riferimento" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copia assembly di riferimento espansi locali" />
+  <StringProperty Name="SDKRootFolder" DisplayName="Radice SDK" ReadOnly="True" />
+  <StringProperty Name="AppXLocation" DisplayName="Percorso pacchetto dell'app" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="Copia payload" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copia payload nella sottodirectory" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="Espandi contenuto" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Espandi assembly di riferimento" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copia assembly di riferimento espansi locali" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ResolvedSdkReference.xaml
@@ -4,18 +4,18 @@
   <Rule.DataSource>
     <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="AppXLocation" DisplayName="アプリ パッケージの場所" />
+  <StringProperty Name="AppXLocation" DisplayName="アプリ パッケージの場所" ReadOnly="True" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
-  <StringProperty Name="OriginalItemSpec" Visible="false" />
-  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="表示名" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="ペイロードのコピー" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
-  <BoolProperty Name="ExpandContent" DisplayName="コンテンツの展開" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="参照アセンブリの展開" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="ローカルに展開された参照アセンブリのコピー" />
+  <StringProperty Name="OriginalItemSpec" Visible="false" ReadOnly="True" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="表示名" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="ペイロードのコピー" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="コンテンツの展開" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="参照アセンブリの展開" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="ローカルに展開された参照アセンブリのコピー" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/SdkReference.xaml
@@ -4,16 +4,16 @@
   <Rule.DataSource>
     <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="SDKRootFolder" DisplayName="SDK ルート" />
-  <StringProperty Name="AppXLocation" DisplayName="アプリ パッケージの場所" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="ペイロードのコピー" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="サブディレクトリへのペイロードのコピー" />
-  <BoolProperty Name="ExpandContent" DisplayName="コンテンツの展開" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="参照アセンブリの展開" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="ローカルに展開された参照アセンブリのコピー" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK ルート" ReadOnly="True" />
+  <StringProperty Name="AppXLocation" DisplayName="アプリ パッケージの場所" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="ペイロードのコピー" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="サブディレクトリへのペイロードのコピー" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="コンテンツの展開" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="参照アセンブリの展開" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="ローカルに展開された参照アセンブリのコピー" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ResolvedSdkReference.xaml
@@ -4,18 +4,18 @@
   <Rule.DataSource>
     <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="AppXLocation" DisplayName="앱 패키지 위치" />
+  <StringProperty Name="AppXLocation" DisplayName="앱 패키지 위치" ReadOnly="True" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
-  <StringProperty Name="OriginalItemSpec" Visible="false" />
-  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="표시 이름" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="페이로드 복사" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
-  <BoolProperty Name="ExpandContent" DisplayName="콘텐츠 확장" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="참조 어셈블리 확장" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="확장된 로컬 참조 어셈블리 복사" />
+  <StringProperty Name="OriginalItemSpec" Visible="false" ReadOnly="True" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="표시 이름" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="페이로드 복사" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="콘텐츠 확장" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="참조 어셈블리 확장" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="확장된 로컬 참조 어셈블리 복사" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/SdkReference.xaml
@@ -4,16 +4,16 @@
   <Rule.DataSource>
     <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="SDKRootFolder" DisplayName="SDK 루트" />
-  <StringProperty Name="AppXLocation" DisplayName="앱 패키지 위치" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="페이로드 복사" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="하위 디렉터리에 페이로드 복사" />
-  <BoolProperty Name="ExpandContent" DisplayName="콘텐츠 확장" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="참조 어셈블리 확장" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="확장된 로컬 참조 어셈블리 복사" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK 루트" ReadOnly="True" />
+  <StringProperty Name="AppXLocation" DisplayName="앱 패키지 위치" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="페이로드 복사" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="하위 디렉터리에 페이로드 복사" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="콘텐츠 확장" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="참조 어셈블리 확장" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="확장된 로컬 참조 어셈블리 복사" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ResolvedSdkReference.xaml
@@ -4,18 +4,18 @@
   <Rule.DataSource>
     <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="AppXLocation" DisplayName="Lokalizacja pakietu aplikacji" />
+  <StringProperty Name="AppXLocation" DisplayName="Lokalizacja pakietu aplikacji" ReadOnly="True" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
-  <StringProperty Name="OriginalItemSpec" Visible="false" />
-  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="Wyświetl nazwę" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="Kopiuj ładunek" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
-  <BoolProperty Name="ExpandContent" DisplayName="Rozwiń zawartość" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Rozwiń zestawy odwołań" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Kopiuj lokalne rozwinięte zestawy referencyjne" />
+  <StringProperty Name="OriginalItemSpec" Visible="false" ReadOnly="True" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="Wyświetl nazwę" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="Kopiuj ładunek" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="Rozwiń zawartość" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Rozwiń zestawy odwołań" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Kopiuj lokalne rozwinięte zestawy referencyjne" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/SdkReference.xaml
@@ -4,16 +4,16 @@
   <Rule.DataSource>
     <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="SDKRootFolder" DisplayName="Główny zestaw SDK" />
-  <StringProperty Name="AppXLocation" DisplayName="Lokalizacja pakietu aplikacji" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="Kopiuj ładunek" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Kopiuj ładunek do podkatalogu" />
-  <BoolProperty Name="ExpandContent" DisplayName="Rozwiń zawartość" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Rozwiń zestawy odwołań" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Kopiuj lokalne rozwinięte zestawy referencyjne" />
+  <StringProperty Name="SDKRootFolder" DisplayName="Główny zestaw SDK" ReadOnly="True" />
+  <StringProperty Name="AppXLocation" DisplayName="Lokalizacja pakietu aplikacji" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="Kopiuj ładunek" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Kopiuj ładunek do podkatalogu" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="Rozwiń zawartość" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Rozwiń zestawy odwołań" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Kopiuj lokalne rozwinięte zestawy referencyjne" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ResolvedSdkReference.xaml
@@ -4,18 +4,18 @@
   <Rule.DataSource>
     <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="AppXLocation" DisplayName="Local do Pacote do Aplicativo" />
+  <StringProperty Name="AppXLocation" DisplayName="Local do Pacote do Aplicativo" ReadOnly="True" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
-  <StringProperty Name="OriginalItemSpec" Visible="false" />
-  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="Nome de Exibição" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="Copiar Conteúdo" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
-  <BoolProperty Name="ExpandContent" DisplayName="Expandir Conteúdo" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expandir Assemblies de Referência" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Assemblies de Referência Expandidos do Local da Cópia" />
+  <StringProperty Name="OriginalItemSpec" Visible="false" ReadOnly="True" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="Nome de Exibição" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="Copiar Conteúdo" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="Expandir Conteúdo" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expandir Assemblies de Referência" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Assemblies de Referência Expandidos do Local da Cópia" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/SdkReference.xaml
@@ -4,16 +4,16 @@
   <Rule.DataSource>
     <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="SDKRootFolder" DisplayName="Raiz do SDK" />
-  <StringProperty Name="AppXLocation" DisplayName="Local do Pacote do Aplicativo" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="Copiar Conteúdo" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copiar Conteúdo para o Subdiretório" />
-  <BoolProperty Name="ExpandContent" DisplayName="Expandir Conteúdo" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expandir Assemblies de Referência" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Assemblies de Referência Expandidos do Local da Cópia" />
+  <StringProperty Name="SDKRootFolder" DisplayName="Raiz do SDK" ReadOnly="True" />
+  <StringProperty Name="AppXLocation" DisplayName="Local do Pacote do Aplicativo" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="Copiar Conteúdo" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copiar Conteúdo para o Subdiretório" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="Expandir Conteúdo" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expandir Assemblies de Referência" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Assemblies de Referência Expandidos do Local da Cópia" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ResolvedSdkReference.xaml
@@ -4,18 +4,18 @@
   <Rule.DataSource>
     <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="AppXLocation" DisplayName="Расположение пакета приложения" />
+  <StringProperty Name="AppXLocation" DisplayName="Расположение пакета приложения" ReadOnly="True" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
-  <StringProperty Name="OriginalItemSpec" Visible="false" />
-  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="Отображаемое имя" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
+  <StringProperty Name="OriginalItemSpec" Visible="false" ReadOnly="True" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="Отображаемое имя" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
   <BoolProperty Name="CopyPayload" DisplayName="Копировать полезные данные" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
-  <BoolProperty Name="ExpandContent" DisplayName="Расширить содержимое" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Расширить эталонные сборки" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Копировать локальные расширенные ссылочные сборки" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Копировать полезные данные в подкаталог" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="Расширить содержимое" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Расширить эталонные сборки" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Копировать локальные расширенные ссылочные сборки" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/SdkReference.xaml
@@ -4,16 +4,16 @@
   <Rule.DataSource>
     <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="SDKRootFolder" DisplayName="Корень пакета SDK" />
-  <StringProperty Name="AppXLocation" DisplayName="Расположение пакета приложения" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="Копировать полезные данные" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Копировать полезные данные в подкаталог" />
-  <BoolProperty Name="ExpandContent" DisplayName="Расширить содержимое" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Расширить эталонные сборки" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Копировать локальные расширенные ссылочные сборки" />
+  <StringProperty Name="SDKRootFolder" DisplayName="Корень пакета SDK" ReadOnly="True" />
+  <StringProperty Name="AppXLocation" DisplayName="Расположение пакета приложения" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="Копировать полезные данные" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Копировать полезные данные в подкаталог" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="Расширить содержимое" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Расширить эталонные сборки" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Копировать локальные расширенные ссылочные сборки" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ResolvedSdkReference.xaml
@@ -4,18 +4,18 @@
   <Rule.DataSource>
     <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="AppXLocation" DisplayName="Uygulama Paketi Konumu" />
+  <StringProperty Name="AppXLocation" DisplayName="Uygulama Paketi Konumu" ReadOnly="True" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
-  <StringProperty Name="OriginalItemSpec" Visible="false" />
-  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="Görünen Ad" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="Yükü Kopyala" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
-  <BoolProperty Name="ExpandContent" DisplayName="İçeriği Genişlet" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Başvuru Bütünleştirilmiş Kodlarını Genişlet" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Yerel Genişletilmiş Başvuru Derlemelerini Kopyala" />
+  <StringProperty Name="OriginalItemSpec" Visible="false" ReadOnly="True" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="Görünen Ad" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="Yükü Kopyala" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="İçeriği Genişlet" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Başvuru Bütünleştirilmiş Kodlarını Genişlet" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Yerel Genişletilmiş Başvuru Derlemelerini Kopyala" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/SdkReference.xaml
@@ -4,16 +4,16 @@
   <Rule.DataSource>
     <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="SDKRootFolder" DisplayName="SDK Kökü" />
-  <StringProperty Name="AppXLocation" DisplayName="Uygulama Paketi Konumu" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="Yükü Kopyala" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Yükü Alt Dizine Kopyala" />
-  <BoolProperty Name="ExpandContent" DisplayName="İçeriği Genişlet" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Başvuru Bütünleştirilmiş Kodlarını Genişlet" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Yerel Genişletilmiş Başvuru Derlemelerini Kopyala" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Kökü" ReadOnly="True" />
+  <StringProperty Name="AppXLocation" DisplayName="Uygulama Paketi Konumu" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="Yükü Kopyala" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Yükü Alt Dizine Kopyala" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="İçeriği Genişlet" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Başvuru Bütünleştirilmiş Kodlarını Genişlet" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Yerel Genişletilmiş Başvuru Derlemelerini Kopyala" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ResolvedSdkReference.xaml
@@ -4,18 +4,18 @@
   <Rule.DataSource>
     <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="AppXLocation" DisplayName="应用包位置" />
+  <StringProperty Name="AppXLocation" DisplayName="应用包位置" ReadOnly="True" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
-  <StringProperty Name="OriginalItemSpec" Visible="false" />
-  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="显示名称" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="复制负载" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
-  <BoolProperty Name="ExpandContent" DisplayName="扩展内容" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="扩展引用程序集" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="复制本地扩展的引用程序集" />
+  <StringProperty Name="OriginalItemSpec" Visible="false" ReadOnly="True" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="显示名称" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="复制负载" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="扩展内容" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="扩展引用程序集" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="复制本地扩展的引用程序集" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/SdkReference.xaml
@@ -4,16 +4,16 @@
   <Rule.DataSource>
     <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="SDKRootFolder" DisplayName="SDK 根" />
-  <StringProperty Name="AppXLocation" DisplayName="应用包位置" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="复制负载" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="将负载复制到子目录" />
-  <BoolProperty Name="ExpandContent" DisplayName="扩展内容" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="扩展引用程序集" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="复制本地扩展的引用程序集" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK 根" ReadOnly="True" />
+  <StringProperty Name="AppXLocation" DisplayName="应用包位置" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="复制负载" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="将负载复制到子目录" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="扩展内容" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="扩展引用程序集" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="复制本地扩展的引用程序集" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ResolvedSdkReference.xaml
@@ -4,18 +4,18 @@
   <Rule.DataSource>
     <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="AppXLocation" DisplayName="應用程式套件位置" />
+  <StringProperty Name="AppXLocation" DisplayName="應用程式套件位置" ReadOnly="True" />
   <!-- This property should be the same as the one for the ResolvedReference item -->
-  <StringProperty Name="OriginalItemSpec" Visible="false" />
-  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="顯示名稱" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="複製承載" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" />
-  <BoolProperty Name="ExpandContent" DisplayName="展開內容" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="展開參考組件" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="複製展開的參考組件到本機" />
+  <StringProperty Name="OriginalItemSpec" Visible="false" ReadOnly="True" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="顯示名稱" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="複製承載" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="展開內容" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="展開參考組件" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="複製展開的參考組件到本機" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/SdkReference.xaml
@@ -4,16 +4,16 @@
   <Rule.DataSource>
     <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False" SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="SDKRootFolder" DisplayName="SDK 根" />
-  <StringProperty Name="AppXLocation" DisplayName="應用程式套件位置" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" />
-  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" />
-  <StringProperty Name="Name" DisplayName="Name" />
-  <StringProperty Name="Version" DisplayName="Version" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" />
-  <BoolProperty Name="CopyPayload" DisplayName="複製承載" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="複製承載到子目錄" />
-  <BoolProperty Name="ExpandContent" DisplayName="展開內容" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="展開參考組件" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="複製展開的參考組件到本機" />
+  <StringProperty Name="SDKRootFolder" DisplayName="SDK 根" ReadOnly="True" />
+  <StringProperty Name="AppXLocation" DisplayName="應用程式套件位置" ReadOnly="True" />
+  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
+  <StringProperty Name="DisplayName" DisplayName="Display Name" Visible="False" ReadOnly="True" />
+  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
+  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
+  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="CopyPayload" DisplayName="複製承載" ReadOnly="True" />
+  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="複製承載到子目錄" ReadOnly="True" />
+  <BoolProperty Name="ExpandContent" DisplayName="展開內容" ReadOnly="True" />
+  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="展開參考組件" ReadOnly="True" />
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="複製展開的參考組件到本機" ReadOnly="True" />
 </Rule>


### PR DESCRIPTION
**Customer scenario**

When user right clicks on implicit SDK or (former package) reference there is error saying that its not possible to remove it. Also if they try to set some properties, that leads to an error as well.

**Bugs this fixes:**

Fixes #1406 Fixes #1412 
https://github.com/dotnet/roslyn-project-system/issues/1250

**Workarounds, if any**

No

**Risk**

Minimal

**Performance impact**

None

**Is this a regression from a previous update?**

No