### PR TITLE
Process command line items (references/sources) even from failed desi…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
@@ -53,8 +53,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             if (!ProcessDesignTimeBuildFailure(projectChange, context))
             {
                 ProcessOptions(projectChange, context);
-                ProcessItems(projectChange, context, isActiveContext);
             }
+
+            // We need to process items even from failed design time builds, as we might be removing some items.
+            ProcessItems(projectChange, context, isActiveContext);
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
…gn time builds.

**Customer scenario**

User sees following type of intellisense errors and squiggles when switching target framework and basic intellisense is broken.

```
Severity	Code	Description	Project	File	Line	Suppression State
Error	CS0518	Predefined type 'System.Object' is not defined or imported	ClassLibrary3	c:\users\mavasani\documents\visual studio 2017\Projects\ClassLibrary3\ClassLibrary3\Class1.cs	5	Active
Error	CS1729	'object' does not contain a constructor that takes 0 arguments	ClassLibrary3	c:\users\mavasani\documents\visual studio 2017\Projects\ClassLibrary3\ClassLibrary3\Class1.cs	5	Active
```

**Bugs this fixes:**

Fixes #1445.

**Workarounds, if any**

User has to do a full reload of the project.

**Risk**

Low. The new code path will get executed for failed design time builds with only removed items, and this is unlikely to cause more issues as we should have a subsequent design time build update that adds the new items.

**Performance impact**

Low.

**Is this a regression from a previous update?**

Yes, this seemed to have shown up recently, most likely due to some CPS change in the way it generates design time build updates (a single update with added and removed items versus multiple updates with separate added and removed items).

**Root cause analysis:**

Currently, our LanguageService ignores any options/items from failed design time builds. However, when we change target framework for the project, sometimes we end up with couple of design time build updates from CPS. First one removes all items and options for the old framework, and the second one adds them for the new framework. If we ignore the first update, then we end up with references and sources files from both the target frameworks and this leads to compiler errors.

**How was the bug found?**

Dogfooding.