### PR TITLE
Fix for 1449: mute data sources versions, since we still getting mismatches

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -348,9 +348,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
                     ProjectContextChanged?.Invoke(this, new ProjectContextEventArgs(this));
 
+                    // TODO We still are getting mismatched data sources and need to figure out better 
+                    // way of merging, mute them for now and get to it in U1
                     return Task.FromResult(new TreeUpdateResult(dependenciesNode, 
                                                                 false, 
-                                                                GetMergedDataSourceVersions(e)));
+                                                                null /*GetMergedDataSourceVersions(e)*/));
                 });
         }
 


### PR DESCRIPTION
**Customer scenario**

Error dialog complaining about mismatched data sources versions in the tree pops up at random points in time.

**Bugs this fixes:**

https://github.com/dotnet/roslyn-project-system/issues/1449

**Workarounds, if any**


**Risk**

No one listens for Dependnecies tree updates and we can send null for data sources version for RTM. 

**Performance impact**

none
