### PR TITLE
Correctly manage editor dirty state after refresh

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Editor/TempFileTextBufferManagerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Editor/TempFileTextBufferManagerTests.cs
@@ -228,6 +228,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
             await textBufferManager.ResetBufferAsync();
             Mock.Get(textBuffer).Verify(t => t.Replace(It.IsAny<Span>(), xml), Times.Once);
             Assert.Equal("<Project />", fileSystem.ReadAllText(tempProjectPath));
+            Mock.Get(unconfiguredProject).Verify(u => u.SaveAsync(null), Times.Once);
         }
 
         [Fact]
@@ -272,6 +273,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
             await textBufferManager.ResetBufferAsync();
             Mock.Get(textBuffer).Verify(t => t.Replace(It.IsAny<Span>(), It.IsAny<string>()), Times.Never);
             Assert.Equal("<Project></Project>", fileSystem.ReadAllText(tempProjectPath));
+            Mock.Get(unconfiguredProject).Verify(u => u.SaveAsync(null), Times.Once);
         }
 
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/ProjectFileEditorPresenter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/ProjectFileEditorPresenter.cs
@@ -4,7 +4,6 @@ using System;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.VS.UI;
-using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;


### PR DESCRIPTION
Tagging @davkean @dotnet/project-system for review. This fixes a bug in how we were resetting state flags when updating the buffer in place, ensures that undo is correctly handled by saving the file on disk, and saves the project file an extra time to ensure we don't race if saving dirty changes on project close.

**Customer scenario**

If the user makes a change programmatically (such as changing a property page setting) with the project file editor open, and then presses undo from inside the project file editor, the editor is not considered dirty and does not prompt to save changes if the project is unloaded causing data loss.

**Bugs this fixes:**

Fixes https://github.com/dotnet/roslyn-project-system/issues/1401.

**Workarounds, if any**

The user can manually save the file, or not undo the change from the editor. Both of these are bad, as the user has no way of knowing they need to do this.

**Risk**

Should be low. When we save the temp file to disk after updating, the main state machine is in the `BufferUpdateScheduled` state, which causes any future update or main file overwrite attempts to bail out immediately. Additionally, saving the main project file again will shield us from a race that was hidden by the state flags bug that this commit also fixes.

**Performance impact**

Should be relatively low. We have a couple of new disk operations that we didn't do in the past, but they should be very quick and shouldn't cause any downstream computation to occur.

**Is this a regression from a previous update?**

Yes.

**Root cause analysis:**

When we moved to the state machine implementation, there was a misunderstanding of what the `ITextDocument` state flags controlled. I did not realize they controlled the dirty state of the document as well as whether the document was readonly.

**How was the bug found?**

Ad hoc testing.