### PR TITLE
Save the last xml written the project, and only update if the project…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectXmlAccessorFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectXmlAccessorFactory.cs
@@ -13,12 +13,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
 
         public static IProjectXmlAccessor Create() => Mock.Of<IProjectXmlAccessor>();
 
-        public static IProjectXmlAccessor ImplementGetProjectXml(string xml) => ImplementGetProjectXml(() => xml);
+        public static IProjectXmlAccessor ImplementGetProjectXml(string xml) => Implement(() => xml, s => { });
 
-        public static IProjectXmlAccessor ImplementGetProjectXml(Func<string> xmlFunc)
+        public static IProjectXmlAccessor Implement(Func<string> xmlFunc, Action<string> saveCallback)
         {
             var mock = new Mock<IProjectXmlAccessor>();
             mock.Setup(m => m.GetProjectXmlAsync()).Returns(() => Task.FromResult(xmlFunc()));
+            mock.Setup(m => m.SaveProjectXmlAsync(It.IsAny<string>())).Callback(saveCallback).Returns(Task.CompletedTask);
             return mock.Object;
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITextBufferFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITextBufferFactory.cs
@@ -17,5 +17,14 @@ namespace Microsoft.VisualStudio.Text
             mock.SetupGet(t => t.CurrentSnapshot).Returns(snapshotMock.Object);
             return mock.Object;
         }
+
+        public static ITextBuffer ImplementSnapshot(Func<string> textFunc)
+        {
+            var mock = new Mock<ITextBuffer>();
+            var snapshotMock = new Mock<ITextSnapshot>();
+            snapshotMock.Setup(s => s.GetText()).Returns(textFunc);
+            mock.SetupGet(t => t.CurrentSnapshot).Returns(snapshotMock.Object);
+            return mock.Object;
+        }
     }
 }


### PR DESCRIPTION
… has changed from the last written xml.

**Customer scenario**

When a user saves the project file and immediately makes a change, this can trigger a "This file has been modified on disk" popup. This is highly annoying and disruptive for users who save often, as both @davkean and myself have found.

**Bugs this fixes:**

Fixes https://github.com/dotnet/roslyn-project-system/issues/1403

**Workarounds, if any**

Wait for several seconds after pressing save in the buffer, with no good visual indication, or don't press save often.

**Risk**

There are no external APIs dependent on this, and no features outside the project file editor, so potential risk should be small.

**Performance impact**

Low. We're doing an extra string comparison in some cases, but on balance we should actually improve performance when actively editing and saving the project constantly because we're not updating the buffer or causing IO operations.

**Is this a regression from a previous update?**

No. Known bug in initial implementation.

**How was the bug found?**

Dogfooding.

Tagging @dotnet/project-system @davkean @srivatsn for review.

@MattGertz, we'd like a bar check for this. @davkean and I have expressed frustration with the feature because of this issue, and I can see it being a very common pain point that should be easily avoided.