### PR TITLE
Make IDependencyNode.Children immutable;Add other breaking changes for IDependencyNode public API

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Mocks\IDteServicesFactory.cs" />
     <Compile Include="Mocks\ExportFactoryFactory.cs" />
     <Compile Include="Mocks\INuGetPackagesDataProviderFactory.cs" />
+    <Compile Include="Mocks\IDependenciesChangeDiffFactory.cs" />
     <Compile Include="Mocks\IVsHiearchyItemFactory.cs" />
     <Compile Include="Mocks\IProjectFileEditorPresenterFactory.cs" />
     <Compile Include="Mocks\IFrameOpenCloseListenerFactory.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesChangeDiffFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesChangeDiffFactory.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Moq;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    internal static class IDependenciesChangeDiffFactory
+    {
+        public static IDependenciesChangeDiff Create()
+        {
+            return Mock.Of<IDependenciesChangeDiff>();
+        }
+
+        public static IDependenciesChangeDiff Implement(IEnumerable<IDependencyNode> addedItems = null,
+                                                   IEnumerable<IDependencyNode> changedItems = null,
+                                                   IEnumerable<IDependencyNode> removedItems = null,
+                                                   MockBehavior? mockBehavior = null)
+        {
+            var behavior = mockBehavior ?? MockBehavior.Default;
+            var mock = new Mock<IDependenciesChangeDiff>(behavior);
+
+            if (addedItems != null)
+            {
+                mock.Setup(x => x.AddedNodes).Returns(addedItems.ToImmutableList());
+            }
+
+            if (changedItems != null)
+            {
+                mock.Setup(x => x.UpdatedNodes).Returns(changedItems.ToImmutableList());
+            }
+
+            if (removedItems != null)
+            {
+                mock.Setup(x => x.RemovedNodes).Returns(removedItems.ToImmutableList());
+            }
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyNodeFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyNodeFactory.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
 using Moq;
 using Newtonsoft.Json.Linq;
@@ -22,7 +24,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             if (children != null)
             {
-                mock.Setup(x => x.Children).Returns(new HashSet<IDependencyNode>(children));
+                var builder = ImmutableHashSet.CreateBuilder<IDependencyNode>();
+                children.ToList().ForEach(x => builder.Add(x));
+
+                mock.Setup(x => x.Children).Returns(builder.ToImmutableHashSet());
             }
 
             return mock.Object;
@@ -38,7 +43,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             {
                 var json = JObject.Parse(childrenJson);
                 var children = json.ToObject<DependenciesNodeCollection>();
-                mock.Setup(x => x.Children).Returns(new HashSet<IDependencyNode>(children.Nodes));
+                var builder = ImmutableHashSet.CreateBuilder<IDependencyNode>();
+                children.Nodes.ToList().ForEach(x => builder.Add(x));
+                mock.Setup(x => x.Children).Returns(builder.ToImmutableHashSet());
             }
 
             return mock.Object;
@@ -56,7 +63,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             if (flags != null && flags.HasValue)
             {
-                data.Flags = data.Flags.Union(flags.Value);
+                ((DependencyNode)data).Flags = data.Flags.Union(flags.Value);
             }
             return data;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/INuGetPackagesDataProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/INuGetPackagesDataProviderFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
 using Moq;
@@ -23,7 +24,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             var mock = new Mock<INuGetPackagesDataProvider>(behavior);
             mock.Setup(x => x.UpdateNodeChildren(itemSpec, node));
 
-            node.Children.AddRange(childrenToAdd);
+            childrenToAdd.ToList().ForEach(x => node.AddChild(x));
+
             return mock.Object;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProviderTests.cs
@@ -23,8 +23,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var projectPath = @"c:\myproject\project.csproj";
             var nodeIdString = @"file:///[MyProvider;MyNodeItemSpec]";
             var mockVsHierarchyItem = IVsHierarchyItemFactory.ImplementProperties(text: "MyNodeItemSpec");
-            var inputNode = IGraphContextFactory.CreateNode(projectPath, 
-                                                            nodeIdString, 
+            var inputNode = IGraphContextFactory.CreateNode(projectPath,
+                                                            nodeIdString,
                                                             hierarchyItem: mockVsHierarchyItem);
             var rootNode = IDependencyNodeFactory.FromJson(@"
 {
@@ -178,8 +178,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var nodeIdString = @"file:///[MyProvider;MyNodeItemSpec]";
 
             var mockVsHierarchyItem = IVsHierarchyItemFactory.ImplementProperties(text: "MyNodeItemSpec");
-            var inputNode = IGraphContextFactory.CreateNode(projectPath, 
-                                                            nodeIdString, 
+            var inputNode = IGraphContextFactory.CreateNode(projectPath,
+                                                            nodeIdString,
                                                             hierarchyItem: mockVsHierarchyItem);
             var rootNode = IDependencyNodeFactory.FromJson(@"
 {
@@ -351,9 +351,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             existingNode.AddChild(existingChildNode);
 
             var mockVsHierarchyItem = IVsHierarchyItemFactory.ImplementProperties(text: "MyNodeItemSpec");
-            var inputNode = IGraphContextFactory.CreateNode(projectPath, 
+            var inputNode = IGraphContextFactory.CreateNode(projectPath,
                                                             nodeIdString,
-                                                            hierarchyItem:mockVsHierarchyItem);
+                                                            hierarchyItem: mockVsHierarchyItem);
             var outputNodes = new HashSet<GraphNode>();
 
             var mockProvider = new IProjectDependenciesSubTreeProviderMock();
@@ -858,8 +858,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                                          new IProjectThreadingServiceMock().JoinableTaskContext);
             provider.AddExpandedGraphContext(mockGraphContext);
 
+            var changes = new ProjectContextEventArgs(updatedProjectContext);
+
             // Act
-            await provider.TrackChangesAsync(updatedProjectContext);
+            await provider.TrackChangesAsync(changes);
 
             // Assert
             Assert.Equal(1, outputNodes.Count);
@@ -927,9 +929,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                                          Mock.Of<SVsServiceProvider>(),
                                                          new IProjectThreadingServiceMock().JoinableTaskContext);
             provider.AddExpandedGraphContext(mockGraphContext);
+            var changes = new ProjectContextEventArgs(updatedProjectContext);
 
             // Act
-            await provider.TrackChangesAsync(updatedProjectContext);
+            await provider.TrackChangesAsync(changes);
 
             // Assert
             Assert.Equal(1, outputNodes.Count);
@@ -1005,9 +1008,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                                          Mock.Of<SVsServiceProvider>(),
                                                          new IProjectThreadingServiceMock().JoinableTaskContext);
             provider.AddExpandedGraphContext(mockGraphContext);
+            var changes = new ProjectContextEventArgs(updatedProjectContext);
 
             // Act
-            await provider.TrackChangesAsync(updatedProjectContext);
+            await provider.TrackChangesAsync(changes);
 
             // Assert
             Assert.Equal(0, outputNodes.Count);
@@ -1033,8 +1037,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             public void AddExpandedGraphContext(IGraphContext context)
             {
                 ContextHolder = context;
-                ExpandedGraphContexts = new PlatformUI.WeakCollection<IGraphContext>();
-                ExpandedGraphContexts.Add(context);
+                ExpandedGraphContexts = new PlatformUI.WeakCollection<IGraphContext>
+                {
+                    context
+                };
             }
 
             public IEnumerable<IGraphContext> GetExpandedGraphContexts()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependenciesSubTreeProviderBaseTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependenciesSubTreeProviderBaseTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         ""ItemSpec"": ""TopNodeItemSpec1""
     }
 }");
-            ((DependencyNode)topNode1).Caption = "Caption1";
+            topNode1.SetProperties(caption: "Caption1");
 
             var topNode2 = IDependencyNodeFactory.FromJson(@"
 {
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         ""ItemSpec"": ""TopNodeItemSpec2""
     }
 }");
-            ((DependencyNode)topNode2).Caption = "Caption2";
+            topNode2.SetProperties(caption: "Caption2");
 
             var topNode3 = IDependencyNodeFactory.FromJson(@"
 {
@@ -67,12 +67,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         ""ItemSpec"": ""TopNodeItemSpec3""
     }
 }");
-            ((DependencyNode)topNode3).Caption = "Caption3";
+            topNode3.SetProperties(caption: "Caption3");
 
-            ((DependencyNode)topNode2).Caption = topNode2.Alias;
-            rootNode.Children.Add(topNode1);
-            rootNode.Children.Add(topNode2);
-            rootNode.Children.Add(topNode3);
+            topNode2.SetProperties(caption:topNode2.Alias);
+            rootNode.AddChild(topNode1);
+            rootNode.AddChild(topNode2);
+            rootNode.AddChild(topNode3);
 
             var dependenciesChange = DependenciesChangeFactory.FromJson(@"
 {
@@ -96,8 +96,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     ""RemovedNodes"": [ ]
 }");
             var addedNodesArray = dependenciesChange.AddedNodes.ToArray();
-            ((DependencyNode)addedNodesArray[0]).Caption = "Caption1";
-            ((DependencyNode)addedNodesArray[1]).Caption = "Caption2";
+            addedNodesArray[0].SetProperties(caption:"Caption1");
+            addedNodesArray[1].SetProperties(caption:"Caption2");
 
             var provider = new TestableDependenciesSubTreeProviderBase();
             provider.SetRootNode(rootNode);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyNodeTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyNodeTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             // Act
             var node = new DependencyNode(id, ProjectTreeFlags.Empty);
-            node.Caption = caption;
+            node.SetProperties(caption:caption);
 
             // Assert
             Assert.Equal(expectedAlias, node.Alias);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/NuGetDependenciesSubTreeProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/NuGetDependenciesSubTreeProviderTests.cs
@@ -162,7 +162,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 ""ProviderType"": ""NuGetDependency"",
                 ""ItemSpec"": ""tfm1/package1/1.0.2.0"",
                 ""ItemType"": ""PackageReference""
-            }
+            },
+            ""Resolved"":""true""
         },
         {
             ""Id"": {
@@ -176,14 +177,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 ""ProviderType"": ""NuGetDependency"",
                 ""ItemSpec"": ""tfm1/ToBeOverridenByResolvedPackage/1.0.0"",
                 ""ItemType"": ""PackageReference""
-            }
+            },
+            ""Resolved"":""true""
         },
         {
             ""Id"": {
                 ""ProviderType"": ""NuGetDependency"",
                 ""ItemSpec"": ""tfm2/ExistingUnresolvedPackage/2.0.0"",
                 ""ItemType"": ""PackageReference""
-            }
+            },
+            ""Resolved"":""true""
         }
     ],    
     ""UpdatedNodes"": [
@@ -192,7 +195,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 ""ProviderType"": ""NuGetDependency"",
                 ""ItemSpec"": ""tfm1/PackageToChange/2.0.0"",
                 ""ItemType"": ""PackageReference""
-            }
+            },
+            ""Resolved"":""true""
         }
     ],
     ""RemovedNodes"": [
@@ -339,7 +343,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 ""ProviderType"": ""NuGetDependency"",
                 ""ItemSpec"": ""tfm1/package1/1.0.0"",
                 ""ItemType"": ""PackageReference""
-            }
+            },
+            ""Resolved"":""true""
         }
     ],    
     ""UpdatedNodes"": [
@@ -528,24 +533,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(5, resultNode.Children.Count);
 
             var childrenArray = resultNode.Children.ToArray();
-            Assert.True(childrenArray[0] is PackageDependencyNode);
-            Assert.Equal("Package3 (2.0.0)", childrenArray[0].Caption);
-            Assert.False(string.IsNullOrEmpty(childrenArray[0].Id.UniqueToken));
-            Assert.True(childrenArray[1] is PackageAssemblyDependencyNode);
-            Assert.Equal("Assembly1", childrenArray[1].Caption);
-            Assert.False(string.IsNullOrEmpty(childrenArray[1].Id.UniqueToken));
-            Assert.True(childrenArray[2] is PackageUnknownDependencyNode);
-            Assert.Equal("SomeUnknown", childrenArray[2].Caption);
-            Assert.False(string.IsNullOrEmpty(childrenArray[2].Id.UniqueToken));
-            // Analyzers
-            Assert.Equal("AnalyzerAssembly1", childrenArray[3].Caption);
-            Assert.True(childrenArray[3] is PackageAnalyzerAssemblyDependencyNode);
-            // Framework assemblies
-            Assert.True(childrenArray[4] is PackageFrameworkAssembliesDependencyNode);
-            Assert.False(string.IsNullOrEmpty(childrenArray[4].Id.UniqueToken));
-            Assert.True(childrenArray[4].Children.First() is PackageAssemblyDependencyNode);
-            Assert.Equal("FrameworkAssembly1", childrenArray[4].Children.First().Caption);
-            Assert.False(string.IsNullOrEmpty(childrenArray[4].Children.First().Id.UniqueToken));
+            var packageNode = resultNode.Children.FirstOrDefault(x => x.Caption.Equals("Package3 (2.0.0)"));
+            Assert.NotNull(packageNode);
+            Assert.True(packageNode is PackageDependencyNode);
+            Assert.False(string.IsNullOrEmpty(packageNode.Id.UniqueToken));
+
+            var assemblyNode = resultNode.Children.FirstOrDefault(x => x.Caption.Equals("Assembly1"));
+            Assert.NotNull(assemblyNode);
+            Assert.True(assemblyNode is PackageAssemblyDependencyNode);
+            Assert.False(string.IsNullOrEmpty(assemblyNode.Id.UniqueToken));
+
+            var unknownNode = resultNode.Children.FirstOrDefault(x => x.Caption.Equals("SomeUnknown"));
+            Assert.NotNull(unknownNode);
+            Assert.True(unknownNode is PackageUnknownDependencyNode);
+            Assert.False(string.IsNullOrEmpty(unknownNode.Id.UniqueToken));
+
+            var analyzerAssemblyNode = resultNode.Children.FirstOrDefault(x => x.Caption.Equals("AnalyzerAssembly1"));
+            Assert.NotNull(analyzerAssemblyNode);
+            Assert.True(analyzerAssemblyNode is PackageAnalyzerAssemblyDependencyNode);
+
+            var fxAssembliesNode = resultNode.Children.FirstOrDefault(x => x is PackageFrameworkAssembliesDependencyNode);
+            Assert.NotNull(fxAssembliesNode);
+            Assert.False(string.IsNullOrEmpty(fxAssembliesNode.Id.UniqueToken));
+            var fxAssemblies = fxAssembliesNode.Children;
+            Assert.True(fxAssemblies.First() is PackageAssemblyDependencyNode);
+            Assert.Equal("FrameworkAssembly1", fxAssemblies.First().Caption);
+            Assert.False(string.IsNullOrEmpty(fxAssemblies.First().Id.UniqueToken));            
 
             Assert.True(provider.GetCurrentSnapshotNodesCache().Contains(id.ItemSpec));
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/NuGetDependenciesSubTreeProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/NuGetDependenciesSubTreeProviderTests.cs
@@ -531,8 +531,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             Assert.NotNull(resultNode);
             Assert.Equal(5, resultNode.Children.Count);
-
-            var childrenArray = resultNode.Children.ToArray();
+            
             var packageNode = resultNode.Children.FirstOrDefault(x => x.Caption.Equals("Package3 (2.0.0)"));
             Assert.NotNull(packageNode);
             Assert.True(packageNode is PackageDependencyNode);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/ProjectDependenciesSubTreeProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/ProjectDependenciesSubTreeProviderTests.cs
@@ -56,8 +56,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 }");
             myDependencyNode1.Id.ContextProject = "c:\\myproject\\project.csproj";
 
-            myTopNode1.Children.Add(myDependencyNode1);
-            myRootNode.Children.Add(myTopNode1);
+            myTopNode1.AddChild(myDependencyNode1);
+            myRootNode.AddChild(myTopNode1);
 
             // other provider nodes
             var otherProviderRootNode = IDependencyNodeFactory.FromJson(@"
@@ -114,9 +114,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         ""ItemSpec"": ""MyChildNodeItemSpec""
     }
 }");
-            topNode1.Children.Add(childNode1);
-            topNode2.Children.Add(childNode3);
-            topNode2.Children.Add(childNode2);
+            topNode1.AddChild(childNode1);
+            topNode2.AddChild(childNode3);
+            topNode2.AddChild(childNode2);
             otherProviderRootNode.AddChild(topNode1);
             otherProviderRootNode.AddChild(topNode2);
             otherProviderRootNode.AddChild(topNode3);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProjectContextProvider.cs
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 return;
             }
 
-            ProjectContextChanged?.Invoke(this, new ProjectContextEventArgs(context));
+            ProjectContextChanged?.Invoke(this, e);
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 return;
             }
 
-            ProjectContextUnloaded?.Invoke(this, new ProjectContextEventArgs(context));
+            ProjectContextUnloaded?.Invoke(this, e);
             // Remove context for the unloaded project from the cache
             ProjectContexts.TryRemove(context.ProjectFilePath, out IDependenciesGraphProjectContext removedContext);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProvider.cs
@@ -482,8 +482,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 // it would not contain our top level node's ItemSpec, ItemType etc. We need to get it here.
                 var caption = hierarchyItem.Text;
                 var rootNodeChildren = subTreeProvider.RootNode.Children;
-                node = rootNodeChildren.Where(x => x.Caption.Equals(caption, StringComparison.OrdinalIgnoreCase))
-                                                 .FirstOrDefault();
+                node = rootNodeChildren.FirstOrDefault(x => x.Caption.Equals(caption, StringComparison.OrdinalIgnoreCase));
                 if (node == null)
                 {
                     // node is not ours or does node exist anymore

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProvider.cs
@@ -245,7 +245,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 var trackChanges = false;
                 using (var scope = new GraphTransactionScope())
                 {
-                    if (node.Flags.Contains(DependencyNode.DependsOnOtherProviders))
+                    if (node.Flags.Contains(DependencyNode.DependsOnOtherProviders)
+                        || subTreeProvider.ProviderType.Equals(SdkDependenciesSubTreeProvider.ProviderTypeString, StringComparison.OrdinalIgnoreCase))
                     {
                         trackChanges = true;
                     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -352,8 +352,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                                                          changes: e.Changes,
                                                                          cancellationToken: cancellationToken,
                                                                          catalogs: e.Catalogs);
-                    dependenciesNode = RefreshDependentProvidersNodes(dependenciesNode, e.Provider);
-
+                    
                     ProjectContextChanged?.Invoke(this, new ProjectContextEventArgs(this, e.Changes));
 
                     // TODO We still are getting mismatched data sources and need to figure out better 
@@ -362,43 +361,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                                                 false, 
                                                                 null /*GetMergedDataSourceVersions(e)*/));
                 });
-        }
-
-        private IProjectTree RefreshDependentProvidersNodes(IProjectTree dependenciesNode, 
-                                                            IProjectDependenciesSubTreeProvider changedProvider)
-        {
-            foreach (var subTreeProvider in SubTreeProviders)
-            {
-                var providerRootTreeNode = GetSubTreeRootNode(dependenciesNode,
-                                      subTreeProvider.Value.RootNode.Flags);
-                if (providerRootTreeNode == null)
-                {
-                    continue;
-                }
-
-                var provider = subTreeProvider.Value as DependenciesSubTreeProviderBase;
-                if (provider == null || !provider.CanDependOnProvider(changedProvider))
-                {
-                    continue;
-                }
-
-                var newProviderNode = providerRootTreeNode;
-                foreach (var treeNode in providerRootTreeNode.Children)
-                {
-                    if (!treeNode.Flags.Contains(DependencyNode.DependsOnOtherProviders))
-                    {
-                        continue;
-                    }
-
-                    var newNode = treeNode;
-                    newProviderNode = newProviderNode.Remove(treeNode);
-                    newProviderNode = newProviderNode.Add(treeNode).Parent;
-                }
-
-                dependenciesNode = newProviderNode.Parent;
-            }
-
-            return dependenciesNode;
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -473,7 +473,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             // item name correctly. Use real Name for the node here instead of caption, since caption
             // can have other info like version in it.
             var itemSpec = nodeInfo.Flags.Contains(DependencyNode.CustomItemSpec)
-                    ? DependencyNode.GetName(nodeInfo)
+                    ? nodeInfo.Name
                     : nodeInfo.Id.ItemSpec;
             var itemContext = ProjectPropertiesContext.GetContext(UnconfiguredProject, itemType, itemSpec);
             var configuredProjectExports = GetActiveConfiguredProjectExports(ActiveConfiguredProject);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -323,12 +323,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             if (disposing)
             {
-                foreach (var provider in SubTreeProviders)
-                {
-                    provider.Value.DependenciesChanged -= OnDependenciesChanged;
-                }
-
                 ProjectContextUnloaded?.Invoke(this, new ProjectContextEventArgs(this));
+
+                try
+                {
+                    foreach (var provider in SubTreeProviders)
+                    {
+                        provider.Value.DependenciesChanged -= OnDependenciesChanged;
+                    }
+                }
+                catch(ObjectDisposedException)
+                {
+                    // do nothing - we are cleaning up here and sometimes CPS throws Object disposed exception
+                }
             }
 
             base.Dispose(disposing);
@@ -347,7 +354,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                                                          catalogs: e.Catalogs);
                     dependenciesNode = RefreshDependentProvidersNodes(dependenciesNode, e.Provider);
 
-                    ProjectContextChanged?.Invoke(this, new ProjectContextEventArgs(this));
+                    ProjectContextChanged?.Invoke(this, new ProjectContextEventArgs(this, e.Changes));
 
                     // TODO We still are getting mismatched data sources and need to figure out better 
                     // way of merging, mute them for now and get to it in U1

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesSubTreeProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesSubTreeProviderBase.cs
@@ -86,16 +86,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             get
             {
-                if (_rootNode == null)
+                lock (_rootNodeSync)
                 {
-                    EnsureInitialized();
-                    _rootNode = CreateRootNode();
-                }
+                    if (_rootNode == null)
+                    {
+                        EnsureInitialized();
+                        _rootNode = CreateRootNode();
+                    }
 
-                return _rootNode;
+                    return _rootNode;
+                }
             }
             protected set
             {
+                // this is only for unit tests, product code should override CreateRootNode()
                 _rootNode = value;
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesSubTreeProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesSubTreeProviderBase.cs
@@ -300,7 +300,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
                 dependenciesChange.UpdatedNodes.ForEach((topLevelNode) =>
                 {
-                    var oldNode = RootNode.Children.FirstOrDefault(x => x.Id.Equals(topLevelNode.Id));
+                    var rootNodeChildren = RootNode.Children;
+                    var oldNode = rootNodeChildren.FirstOrDefault(x => x.Id.Equals(topLevelNode.Id));
                     if (oldNode != null)
                     {
                         RootNode.RemoveChild(oldNode);
@@ -308,7 +309,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     }
                 });
 
-                dependenciesChange.AddedNodes.ForEach(RootNode.AddChild);
+                RootNode.AddChildren(dependenciesChange.AddedNodes);
 
                 OnDependenciesChanged(dependenciesChange.GetDiff(), e, handlerType);
             }
@@ -318,7 +319,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             Requires.NotNull(nodeId, nameof(nodeId));
 
-            return RootNode.Children.FirstOrDefault(x => x.Id.Equals(nodeId));
+            var rootNodeChildren = RootNode.Children;
+            return rootNodeChildren.FirstOrDefault(x => x.Id.Equals(nodeId));
         }
 
         public virtual Task<IEnumerable<IDependencyNode>> SearchAsync(IDependencyNode node, string searchTerm)
@@ -342,7 +344,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                               StringComparison.OrdinalIgnoreCase)))
                 .ToDictionary(d => d.After.RuleName, d => d, StringComparer.OrdinalIgnoreCase);
 
-            var rootTreeNodes = new HashSet<IDependencyNode>(RootNode.Children);
+            var rootTreeNodes = RootNode.Children;
             var dependenciesChange = new DependenciesChange();
             foreach (var unresolvedChange in unresolvedReferenceSnapshots.Values)
             {
@@ -538,12 +540,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             // same caption. If yes, we just need to apply alias to our current node only.
             foreach (var nodeToAdd in dependenciesChange.AddedNodes)
             {
+                var rootNodeChildren = RootNode.Children;
                 var shouldApplyAlias = false;
-                var matchingChild = RootNode.Children.FirstOrDefault(
+                var matchingChild = rootNodeChildren.FirstOrDefault(
                         x => x.Caption.Equals(nodeToAdd.Caption, StringComparison.OrdinalIgnoreCase));
                 if (matchingChild == null)
                 {
-                    shouldApplyAlias = RootNode.Children.Any(
+                    shouldApplyAlias = rootNodeChildren.Any(
                         x => x.Caption.Equals(
                                 string.Format(CultureInfo.CurrentCulture, "{0} ({1})", nodeToAdd.Caption, x.Id.ItemSpec),
                                 StringComparison.OrdinalIgnoreCase));
@@ -557,14 +560,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 {
                     if (matchingChild != null)
                     {
-                        ((DependencyNode)matchingChild).Caption = matchingChild.Alias;
+                        matchingChild.SetProperties(caption: matchingChild.Alias);
                         dependenciesChange.UpdatedNodes.Add(matchingChild);
                     }
 
-                    ((DependencyNode)nodeToAdd).Caption = nodeToAdd.Alias;
+                    nodeToAdd.SetProperties(caption:nodeToAdd.Alias);
                 }
 
-                RootNode.Children.Add(nodeToAdd);
+                RootNode.AddChild(nodeToAdd);
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
@@ -122,7 +122,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                         : UnresolvedDependencyFlags.Union(flags);
         }
 
-        private object _childrenLock = new object();
+        private readonly object _childrenLock = new object();
 
         /// <summary>
         /// Unique id of the node, combination of ItemSpec, ItemType, ProviderType and when
@@ -276,7 +276,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
         public override int GetHashCode()
         {
-            return unchecked(Id.GetHashCode());
+            return Id.GetHashCode();
         }
 
         public override bool Equals(object obj)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
@@ -3,7 +3,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
-using System.Linq;
 using Microsoft.VisualStudio.Imaging.Interop;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
@@ -134,45 +133,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// Note: Dependency node has public set for caption, since sometimes providers need
         /// to change captions. All other consumers will use IDependencyNode which has only "get".
         /// </summary>
-        public string Caption { get; set; }
+        public string Caption { get; protected set; }
 
-        /// <summary>
-        /// Actual formal name of the node. In most cases it will be equal to Caption,
-        /// however in some cases caption would have name + version or something else.
-        /// So to allow tree provider store formal name we need this property too. 
-        /// It is a hack now and we should make it public and move to IDependencyNode when
-        /// we get a chance and it is safe to do a breaking change.
-        /// Tracking with https://github.com/dotnet/roslyn-project-system/issues/1101
-        /// </summary>
         private string _name;
-        internal string Name {
+        public string Name {
             get
             {
                 return _name ?? Caption;
             }
-            set
+            internal set
             {
                 _name = value;
             }
         }
 
-        /// <summary>
-        /// This is temporary until we can add Name to IDependencyNode to protect us from custom 
-        /// implementations of IDependencyNode which don't have Name yet.
-        /// </summary>
-        internal static string GetName(IDependencyNode node)
-        {
-            Requires.NotNull(node, nameof(node));
-
-            if (node is DependencyNode dependencyNode)
-            {
-                return dependencyNode.Name;
-            }
-            else
-            {
-                return node.Caption;
-            }
-        }
         /// <summary>
         /// Unique name constructed in the form Caption (ItemSpec).
         /// Is used to dedupe dependency nodes when they have same caption but different 
@@ -201,16 +175,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
         public int Priority { get; protected set; }
 
-        public ProjectTreeFlags Flags { get; set; }
+        public ProjectTreeFlags Flags { get; internal set; }
 
         public IImmutableDictionary<string, string> Properties { get; protected set; }
 
-        private HashSet<IDependencyNode> _children = new HashSet<IDependencyNode>();
-        public HashSet<IDependencyNode> Children
+        private ImmutableHashSet<IDependencyNode> _children = ImmutableHashSet<IDependencyNode>.Empty;
+        public ImmutableHashSet<IDependencyNode> Children
         {
             get
             {
-                return _children;
+                lock (_children)
+                {
+                    return _children;
+                }
             }
         }
 
@@ -218,30 +195,86 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             get
             {
-                return Children.Any();
+                return Children.Count > 0;
             }
         }
 
+        /// <summary>
+        /// Adds a child to the node
+        /// </summary>
+        /// <param name="childNode">child node to be added. Should not be null.</param>
         public void AddChild(IDependencyNode childNode)
         {
             Requires.NotNull(childNode, nameof(childNode));
 
-            _children.Add(childNode);
+            lock(_children)
+            {
+                _children = _children.Add(childNode);
+            }
         }
 
+        /// <summary>
+        /// Adds children to the node
+        /// </summary>
+        /// <param name="children">child nodes to be added. Should not be null.</param>
+        public void AddChildren(IEnumerable<IDependencyNode> children)
+        {
+            Requires.NotNull(children, nameof(children));
+
+            lock (_children)
+            {
+                var builder = _children.ToBuilder();
+                foreach (var child in children)
+                {
+                    builder.Add(child);
+                }
+
+                _children = builder.ToImmutableHashSet();
+            }
+        }
+
+        /// <summary>
+        /// Removes child from node's children.
+        /// </summary>
+        /// <param name="childNode">Node to be removed if it belongs to children. Should not be null.</param>
         public void RemoveChild(IDependencyNode childNode)
         {
             Requires.NotNull(childNode, nameof(childNode));
 
-            if (_children.Contains(childNode))
+            lock (_children)
             {
-                _children.Remove(childNode);
+                if (_children.Contains(childNode))
+                {
+                    _children = _children.Remove(childNode);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Removes all children from node
+        /// </summary>
+        public void RemoveAllChildren()
+        {
+            lock (_children)
+            {
+                _children = _children.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Changes some properties of the node
+        /// </summary>
+        public void SetProperties(string caption = null)
+        {
+            if (caption != null)
+            {
+                Caption = caption;
             }
         }
 
         public override int GetHashCode()
         {
-            return unchecked(Id.GetHashCode());
+            return unchecked(Id.GetHashCode() + Resolved.GetHashCode());
         }
 
         public override bool Equals(object obj)
@@ -256,7 +289,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
         public bool Equals(IDependencyNode other)
         {
-            if (other != null && other.Id.Equals(Id))
+            if (other != null && other.Id.Equals(Id) && other.Resolved.Equals(Resolved))
             {
                 return true;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
@@ -69,6 +69,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         public static readonly ProjectTreeFlags DoesNotSupportRemove
                 = ProjectTreeFlags.Create("DoesNotSupportRemove");
 
+         /// <summary>
+         /// This flg indicates that dependency shows a hierarchy or other data that is coming from other sub 
+         /// tree provider. This would allow components responsible for data displaying do necessary steps to 
+         /// stay in sync with other providers changes.
+         /// </summary>
+         public static readonly ProjectTreeFlags DependsOnOtherProviders
+                 = ProjectTreeFlags.Create("DependsOnOtherProviders");
+
         /// <summary>
         /// This flg indicates that dependency shows a hierarchy or other data that is coming from other sub 
         /// tree provider. This would allow components responsible for data displaying do necessary steps to 
@@ -120,6 +128,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Flags = Resolved
                         ? ResolvedDependencyFlags.Union(flags)
                         : UnresolvedDependencyFlags.Union(flags);
+        }
+
+        private DependencyNode(IDependencyNode node)
+        {
+            Id = node.Id;
+            Caption = node.Caption;
+            Name = node.Name;
+            Priority = node.Priority;
+            Properties = node.Properties;
+            Resolved = node.Resolved;
+            Flags = node.Flags;
+            Icon = node.Icon;
+            ExpandedIcon = node.ExpandedIcon;
+
+            AddChildren(node.Children);
         }
 
         private readonly object _childrenLock = new object();
@@ -297,6 +320,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             }
 
             return false;
+        }
+
+        public static IDependencyNode Clone(IDependencyNode node)
+        {
+            return new DependencyNode(node);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
@@ -122,6 +122,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                         : UnresolvedDependencyFlags.Union(flags);
         }
 
+        private object _childrenLock = new object();
+
         /// <summary>
         /// Unique id of the node, combination of ItemSpec, ItemType, ProviderType and when
         /// needed some unique token.
@@ -184,7 +186,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             get
             {
-                lock (_children)
+                lock (_childrenLock)
                 {
                     return _children;
                 }
@@ -207,7 +209,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             Requires.NotNull(childNode, nameof(childNode));
 
-            lock(_children)
+            lock(_childrenLock)
             {
                 _children = _children.Add(childNode);
             }
@@ -221,7 +223,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             Requires.NotNull(children, nameof(children));
 
-            lock (_children)
+            lock (_childrenLock)
             {
                 var builder = _children.ToBuilder();
                 foreach (var child in children)
@@ -241,7 +243,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             Requires.NotNull(childNode, nameof(childNode));
 
-            lock (_children)
+            lock (_childrenLock)
             {
                 if (_children.Contains(childNode))
                 {
@@ -255,7 +257,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// </summary>
         public void RemoveAllChildren()
         {
-            lock (_children)
+            lock (_childrenLock)
             {
                 _children = _children.Clear();
             }
@@ -274,7 +276,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
         public override int GetHashCode()
         {
-            return unchecked(Id.GetHashCode() + Resolved.GetHashCode());
+            return unchecked(Id.GetHashCode());
         }
 
         public override bool Equals(object obj)
@@ -289,7 +291,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
         public bool Equals(IDependencyNode other)
         {
-            if (other != null && other.Id.Equals(Id) && other.Resolved.Equals(Resolved))
+            if (other != null && other.Id.Equals(Id))
             {
                 return true;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
@@ -78,14 +78,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                  = ProjectTreeFlags.Create("DependsOnOtherProviders");
 
         /// <summary>
-        /// This flg indicates that dependency shows a hierarchy or other data that is coming from other sub 
-        /// tree provider. This would allow components responsible for data displaying do necessary steps to 
-        /// stay in sync with other providers changes.
-        /// </summary>
-        public static readonly ProjectTreeFlags DependsOnOtherProviders
-                 = ProjectTreeFlags.Create("DependsOnOtherProviders");
-
-        /// <summary>
         /// These set of flags is internal and should be used only by standard known
         /// project item nodes, that come from design time build. This is important,
         /// since some of flags enable other functionality, like Add Reference dialog

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependenciesGraphProjectContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependenciesGraphProjectContext.cs
@@ -47,11 +47,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
     internal class ProjectContextEventArgs : EventArgs
     {
-        public ProjectContextEventArgs(IDependenciesGraphProjectContext context)
+        public ProjectContextEventArgs(IDependenciesGraphProjectContext context,
+                                       IDependenciesChangeDiff diff = null)
         {
             Context = context;
+            Diff = diff ?? new DependenciesChange().GetDiff();
         }
 
         public IDependenciesGraphProjectContext Context { get; }
+        public IDependenciesChangeDiff Diff { get; }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependencyNode.cs
@@ -21,6 +21,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         DependencyNodeId Id { get; }
 
         /// <summary>
+        /// Formal node name from tree perspective. By default it is equal to Caption,
+        /// however some nodes might have add some data to Caption, like version etc. So 
+        /// we need to have a way to avoid caprion parsing and get it directly form node.
+        /// Note: it is different from DependencyNodeId.ItemSpec, since that one is unique 
+        /// form project item perspective for default nodes and might have any form, not 
+        /// necesarily readable. So actual IProjectTree would use Caption to display nodes,
+        /// and Name or ItemSpec when tries to find children depending on node types.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
         /// Node's caption displayed in the tree
         /// </summary>
         string Caption { get; }
@@ -61,9 +72,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         ProjectTreeFlags Flags { get; }
 
         /// <summary>
+        /// Changes some properties of the node
+        /// </summary>
+        void SetProperties(string caption = null);
+
+        /// <summary>
         /// Children of current node.
         /// </summary>
-        HashSet<IDependencyNode> Children { get; }
+        ImmutableHashSet<IDependencyNode> Children { get; }
 
         /// <summary>
         /// Quick check if node has children.
@@ -83,9 +99,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         void AddChild(IDependencyNode childNode);
 
         /// <summary>
+        /// Adds children to the node
+        /// </summary>
+        /// <param name="children">child nodes to be added. Should not be null.</param>
+        void AddChildren(IEnumerable<IDependencyNode> children);
+
+        /// <summary>
         /// Removes child from node's children.
         /// </summary>
         /// <param name="childNode">Node to be removed if it belongs to children. Should not be null.</param>
         void RemoveChild(IDependencyNode childNode);
+
+        /// <summary>
+        /// Removes all children from node
+        /// </summary>
+        void RemoveAllChildren();
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependencyNodeExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependencyNodeExtensions.cs
@@ -13,7 +13,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         public static IDependencyNode FindNode(this IDependencyNode self, DependencyNodeId id, bool recursive = false)
         {
             IDependencyNode resultNode = null;
-            foreach(var child in self.Children)
+            var children = self.Children;
+            foreach (var child in children)
             {
                 if (child.Id.Equals(id))
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ProjectDependenciesSubTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ProjectDependenciesSubTreeProvider.cs
@@ -167,7 +167,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 return node;
             }
 
-            node.Children.Clear();
+            node.RemoveAllChildren();
             foreach (var subTreeProvider in projectContext.GetProviders())
             {
                 if (subTreeProvider.RootNode == null || !subTreeProvider.RootNode.HasChildren)
@@ -175,7 +175,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     continue;
                 }
 
-                foreach (var child in subTreeProvider.RootNode.Children)
+                var rootNodeChildren = subTreeProvider.RootNode.Children;
+                foreach (var child in rootNodeChildren)
                 {
                     node.AddChild(child);
                 }
@@ -183,7 +184,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             // create a new instance of the node to allow graph provider to compare changes
             var newNode = CreateDependencyNode(node.Id, node.Priority, node.Properties, node.Resolved);
-            newNode.Children.AddRange(node.Children);
+            newNode.AddChildren(node.Children);
+
             return newNode;
         }
 
@@ -200,7 +202,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Requires.NotNull(dependenciesChange, nameof(dependenciesChange));
 
             var sharedFolderProjectPaths = sharedFolders.Value.Select(sf => sf.ProjectPath);
-            var currentSharedImportNodes = RootNode.Children
+            var rootNodeChildren = RootNode.Children;
+            var currentSharedImportNodes = rootNodeChildren
                     .Where(x => x.Flags.Contains(ProjectTreeFlags.Common.SharedProjectImportReference));
             var currentSharedImportNodePaths = currentSharedImportNodes.Select(x => x.Id.ItemSpec);
 
@@ -209,7 +212,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var itemType = ResolvedProjectReference.PrimaryDataSourceItemType;
             foreach (string addedSharedImportPath in addedSharedImportPaths)
             {
-                var node = RootNode.Children.FindNode(addedSharedImportPath, itemType);
+                rootNodeChildren = RootNode.Children;
+                var node = rootNodeChildren.FindNode(addedSharedImportPath, itemType);
                 if (node == null)
                 {
                     var sharedFlags = ProjectTreeFlags.Create(ProjectTreeFlags.Common.SharedProjectImportReference);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ProjectDependenciesSubTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ProjectDependenciesSubTreeProvider.cs
@@ -178,7 +178,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 var rootNodeChildren = subTreeProvider.RootNode.Children;
                 foreach (var child in rootNodeChildren)
                 {
-                    node.AddChild(child);
+                    node.AddChild(DependencyNode.Clone(child));
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SdkDependenciesSubTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SdkDependenciesSubTreeProvider.cs
@@ -99,8 +99,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var flags = SdkSubTreeNodeFlags;
             if (IsImplicit(properties, out string packageItemSpec))
             {
-                flags = flags.Union(DependencyNode.DoesNotSupportRemove)
-                             .Union(DependencyNode.DependsOnOtherProviders);
+                flags = flags.Union(DependencyNode.DoesNotSupportRemove);
             }
 
             return new SdkDependencyNode(id,


### PR DESCRIPTION
**Customer scenario**

Random nodes in the dependency tree in solution explorer might not appear after some dependent project changes or have incorrect icons (resolved vs unresolved). This gives the impression of poor quality and one cannot trust the data in solution explorer.

**Bugs this fixes:**

https://github.com/dotnet/roslyn-project-system/issues/1423 or similar

**Workarounds, if any**

Reload project

**Risk**

Even though it introduces a breaking change for web tools, change on web side is small and we just need to do insertions from core and web with matching bits.

**Root cause analysis:**

Original implementation was working ok, but then we introduced async dependencies accross sub tree providers which would need immutable data
