### PR TITLE
Fix for 1456 Dependencies are confusing with multiple TFMS

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -345,6 +345,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                                                          changes: e.Changes,
                                                                          cancellationToken: cancellationToken,
                                                                          catalogs: e.Catalogs);
+                    dependenciesNode = RefreshDependentProvidersNodes(dependenciesNode, e.Provider);
 
                     ProjectContextChanged?.Invoke(this, new ProjectContextEventArgs(this));
 
@@ -354,6 +355,43 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                                                 false, 
                                                                 null /*GetMergedDataSourceVersions(e)*/));
                 });
+        }
+
+        private IProjectTree RefreshDependentProvidersNodes(IProjectTree dependenciesNode, 
+                                                            IProjectDependenciesSubTreeProvider changedProvider)
+        {
+            foreach (var subTreeProvider in SubTreeProviders)
+            {
+                var providerRootTreeNode = GetSubTreeRootNode(dependenciesNode,
+                                      subTreeProvider.Value.RootNode.Flags);
+                if (providerRootTreeNode == null)
+                {
+                    continue;
+                }
+
+                var provider = subTreeProvider.Value as DependenciesSubTreeProviderBase;
+                if (provider == null || !provider.CanDependOnProvider(changedProvider))
+                {
+                    continue;
+                }
+
+                var newProviderNode = providerRootTreeNode;
+                foreach (var treeNode in providerRootTreeNode.Children)
+                {
+                    if (!treeNode.Flags.Contains(DependencyNode.DependsOnOtherProviders))
+                    {
+                        continue;
+                    }
+
+                    var newNode = treeNode;
+                    newProviderNode = newProviderNode.Remove(treeNode);
+                    newProviderNode = newProviderNode.Add(treeNode).Parent;
+                }
+
+                dependenciesNode = newProviderNode.Parent;
+            }
+
+            return dependenciesNode;
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesSubTreeProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesSubTreeProviderBase.cs
@@ -127,6 +127,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
         public abstract IEnumerable<ImageMoniker> Icons { get; }
 
+        public virtual bool CanDependOnProvider(IProjectDependenciesSubTreeProvider otherProvider)
+        {
+            return false;
+        }
+
         /// <summary>
         /// Creates a root node specific to provider implementation
         /// </summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyNode.cs
@@ -71,6 +71,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 = ProjectTreeFlags.Create("DoesNotSupportRemove");
 
         /// <summary>
+        /// This flg indicates that dependency shows a hierarchy or other data that is coming from other sub 
+        /// tree provider. This would allow components responsible for data displaying do necessary steps to 
+        /// stay in sync with other providers changes.
+        /// </summary>
+        public static readonly ProjectTreeFlags DependsOnOtherProviders
+                 = ProjectTreeFlags.Create("DependsOnOtherProviders");
+
+        /// <summary>
         /// These set of flags is internal and should be used only by standard known
         /// project item nodes, that come from design time build. This is important,
         /// since some of flags enable other functionality, like Add Reference dialog

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/NuGetDependenciesSubTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/NuGetDependenciesSubTreeProvider.cs
@@ -21,7 +21,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     internal class NuGetDependenciesSubTreeProvider : DependenciesSubTreeProviderBase, INuGetPackagesDataProvider
     {
         public const string ProviderTypeString = "NuGetDependency";
-
         public static readonly ProjectTreeFlags NuGetSubTreeRootNodeFlags
                             = ProjectTreeFlags.Create("NuGetSubTreeRootNode");
 
@@ -201,6 +200,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 if (childDependencyMetadata.DependencyType == DependencyType.FrameworkAssembly)
                 {
                     frameworkAssemblies.Add(childDependencyMetadata);
+                    continue;
+                }
+                else if (childDependencyMetadata.Properties.TryGetValue(MetadataKeys.IsImplicitlyDefined, out string isImplicitPackageString)
+                    && bool.TryParse(isImplicitPackageString, out bool isImplicitPackage)
+                    && isImplicitPackage)
+                {
+                    // we don't want to show implicit packages at all, since they are SDK's
                     continue;
                 }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ProjectDependenciesSubTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ProjectDependenciesSubTreeProvider.cs
@@ -75,6 +75,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             }
         }
 
+        public override bool CanDependOnProvider(IProjectDependenciesSubTreeProvider otherProvider)
+        {
+            // projects depend on all kinds of providers changes
+            return true;
+        }
+
         protected override IDependencyNode CreateRootNode()
         {
             return new SubTreeRootDependencyNode(ProviderType, 
@@ -115,7 +121,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                                      bool resolved)
         {
             return new ProjectDependencyNode(id,
-                                             flags: ProjectSubTreeNodeFlags,
+                                             flags: ProjectSubTreeNodeFlags.Union(DependencyNode.DependsOnOtherProviders),
                                              priority: priority,
                                              properties: properties,
                                              resolved: resolved);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SdkDependenciesSubTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SdkDependenciesSubTreeProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
@@ -72,6 +73,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             }
         }
 
+        public override bool CanDependOnProvider(IProjectDependenciesSubTreeProvider otherProvider)
+        {
+            return NuGetDependenciesSubTreeProvider.ProviderTypeString
+                    .Equals(otherProvider?.ProviderType, StringComparison.OrdinalIgnoreCase);
+        }
+
         protected override IDependencyNode CreateRootNode()
         {
             return new SubTreeRootDependencyNode(ProviderType, 
@@ -92,7 +99,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var flags = SdkSubTreeNodeFlags;
             if (IsImplicit(properties, out string packageItemSpec))
             {
-                flags = flags.Union(DependencyNode.DoesNotSupportRemove);
+                flags = flags.Union(DependencyNode.DoesNotSupportRemove)
+                             .Union(DependencyNode.DependsOnOtherProviders);
             }
 
             return new SdkDependencyNode(id,


### PR DESCRIPTION
**Customer scenario**

When user has multiple TFMs , switching the active one would have different SDKs and some SDK oculd appear as packages, since for other TFM they are not marked as implicit packages. To solve it we add a property in common SDK targets to hardcode list of known SDK implicit packages.

**Bugs this fixes:**

https://github.com/dotnet/roslyn-project-system/issues/1456

**Workarounds, if any**

N/A

**Risk**

Low

**Performance impact**

We resolve packages form assets.json file several times for unresolved and resolved SDK resolution.

