### PR TITLE
Avoid searching SDK references in DTAR

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/Reference3Factory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/Reference3Factory.cs
@@ -16,7 +16,7 @@ namespace VSLangProj80
             return mock.Object;
         }
 
-        public static Reference3 CreateAssemblyReference(string name, string version = null, string path = null, prjReferenceType referenceType = prjReferenceType.prjReferenceTypeAssembly)
+        public static Reference3 CreateAssemblyReference(string name, string version = null, string path = null, prjReferenceType type = prjReferenceType.prjReferenceTypeAssembly, __PROJECTREFERENCETYPE refType = __PROJECTREFERENCETYPE.PROJREFTYPE_ASSEMBLY)
         {
             var mock = new Mock<Reference3>();
             mock.SetupGet(r => r.Name)
@@ -32,7 +32,10 @@ namespace VSLangProj80
                 .Returns(path != null);
 
             mock.SetupGet(r => r.Type)
-                .Returns(referenceType);
+                .Returns(type);
+
+            mock.SetupGet(r => r.RefType)
+              .Returns((uint)refType);
 
             return mock.Object;            
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/References/DesignTimeAssemblyResolutionTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/References/DesignTimeAssemblyResolutionTests.cs
@@ -3,6 +3,7 @@
 using EnvDTE;
 using Microsoft.VisualStudio.Shell.Interop;
 using VSLangProj;
+using VSLangProj110;
 using VSLangProj80;
 using Xunit;
 
@@ -164,9 +165,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         }
 
         [Fact]
-        public void ResolveAssemblyPathInTargetFx_NonAssembly_SetsResolvedAssemblyPathsToZero()
+        public void ResolveAssemblyPathInTargetFx_ComReference_SetsResolvedAssemblyPathsToZero()
         {   
-            var reference = Reference3Factory.CreateAssemblyReference("mscorlib", "1.0.0.0", referenceType: prjReferenceType.prjReferenceTypeActiveX);
+            var reference = Reference3Factory.CreateAssemblyReference("mscorlib", "1.0.0.0", type: prjReferenceType.prjReferenceTypeActiveX, refType:__PROJECTREFERENCETYPE.PROJREFTYPE_ACTIVEX);
+
+            var resolution = CreateInstance(reference);
+
+            var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { "mscorlib" }, 1, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
+
+            Assert.Equal(VSConstants.S_OK, result);
+            Assert.Equal(0u, resolvedAssemblyPaths);
+        }
+
+        [Fact]
+        public void ResolveAssemblyPathInTargetFx_SdkReference_SetsResolvedAssemblyPathsToZero()
+        {
+            // SDKs say they are "assemblies" for Reference.Type, but SDK for Reference.RefType
+            var reference = Reference3Factory.CreateAssemblyReference("mscorlib", "1.0.0.0", type: prjReferenceType.prjReferenceTypeAssembly, refType: (__PROJECTREFERENCETYPE)__PROJECTREFERENCETYPE2.PROJREFTYPE_SDK);
 
             var resolution = CreateInstance(reference);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
@@ -134,7 +134,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
                 foreach (Reference3 reference in project.References.OfType<Reference3>())
                 {
                     // We only want resolved assembly references
-                    if (reference.Type == prjReferenceType.prjReferenceTypeAssembly && reference.Resolved)
+                    if (reference.RefType == (uint)__PROJECTREFERENCETYPE.PROJREFTYPE_ASSEMBLY && reference.Resolved)
                     {
                         resolvedReferences[reference.Name] = new ResolvedReference(reference.Path, TryParseVersionOrNull(reference.Version));
                     }


### PR DESCRIPTION
Avoid searching SDK references in DTAR

SDK references return "assembly" as their Reference.Type for compatibility reasons. We shouldn't be looking at them as we're only looking for assemblies.

Hit this as part of: https://github.com/dotnet/roslyn-project-system/issues/1555.