### PR TITLE
Prevent deadlock when the project file has conditioned TargetFramewor…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -171,6 +171,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                         return _currentAggregateProjectContext;
                     }
 
+                    // Check if the current project context is up-to-date for the current active and known project configurations.
+                    var activeProjectConfiguration = _commonServices.ActiveConfiguredProject.ProjectConfiguration;
+                    var knownProjectConfigurations = await _commonServices.Project.Services.ProjectConfigurationsService.GetKnownProjectConfigurationsAsync().ConfigureAwait(false);
+                    if (knownProjectConfigurations.All(c => c.IsCrossTargeting()) &&
+                        _currentAggregateProjectContext.HasMatchingTargetFrameworks(activeProjectConfiguration, knownProjectConfigurations))
+                    {
+                        return _currentAggregateProjectContext;
+                    }
+
                     previousContextToDispose = _currentAggregateProjectContext;
                 }
 


### PR DESCRIPTION
…ks property

**Customer scenario**

User creates an SDK based project that has conditioned TargetFrameworks property, for example:

```
    <TargetFrameworks>netcoreapp1.0</TargetFrameworks>
    <TargetFrameworks Condition="'$(OS)'=='Windows_NT'">$(TargetFrameworks);net451</TargetFrameworks>
```
As soon as the project is opened in VS, we enter an infinite computation in the language service, which constantly allocates memory with a UI hang, until we throw an OOM.

**Bugs this fixes:**

Fixes #1431

**Workarounds, if any**

Do not use conditioned TargetFrameworks property.

**Risk**

Low. We now do a simple additional check that current aggregate workspace project context is up-to-date with the active and known project configurations, and if so avoid re-computing the context. 

**Performance impact**

Low. The added code should only execute when TargetFrameworks changes, or is first initialized and should be cheap.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

We currently don't support conditioned TargetFrameworks property, due to a restriction of CPS/MSBuild that a project evaluation cannot be done at an unconfigured project level. However, we should not deadlock VS and OOM when such a project file is opened. This fix ensures that we avoid infinite workspace project context computation when evaluated TargetFrameworks doesn't match the known project configurations.

**How was the bug found?**

Customer reported.