### PR TITLE
Ensure that we aquire the lock for LanguageService's AggregeateWorksp…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -144,6 +144,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         private JoinableTask<T> ExecuteWithinLockAsync<T>(Func<Task<T>> task)
         {
+            // We need to request the lock within a joinable task to ensure that if we are blocking the UI
+            // thread (i.e. when CPS is draining critical tasks on the UI thread and is waiting on this task),
+            // and the lock is already held by another task requesting UI thread access, we don't reach a deadlock.
             return JoinableFactory.RunAsync(async delegate
             {
                 using (JoinableCollection.Join())
@@ -156,6 +159,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         private JoinableTask ExecuteWithinLockAsync(Func<Task> task)
         {
+            // We need to request the lock within a joinable task to ensure that if we are blocking the UI
+            // thread (i.e. when CPS is draining critical tasks on the UI thread and is waiting on this task),
+            // and the lock is already held by another task requesting UI thread access, we don't reach a deadlock.
             return JoinableFactory.RunAsync(async delegate
             {
                 using (JoinableCollection.Join())


### PR DESCRIPTION
…aceProject creation using a JoinableTaskFactory.

See [this comment](https://github.com/dotnet/roslyn-project-system/issues/1518#issuecomment-278784242) from @lifengl for details on possible causes of deadlock when not using the JTF and his recommended fix, which this PR implements.

**Customer scenario**

VS might occasionally deadlock if user tries to unload the project/solution while the LanguageService is attempting to create a new Roslyn workspace project context.

**Bugs this fixes:**

Fixes #1518

**Workarounds, if any**

None.

**Risk**

Low. We are following the recommendation from CPS team to use JoinableTaskFactory/JoinableTaskCollection to create a joinable task within which to aquire the lock.

**Performance impact**

Low.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

This is a race condition.

**How was the bug found?**

Ad hoc testing