### PR TITLE
Handle negative value of Version.Build when Version.TryParse succeeds…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
@@ -260,6 +260,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData(@"[assembly: System.Reflection.AssemblyVersionAttribute(""random"")]", "AssemblyVersion", "random", typeof(AssemblyVersionValueProvider))]
         [InlineData(@"[assembly: System.Reflection.AssemblyInformationalVersionAttribute(""2.0.0"")]", "AssemblyVersion", "2.0.0.0", typeof(AssemblyVersionValueProvider))]
         [InlineData(@"[assembly: System.Reflection.AssemblyInformationalVersionAttribute(""2.0.1-beta1"")]", "AssemblyVersion", "2.0.1.0", typeof(AssemblyVersionValueProvider))]
+        [InlineData(@"[assembly: System.Reflection.AssemblyInformationalVersionAttribute(""2016.2"")]", "AssemblyVersion", "2016.2.0.0", typeof(AssemblyVersionValueProvider))]
         // FileVersion
         [InlineData(@"", "FileVersion", "1.0.0.0", typeof(FileVersionValueProvider))]
         [InlineData(@"[assembly: System.Reflection.AssemblyFileVersionAttribute(""1.1.1"")]", "FileVersion", "1.1.1", typeof(FileVersionValueProvider))]
@@ -267,13 +268,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData(@"[assembly: System.Reflection.AssemblyFileVersionAttribute(""random"")]", "FileVersion", "random", typeof(FileVersionValueProvider))]
         [InlineData(@"[assembly: System.Reflection.AssemblyInformationalVersionAttribute(""2.0.0"")]", "FileVersion", "2.0.0.0", typeof(FileVersionValueProvider))]
         [InlineData(@"[assembly: System.Reflection.AssemblyInformationalVersionAttribute(""2.0.1-beta1"")]", "FileVersion", "2.0.1.0", typeof(FileVersionValueProvider))]
-        // PackageVersion
+        [InlineData(@"[assembly: System.Reflection.AssemblyInformationalVersionAttribute(""2016.2"")]", "FileVersion", "2016.2.0.0", typeof(FileVersionValueProvider))]
+        // Version
         [InlineData(@"", "Version", null, null)]
         [InlineData(@"[assembly: System.Reflection.AssemblyInformationalVersionAttribute(""1.1.1"")]", "Version", "1.1.1", null)]
         [InlineData(@"[assembly: System.Reflection.AssemblyInformationalVersionAttribute("""")]", "Version", "", null)]
         [InlineData(@"[assembly: System.Reflection.AssemblyInformationalVersionAttribute(""random"")]", "Version", "random", null)]
         [InlineData(@"[assembly: System.Reflection.AssemblyInformationalVersionAttribute(""2.0.0"")]", "Version", "2.0.0", null)]
         [InlineData(@"[assembly: System.Reflection.AssemblyInformationalVersionAttribute(""2.0.1-beta1"")]", "Version", "2.0.1-beta1", null)]
+        [InlineData(@"[assembly: System.Reflection.AssemblyInformationalVersionAttribute(""2016.2"")]", "Version", "2016.2", null)]
         internal async void SourceFileProperties_DefaultValues_GetEvalutedPropertyAsync(string code, string propertyName, string expectedValue, Type interceptingProviderType)
         {
             var interceptingProvider = interceptingProviderType != null ?
@@ -325,6 +328,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData("AssemblyVersion", "1.0.0.0", "1.0.0.0", "1.0.0.0", typeof(AssemblyVersionValueProvider))]
         [InlineData("AssemblyVersion", "1.1.1", "1.0.0.0", "1.0.0.0", typeof(AssemblyVersionValueProvider))]
         [InlineData("AssemblyVersion", "1.0.0.0", "1.0.0", "1.0.0", typeof(AssemblyVersionValueProvider))]
+        [InlineData("AssemblyVersion", null, "2016.2", "2016.2", typeof(AssemblyVersionValueProvider))]
         // FileVersion
         [InlineData("FileVersion", null, "1.0.0.0", "1.0.0.0", typeof(FileVersionValueProvider))]
         [InlineData("FileVersion", "", "1.0.0.0", "1.0.0.0", typeof(FileVersionValueProvider))]
@@ -332,6 +336,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData("FileVersion", "1.0.0.0", "1.0.0.0", "1.0.0.0", typeof(FileVersionValueProvider))]
         [InlineData("FileVersion", "1.1.1", "1.0.0.0", "1.0.0.0", typeof(FileVersionValueProvider))]
         [InlineData("FileVersion", "1.0.0.0", "1.0.0", "1.0.0", typeof(FileVersionValueProvider))]
+        [InlineData("FileVersion", null, "2016.2", "2016.2", typeof(FileVersionValueProvider))]
         // PackageVersion
         [InlineData("Version", null, "1.0.0", "1.0.0", null)]
         [InlineData("Version", null, "1.0.0-beta1", "1.0.0-beta1", null)]
@@ -343,6 +348,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData("Version", "1.0.0", "1.0.0-beta1", "1.0.0-beta1", null)]
         [InlineData("Version", "1.1.1", "1.0.0.0", "1.0.0.0", null)]
         [InlineData("Version", "1.0.0", "1.0.0.0", "1.0.0.0", null)]
+        [InlineData("Version", null, "2016.2", "2016.2", null)]
         internal async void ProjectFileProperties_WithInterception_SetEvalutedPropertyAsync(string propertyName, string existingPropertyValue, string propertyValueToSet, string expectedValue, Type interceptingProviderType)
         {
             var interceptingProvider = interceptingProviderType != null ?

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/AssemblyVersionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/AssemblyVersionValueProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
                 return s_DefaultAssemblyVersion;
             }
 
-            return new Version(defaultVersion.Major, defaultVersion.Minor, defaultVersion.Build, revision: 0);
+            return new Version(defaultVersion.Major, defaultVersion.Minor, Math.Max(defaultVersion.Build, 0), revision: Math.Max(defaultVersion.Revision, 0));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/FileVersionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/FileVersionValueProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
                 return s_DefaultFileVersion;
             }
 
-            return new Version(defaultVersion.Major, defaultVersion.Minor, defaultVersion.Build, revision: 0);
+            return new Version(defaultVersion.Major, defaultVersion.Minor, Math.Max(defaultVersion.Build, 0), revision: Math.Max(defaultVersion.Revision, 0));
         }
     }
 }


### PR DESCRIPTION
… for a version string with only 2 fields (e.g. 1.0)

**Customer scenario**

Package property page fails to load due to an Argument exception when the Version property in the project file has less than 3 fields (e.g. 1.0)

**Bugs this fixes:**

Fixes VSO #[382040](https://devdiv.visualstudio.com/DevDiv/_workitems/index?_a=edit&id=382040&triage=true)

**Workarounds, if any**

Ensure the version field has at least 3 fields.

**Risk**

Low risk, we are just defaulting to 0 for non-existent fields.

**Performance impact**

None

**Is this a regression from a previous update?**

No, package property page was added very recently.

**Root cause analysis:**

 Version.TryParse succeeds for version string with 2 fields, but the parsed version has a negative value for unspecified fields. Subsequently, we try to new up a Version with the individual fields, and this throws an ArgumentException.

**How was the bug found?**

Vsfeedback