### PR TITLE
Critical task registration for Solution Restore service should exclude Save operation

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
@@ -135,7 +135,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             if (projectRestoreInfo != null)
             {
                 _projectVsServices.Project.Services.ProjectAsynchronousTasks
-                    .RegisterCriticalAsyncTask(JoinableFactory.RunAsync(async () =>
+                    .RegisterAsyncTask(JoinableFactory.RunAsync(async () =>
                     {
                         await _solutionRestoreService
                                .NominateProjectAsync(_projectVsServices.Project.FullPath, projectRestoreInfo,
@@ -144,7 +144,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 
                         Microsoft.Internal.Performance.CodeMarkers.Instance.CodeMarker(perfPackageRestoreEnd);
 
-                    }), registerFaultHandler: true);
+                    }),
+                    ProjectCriticalOperation.Build | ProjectCriticalOperation.Unload | ProjectCriticalOperation.Rename,
+                    registerFaultHandler: true);
             }
 
             return Task.CompletedTask;


### PR DESCRIPTION
Fixes #1501

**Customer scenario**

A customer that tries to save a solution while auto restore is running may run into a deadlock. This change drops Save as one of the operations that should wait for restore to complete (Build, Unload, and Rename still have to wait). From #1501:

> This is important because "Save" is done in a sync method in VS, but NuGet is running scripts in the background that depend on RPC to finish some tasks on the UI thread, so it can easily run into dead locks.

**Bugs this fixes:**

#1501 

**Workarounds, if any**

N/A

**Risk**

Low. No change in behavior for Build, Rename and Unload, and the current arrangement is more deadlock prone for Save, according to the analysis from CPS team.

**Performance impact**

None

**Is this a regression from a previous update?**

No

**Root cause analysis:**

We registered solution restore as a critical task to avoid deadlocks during _build_, but have now determined that this is not necessary for _Save_

**How was the bug found?**

Testing by CPS team

/cc @srivatsn @lifengl @dotnet/project-system 