### PR TITLE
Output type property fixes

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
@@ -1347,11 +1347,11 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         '
         '  Application Type      -> Output Type
         '  ---------------------    -----------
-        '  Windows Application   -> winexe
-        '  Windows Class Library -> library
+        '  Windows Application   -> WinExe
+        '  Windows Class Library -> Library
         '  Console Application   -> exe
-        '  Windows Service       -> winexe
-        '  Web Control Library   -> library
+        '  Windows Service       -> WinExe
+        '  Web Control Library   -> Library
         '
 
         '

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
@@ -499,9 +499,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         '
         '  Application Type      -> Output Type
         '  ---------------------    -----------
-        '  Windows Application   -> winexe
-        '  Windows Class Library -> library
-        '  Console Application   -> exe
+        '  Windows Application   -> WinExe
+        '  Windows Class Library -> Library
+        '  Console Application   -> Exe
         '
 
         ''' <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/OutputTypeEnumProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/OutputTypeEnumProviderTests.cs
@@ -29,11 +29,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         }
 
         [Theory]
-        [InlineData("winexe", "0")]
-        [InlineData("exe", "1")]
-        [InlineData("library", "2")]
-        [InlineData("appcontainerexe", "1")]
-        [InlineData("winmdobj", "2")]
+        [InlineData("WinExe", "0")]
+        [InlineData("Exe", "1")]
+        [InlineData("Library", "2")]
+        [InlineData("AppContainerExe", "1")]
+        [InlineData("WinMDObj", "2")]
         public async Task TryCreateEnumValue(string input, string expected)
         {
             var provider = new OutputTypeEnumProvider();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/OutputTypeExValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/OutputTypeExValueProviderTests.cs
@@ -16,18 +16,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             {
                 yield return new object[]
                 {
-                    new PageEnumValue(new EnumValue { Name = "exe", DisplayName = "1" }),
+                    new PageEnumValue(new EnumValue { Name = "Exe", DisplayName = "1" }),
                     "1"
                 };
             }
         }
 
         [Theory]
-        [InlineData("WINEXE", "0")]
-        [InlineData("EXE", "1")]
-        [InlineData("LIBRARY", "2")]
-        [InlineData("WINMDOBJ", "3")]
-        [InlineData("APPCONTAINEREXE", "4")]
+        [InlineData("WinExe", "0")]
+        [InlineData("Exe", "1")]
+        [InlineData("Library", "2")]
+        [InlineData("WinMDObj", "3")]
+        [InlineData("AppContainerExe", "4")]
         [InlineData("InvalidValue", null)]
         [MemberData("ExeEnumValue", "1")]
         public async void GetEvaluatedValue(object propertyValue, string expectedPropertyValue)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/OutputTypeExValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/OutputTypeExValueProviderTests.cs
@@ -54,8 +54,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
                 UnconfiguredProjectFactory.Create(),
                 new PropertyPageData()
                 {
-                    Category = ConfigurationGeneral.SchemaName,
-                    PropertyName = ConfigurationGeneral.OutputTypeProperty,
+                    Category = ConfigurationGeneralBrowseObject.SchemaName,
+                    PropertyName = ConfigurationGeneralBrowseObject.OutputTypeProperty,
                     Value = "InitialValue"
                 });
             var provider = new OutputTypeExValueProvider(properties);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/OutputTypeExValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/OutputTypeExValueProviderTests.cs
@@ -60,8 +60,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
                 });
             var provider = new OutputTypeExValueProvider(properties);
 
-            var actualPropertyValue = await provider.OnSetPropertyValueAsync(propertyValue, null);
-            Assert.Equal(propertyValue, actualPropertyValue);
+            var outputTypeExValue = await provider.OnSetPropertyValueAsync(propertyValue, null);
+            Assert.Equal(null, outputTypeExValue);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/OutputTypeExValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/OutputTypeExValueProvider.cs
@@ -36,25 +36,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
             if (outputType != null)
             {
-                switch (outputType.ToLowerInvariant())
+                switch (outputType)
                 {
-                    case "winexe":
+                    case "WinExe":
                         // prjOutputTypeEx_WinExe
                         value = "0";
                         break;
-                    case "exe":
+                    case "Exe":
                         // prjOutputTypeEx_Exe
                         value = "1";
                         break;
-                    case "library":
+                    case "Library":
                         // prjOutputTypeEx_Library
                         value = "2";
                         break;
-                    case "winmdobj":
+                    case "WinMDObj":
                         // prjOutputTypeEx_WinMDObj
                         value = "3";
                         break;
-                    case "appcontainerexe":
+                    case "AppContainerExe":
                         // prjOutputTypeEx_AppContainerExe
                         value = "4";
                         break;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/OutputTypeExValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/OutputTypeExValueProvider.cs
@@ -66,9 +66,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
         public override async Task<string> OnSetPropertyValueAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string> dimensionalConditions = null)
         {
+            // Set the value of OutputType
             var configuration = await _properties.GetConfigurationGeneralBrowseObjectPropertiesAsync().ConfigureAwait(true);
             await configuration.OutputType.SetValueAsync(unevaluatedPropertyValue).ConfigureAwait(false);
-            return unevaluatedPropertyValue;
+
+            // return null so that OutputTypeEx is not written to the project
+            return null;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/OutputTypeExValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/OutputTypeExValueProvider.cs
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
         public override async Task<string> OnSetPropertyValueAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string> dimensionalConditions = null)
         {
-            var configuration = await _properties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(true);
+            var configuration = await _properties.GetConfigurationGeneralBrowseObjectPropertiesAsync().ConfigureAwait(true);
             await configuration.OutputType.SetValueAsync(unevaluatedPropertyValue).ConfigureAwait(false);
             return unevaluatedPropertyValue;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/OutputTypeEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/OutputTypeEnumProvider.cs
@@ -24,15 +24,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         {
             private readonly Dictionary<string, IEnumValue> _listedOutputTypeValues = new Dictionary<string, IEnumValue>
             {
-                { "winexe",          new PageEnumValue(new EnumValue {Name = "winexe",  DisplayName = "0" }) },
-                { "exe",             new PageEnumValue(new EnumValue {Name = "exe",     DisplayName = "1" }) },
-                { "library",         new PageEnumValue(new EnumValue {Name = "library", DisplayName = "2" }) },
+                { "WinExe",          new PageEnumValue(new EnumValue {Name = "WinExe",  DisplayName = "0" }) },
+                { "Exe",             new PageEnumValue(new EnumValue {Name = "Exe",     DisplayName = "1" }) },
+                { "Library",         new PageEnumValue(new EnumValue {Name = "Library", DisplayName = "2" }) },
             };
 
             private readonly Dictionary<string, IEnumValue> _mappedOutputTypeValues = new Dictionary<string, IEnumValue>
             {
-                { "winmdobj",        new PageEnumValue(new EnumValue {Name = "library", DisplayName = "2" }) },
-                { "appcontainerexe", new PageEnumValue(new EnumValue {Name = "exe",     DisplayName = "1" }) }
+                { "WinMDObj",        new PageEnumValue(new EnumValue {Name = "Library", DisplayName = "2" }) },
+                { "AppContainerExe", new PageEnumValue(new EnumValue {Name = "Exe",     DisplayName = "1" }) }
             };
 
             public bool AllowCustomValues => false;
@@ -46,13 +46,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             public Task<IEnumValue> TryCreateEnumValueAsync(string userSuppliedValue)
             {
-                string lowercasedValue = userSuppliedValue.ToLowerInvariant();
-                if (_listedOutputTypeValues.TryGetValue(lowercasedValue, out IEnumValue value))
+                if (_listedOutputTypeValues.TryGetValue(userSuppliedValue, out IEnumValue value))
                 {
                     return Task.FromResult(value);
                 }
 
-                if (_mappedOutputTypeValues.TryGetValue(lowercasedValue, out value))
+                if (_mappedOutputTypeValues.TryGetValue(userSuppliedValue, out value))
                 {
                     return Task.FromResult(value);
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -65,8 +65,8 @@
     <StringProperty Name="BaseIntermediateOutputPath" />
     <EnumProperty Name="OutputType">
         <EnumValue Name="Library" DisplayName="Class Library" />
-        <EnumValue Name="exe" DisplayName="Console Application" />
-        <EnumValue Name="winexe" DisplayName="Windows Application" />
+        <EnumValue Name="Exe" DisplayName="Console Application" />
+        <EnumValue Name="WinExe" DisplayName="Windows Application" />
         <EnumValue Name="AppContainerExe" DisplayName="Windows Store app" />
         <EnumValue Name="WinMDObj" DisplayName="WinMD" />
     </EnumProperty>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -43,11 +43,11 @@
   <StringProperty Name="OutputName" Visible="True" />
   <DynamicEnumProperty Name="OutputType" DisplayName="Output Type" EnumProvider="OutputTypeEnumProvider" Visible="True"/>
   <EnumProperty Name="OutputTypeEx" DisplayName="Output Type" Visible="True">
-    <EnumValue Name="winexe" DisplayName="0" />
-    <EnumValue Name="exe" DisplayName="1" />
-    <EnumValue Name="library" DisplayName="2" />
-    <EnumValue Name="appcontainerexe" DisplayName="3" />
-    <EnumValue Name="winmdobj" DisplayName="4" />
+    <EnumValue Name="WinExe" DisplayName="0" />
+    <EnumValue Name="Exe" DisplayName="1" />
+    <EnumValue Name="Library" DisplayName="2" />
+    <EnumValue Name="AppContainerExe" DisplayName="3" />
+    <EnumValue Name="WinMDObj" DisplayName="4" />
     <EnumProperty.DataSource>
       <DataSource Persistence="ProjectFileWithInterception" PersistedName="OutputTypeEx" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
     </EnumProperty.DataSource>


### PR DESCRIPTION
Fixes the following issues:
#1298 - Return null on OutputTypeEx SetValue so that the value is not propagated to the project
#1299 - Change all references of case insensitive values for OutputType to be case sensitive
#1300 - Use the correct object for the project property on Set so that it's not written as config specific