### PR TITLE
Fix for 1580 stack overflow crash during search

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProvider.cs
@@ -836,37 +836,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             var partialValues = new List<GraphNodeId>
             {
-                GraphNodeId.GetPartial(CodeGraphNodeIdName.Assembly,
-                                                     new Uri(projectPath, UriKind.RelativeOrAbsolute))
+                GraphNodeId.GetPartial(CodeGraphNodeIdName.Assembly, new Uri(projectPath, UriKind.RelativeOrAbsolute))
             };
 
-            if (nodeInfo.Flags.Contains(DependencyNode.GenericDependencyFlags))
+            var projectFolder = Path.GetDirectoryName(projectPath)?.ToLowerInvariant();
+            if (nodeInfo.Flags.Contains(DependencyNode.CustomItemSpec))
             {
-                var projectFolder = Path.GetDirectoryName(projectPath)?.ToLowerInvariant();
-                if (nodeInfo.Flags.Contains(DependencyNode.CustomItemSpec))
+                if (nodeInfo.Name != null)
                 {
-                    if (nodeInfo.Name != null)
-                    {
-                        partialValues.Add(GraphNodeId.GetPartial(
-                            CodeGraphNodeIdName.File,
-                            new Uri(Path.Combine(projectFolder, nodeInfo.Name.ToLowerInvariant()),
-                            UriKind.RelativeOrAbsolute)));
-                    }
-                }
-                else
-                {
-                    var fullItemSpecPath = MakeRooted(projectFolder, nodeInfo.Id.ItemSpec);
-                    if (!string.IsNullOrEmpty(fullItemSpecPath))
-                    {
-                        partialValues.Add(GraphNodeId.GetPartial(CodeGraphNodeIdName.File,
-                            new Uri(fullItemSpecPath.ToLowerInvariant(), UriKind.RelativeOrAbsolute)));
-                    }
+                    partialValues.Add(GraphNodeId.GetPartial(
+                        CodeGraphNodeIdName.File,
+                        new Uri(Path.Combine(projectFolder, nodeInfo.Name.ToLowerInvariant()),
+                        UriKind.RelativeOrAbsolute)));
                 }
             }
             else
             {
-                partialValues.Add(GraphNodeId.GetPartial(CodeGraphNodeIdName.File,
-                    new Uri(nodeInfo.Id.ToString().ToLowerInvariant(), UriKind.RelativeOrAbsolute)));
+                var fullItemSpecPath = MakeRooted(projectFolder, nodeInfo.Id.ItemSpec);
+                if (!string.IsNullOrEmpty(fullItemSpecPath))
+                {
+                    partialValues.Add(GraphNodeId.GetPartial(CodeGraphNodeIdName.File,
+                        new Uri(fullItemSpecPath.ToLowerInvariant(), UriKind.RelativeOrAbsolute)));
+                }
             }
 
             return GraphNodeId.GetNested(partialValues.ToArray());


### PR DESCRIPTION
**Customer scenario**

Search for web packages provided by external provider ended up with stackoverflow crash

**Bugs this fixes:**

https://github.com/dotnet/roslyn-project-system/issues/1580

**Workarounds, if any**

N/A

**Risk**

Minimal

**Performance impact**

Nona

**Is this a regression from a previous update?**

Yes

**Root cause analysis:**

We did not match correctly results returned form external provider and returned null when progression asked to find a tree node. By some reason progression kept asking us again and again which resulted in stack overflow. Fix is on our side, however possibility of overflow still hidden in progression if consumers don't do things right..

**How was the bug found?**

Internal dogfooding.