### PR TITLE
LOC CHECKIN | dotnet/roslyn-project-system | 20170206 | bugfix

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.cs.xlf
@@ -40,7 +40,7 @@
       </trans-unit>
       <trans-unit id="NeutralLanguageLabel.Text">
         <source>&amp;Neutral language:</source>
-        <target state="translated">&amp;Neutrální jazyk:</target>
+        <target state="translated">Ne&amp;utrální jazyk:</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionLabel.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.tr.xlf
@@ -35,17 +35,17 @@
       </trans-unit>
       <trans-unit id="ComVisibleCheckBox.Text">
         <source>&amp;Make assembly COM-Visible</source>
-        <target state="translated">&amp;Bütünleştirilmiş kodu COM-Görünür yap</target>
+        <target state="translated">Bütünleştirilmiş kodu &amp;COM-Görünür yap</target>
         <note />
       </trans-unit>
       <trans-unit id="NeutralLanguageLabel.Text">
         <source>&amp;Neutral language:</source>
-        <target state="translated">&amp;Bağımsız dil:</target>
+        <target state="translated">Bağımsı&amp;z dil:</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionLabel.Text">
         <source>&amp;Assembly version:</source>
-        <target state="translated">&amp;Bütünleştirilmiş kod sürümü:</target>
+        <target state="translated">Bütünleştirilmiş k&amp;od sürümü:</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionLabel.Text">


### PR DESCRIPTION
Bug 368857:[CSY] The ‘Title’ and ‘Neutral language’ option have the same
hot-key: <ALT + N> in Assembly Information dialog
Bug 368001:[TRK] The 'Title', ‘Assembly version’, ‘Neutral language’ &
‘Make assembly COM-Visible’ items have the same hot-key 'Alt + B' in
Assembly Information dialog