### PR TITLE
Don't register duplicate CPS subscriptions for same project configura…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -137,7 +137,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             if (previousProjectContext != newProjectContext)
             {
                 // Add subscriptions for the new configured projects in the new project context.
-                AddSubscriptions(newProjectContext);
+                await AddSubscriptionsAsync(newProjectContext).ConfigureAwait(false);
             }
         }
 
@@ -238,9 +238,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             });
         }
 
-        private void AddSubscriptions(AggregateWorkspaceProjectContext newProjectContext)
+        private async Task AddSubscriptionsAsync(AggregateWorkspaceProjectContext newProjectContext)
         {
             Requires.NotNull(newProjectContext, nameof(newProjectContext));
+
+            await _commonServices.ThreadingService.SwitchToUIThread();
 
             using (_tasksService.LoadedProject())
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             {
                 var watchedEvaluationRules = GetWatchedRules(RuleHandlerType.Evaluation);
                 var watchedDesignTimeBuildRules = GetWatchedRules(RuleHandlerType.DesignTimeBuild);
-                
+
                 _designTimeBuildSubscriptionLinks.Add(_activeConfiguredProjectSubscriptionService.JointRuleSource.SourceBlock.LinkTo(
                   new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(e => OnProjectChangedAsync(e, RuleHandlerType.DesignTimeBuild)),
                   ruleNames: watchedDesignTimeBuildRules.Union(watchedEvaluationRules), suppressVersionOnlyUpdates: true));
@@ -246,7 +246,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             {
                 var watchedEvaluationRules = GetWatchedRules(RuleHandlerType.Evaluation);
                 var watchedDesignTimeBuildRules = GetWatchedRules(RuleHandlerType.DesignTimeBuild);
-                
+
                 foreach (var configuredProject in newProjectContext.InnerConfiguredProjects)
                 {
                     if (_projectConfigurationsWithSubscriptions.Contains(configuredProject.ProjectConfiguration))


### PR DESCRIPTION
…tion.


**Customer scenario**

VS crashes with ArgumentException on opening dotnet core solutions with projects that have additional files.

**Bugs this fixes:**

Fixes #1563

**Workarounds, if any**

None.

**Risk**

Low risk.
We sometimes ended up with duplicate CPS subscriptions for same configured project, causing us to attempt to add duplicate items to the same workspace project in the langauge service and throwing an ArgumentException. Fix is to keep track of project configurations which have already subscribed.

**Performance impact**

Low

**Is this a regression from a previous update?**

Yes. Even though we always registered duplicate subscriptions and I can see the same ArgumentException under the debugger on older builds, the exception was getting swallowed up the stack and not crashing VS. My recent PR to move the Language service to JTF causes this code to now execute in a joinable task, and the exception goes unhandled, crashing VS.

**Root cause analysis:**

Noted above.

**How was the bug found?**

Dogfooding.