### PR TITLE
F5 framework selector

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
@@ -43,6 +43,7 @@
   <ItemGroup>
     <Compile Include="Mocks\ConfiguredProjectFactory.cs" />
     <Compile Include="Mocks\DispatchThread.cs" />
+    <Compile Include="Mocks\IActiveConfiguredProjectsProviderFactory.cs" />
     <Compile Include="Mocks\IFolderManagerFactory.cs" />
     <Compile Include="Mocks\IProjectLockServiceFactory.cs" />
     <Compile Include="Mocks\ActiveConfiguredProjectFactory.cs" />
@@ -87,6 +88,7 @@
     <Compile Include="OrderPrecedenceImportCollectionExtensions.cs" />
     <Compile Include="ProjectSystem\AppDesignerFolderProjectTreePropertiesProviderTests.cs" />
     <Compile Include="ProjectSystem\Build\TargetFrameworkGlobalBuildPropertyProviderTests.cs" />
+    <Compile Include="ProjectSystem\Debug\ActiveDebugFrameworkServicesTests.cs" />
     <Compile Include="ProjectSystem\Debug\LaunchProfileDataTests.cs" />
     <Compile Include="ProjectSystem\Debug\LaunchProfileTests.cs" />
     <Compile Include="ProjectSystem\Debug\DebugTokenReplacerTests.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/DispatchThread.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/DispatchThread.cs
@@ -27,8 +27,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
                     unused.UnhandledException += new DispatcherUnhandledExceptionEventHandler(OnUnhandledException);
 
                     resetEvent.Set();
-
-                    Dispatcher.Run();
+                    try
+                    {
+                        Dispatcher.Run();
+                    }
+                    catch(ThreadAbortException)
+                    {
+                    }
                 });
 
                 _thread.Name = GetType().FullName;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveConfiguredProjectsProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveConfiguredProjectsProviderFactory.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    internal class IActiveConfiguredProjectsProviderFactory
+    {
+        Mock<IActiveConfiguredProjectsProvider> _mock;
+        public IActiveConfiguredProjectsProviderFactory(MockBehavior mockBehavior = MockBehavior.Strict)
+        {
+            _mock = new Mock<IActiveConfiguredProjectsProvider>(mockBehavior);
+        }
+
+        public IActiveConfiguredProjectsProvider Object => _mock.Object;
+
+        public void Verify()
+        {
+            _mock.Verify();
+        }
+
+        public IActiveConfiguredProjectsProviderFactory ImplementGetActiveConfiguredProjectsMapAsync(ImmutableDictionary<string, ConfiguredProject> configuredProjects) 
+        {
+            _mock.Setup(x => x.GetActiveConfiguredProjectsMapAsync())
+                              .Returns(Task.FromResult(configuredProjects));
+            return this;
+        }
+
+        public IActiveConfiguredProjectsProviderFactory ImplementGetActiveConfiguredProjectsAsync(ImmutableArray<ConfiguredProject> configuredProjects) 
+        {
+            _mock.Setup(x => x.GetActiveConfiguredProjectsAsync())
+                              .Returns(Task.FromResult(configuredProjects));
+            return this;
+        }
+
+        public IActiveConfiguredProjectsProviderFactory ImplementGetProjectFrameworksAsync(ImmutableArray<ProjectConfiguration> projectConfigurations) 
+        {
+            _mock.Setup(x => x.GetActiveProjectConfigurationsAsync())
+                              .Returns(Task.FromResult(projectConfigurations));
+            return this;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/ActiveDebugFrameworkServicesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/ActiveDebugFrameworkServicesTests.cs
@@ -1,0 +1,236 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+{
+    [ProjectSystemTrait]
+    public class ActiveDebugFrameworkServicesTests
+    {
+        [Theory]
+        [InlineData("netcoreapp1.0;net462", new string[] {"netcoreapp1.0", "net462"})]
+        [InlineData("net461;netcoreapp1.0;net45;net462", new string[] {"net461", "netcoreapp1.0", "net45", "net462"})]
+        public async Task GetProjectFrameworksAsync_ReturnsFrameworksInCorrectOrder(string frameworks, string[] expectedOrder)
+        {
+            var project = UnconfiguredProjectFactory.Create();
+            var data = new PropertyPageData() {
+                Category = ConfigurationGeneral.SchemaName,
+                PropertyName = ConfigurationGeneral.TargetFrameworksProperty,
+                Value = frameworks
+            };
+
+            var projectProperties = ProjectPropertiesFactory.Create(project, data);
+            
+            var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(projectProperties: projectProperties);
+
+            var debugFrameworkSvcs = new ActiveDebugFrameworkServices(null, commonServices);
+            var result = await debugFrameworkSvcs.GetProjectFrameworksAsync();
+            
+            Assert.Equal(expectedOrder.Length, result.Count);
+            for(int i = 0; i < result.Count; i++)
+            {
+                Assert.Equal(expectedOrder[i], result[i]);
+            }
+        }
+
+        [Theory]
+        [InlineData("netcoreapp1.0")]
+        [InlineData("net461")]
+        public async Task GetActiveDebuggingFrameworkPropertyAsync_ReturnsFrameworkValue(string framework)
+        {
+            var project = UnconfiguredProjectFactory.Create();
+            var data = new PropertyPageData() {
+                Category = ProjectDebugger.SchemaName,
+                PropertyName = ProjectDebugger.ActiveDebugFrameworkProperty,
+                Value = framework
+            };
+            
+            var projectProperties = ProjectPropertiesFactory.Create(project, data);
+            
+            var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(projectProperties: projectProperties);
+
+            var debugFrameworkSvcs = new ActiveDebugFrameworkServices(null, commonServices);
+            var result = await debugFrameworkSvcs.GetActiveDebuggingFrameworkPropertyAsync();
+            
+            Assert.Equal(framework, result);
+        }
+
+        [Fact]
+        public async Task SetActiveDebuggingFrameworkPropertyAsync_SetsValue()
+        {
+            var project = UnconfiguredProjectFactory.Create();
+            var data = new PropertyPageData() {
+                Category = ProjectDebugger.SchemaName,
+                PropertyName = ProjectDebugger.ActiveDebugFrameworkProperty,
+                Value = "FrameworkOne"
+            };
+
+            var projectProperties = ProjectPropertiesFactory.Create(project, data);
+            
+            var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(projectProperties: projectProperties);
+
+            var debugFrameworkSvcs = new ActiveDebugFrameworkServices(null, commonServices);
+            await debugFrameworkSvcs.SetActiveDebuggingFrameworkPropertyAsync("netcoreapp1.0");
+        }
+
+        [Theory]
+        [InlineData("netcoreapp1.0", "netcoreapp1.0")]
+        [InlineData("net461", "net461")]
+        [InlineData("", "net462")]
+        [InlineData("someframwork", "net462")]
+        public async Task GetConfiguredProjectForActiveFrameworkAsync_ReturnsCorrectProject(string framework, string selectedConfigFramework)
+        {
+            var project = UnconfiguredProjectFactory.Create();
+            var data = new PropertyPageData() {
+                Category = ProjectDebugger.SchemaName,
+                PropertyName = ProjectDebugger.ActiveDebugFrameworkProperty,
+                Value = framework
+            };
+            var data2 = new PropertyPageData() {
+                Category = ConfigurationGeneral.SchemaName,
+                PropertyName = ConfigurationGeneral.TargetFrameworksProperty,
+                Value = "net462;net461;netcoreapp1.0"
+            };
+
+            var projects = ImmutableDictionary<string, ConfiguredProject>.Empty
+                            .Add("net461", ConfiguredProjectFactory.Create(null, new StandardProjectConfiguration("Debug|AnyCPU|net461", Empty.PropertiesMap
+                                                                                    .Add("Configuration", "Debug")
+                                                                                    .Add("Platform", "AnyCPU")
+                                                                                    .Add("TargetFramework", "net461"))))
+                            .Add("netcoreapp1.0", ConfiguredProjectFactory.Create(null, new StandardProjectConfiguration("Debug|AnyCPU|netcoreapp1.0", Empty.PropertiesMap
+                                                                                    .Add("Configuration", "Debug")
+                                                                                    .Add("Platform", "AnyCPU")
+                                                                                    .Add("TargetFramework", "netcoreapp1.0"))))
+                            .Add("net462", ConfiguredProjectFactory.Create(null, new StandardProjectConfiguration("Debug|AnyCPU|net462", Empty.PropertiesMap
+                                                                                    .Add("Configuration", "Debug")
+                                                                                    .Add("Platform", "AnyCPU")
+                                                                                    .Add("TargetFramework", "net462"))));
+                    
+            var projectProperties = ProjectPropertiesFactory.Create(project, data, data2);
+            var projectConfgProvider = new IActiveConfiguredProjectsProviderFactory(MockBehavior.Strict)
+                                       .ImplementGetActiveConfiguredProjectsMapAsync(projects);
+            
+            var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(projectProperties: projectProperties);
+
+            var debugFrameworkSvcs = new ActiveDebugFrameworkServices(projectConfgProvider.Object, commonServices);
+            var activeConfiguredProject = await debugFrameworkSvcs.GetConfiguredProjectForActiveFrameworkAsync();
+            Assert.Equal(selectedConfigFramework,  activeConfiguredProject.ProjectConfiguration.Dimensions.GetValueOrDefault("TargetFramework"));
+
+        }
+
+        //[Fact]
+        //public void ExecCommand_HandleNullProject()
+        //{
+        //    var startupHelper = new Mock<IStartupProjectHelper>();
+        //                        startupHelper.Setup(x => x.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
+        //                                     .Returns((IActiveDebugFrameworkServices)null);
+
+        //    var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+        //    Assert.Equal(false, command.ExecCommand(0, EventArgs.Empty));
+        //    startupHelper.Verify();
+        //}
+
+        //[Fact]
+        //public void QueryStatus_HandleNullProject()
+        //{
+        //    var startupHelper = new Mock<IStartupProjectHelper>();
+        //                        startupHelper.Setup(x => x.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
+        //                                     .Returns((IActiveDebugFrameworkServices)null);
+
+        //    var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+        //    Assert.Equal(false, command.QueryStatusCommand(0, EventArgs.Empty));
+        //    startupHelper.Verify();
+        //}
+
+        //[Fact]
+        //public void QueryStatus_NullFrameworks()
+        //{
+        //    var activeDebugFrameworkSvcs = new IActiveDebugFrameworkServicesFactory()
+        //                                       .ImplementGetProjectFrameworksAsync(null);
+        //    var startupHelper = new Mock<IStartupProjectHelper>();
+        //    startupHelper.Setup(x => x.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
+        //                 .Returns(activeDebugFrameworkSvcs.Object);
+
+        //    var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+        //    Assert.True(command.QueryStatusCommand(0, EventArgs.Empty));
+        //    Assert.False(command.Visible);
+        //    Assert.Equal("", command.Text);
+        //    Assert.False(command.Checked);
+        //    Assert.False(command.Enabled);
+
+        //    startupHelper.Verify();
+        //    activeDebugFrameworkSvcs.Verify();
+        //}
+
+        //[Theory]
+        //[InlineData(false)]
+        //[InlineData(true)]
+        //public void QueryStatus_LessThan2Frameworks(bool createList)
+        //{
+        //    var activeDebugFrameworkSvcs = new IActiveDebugFrameworkServicesFactory()
+        //                                       .ImplementGetProjectFrameworksAsync(createList? new List<string>(){"netcoreapp1.0"} : null);
+        //    var startupHelper = new Mock<IStartupProjectHelper>();
+        //    startupHelper.Setup(x => x.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
+        //                 .Returns(activeDebugFrameworkSvcs.Object);
+
+        //    var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+        //    Assert.True(command.QueryStatusCommand(0, EventArgs.Empty));
+        //    Assert.False(command.Visible);
+        //    Assert.Equal("", command.Text);
+        //    Assert.False(command.Checked);
+        //    Assert.False(command.Enabled);
+
+        //    startupHelper.Verify();
+        //    activeDebugFrameworkSvcs.Verify();
+        //}
+
+        //[Theory]
+        //[InlineData(0, "netcoreapp1.0")]
+        //[InlineData(1, "net461")]
+        //[InlineData(2, "net461")]
+        //[InlineData(2, "net462")]
+        //public void QueryStatus_TestValidFrameworkIndexes(int cmdIndex, string activeFramework)
+        //{
+        //    var frameworks = new List<string>(){"netcoreapp1.0", "net461", "net462"};
+
+        //    var activeDebugFrameworkSvcs = new IActiveDebugFrameworkServicesFactory()
+        //                                       .ImplementGetProjectFrameworksAsync(frameworks)
+        //                                       .ImplementGetActiveDebuggingFrameworkPropertyAsync(activeFramework);
+
+        //    var startupHelper = new Mock<IStartupProjectHelper>();
+        //    startupHelper.Setup(x => x.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
+        //                 .Returns(activeDebugFrameworkSvcs.Object);
+
+        //    var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+        //    Assert.True(command.QueryStatusCommand(cmdIndex, EventArgs.Empty));
+        //    Assert.True(command.Visible);
+        //    Assert.Equal(frameworks[cmdIndex], command.Text);
+        //    Assert.Equal(frameworks[cmdIndex] == activeFramework, command.Checked);
+        //    Assert.True(command.Enabled);
+
+        //    startupHelper.Verify();
+        //    activeDebugFrameworkSvcs.Verify();
+        //}
+
+        //class TestDebugFrameworksDynamicMenuCommand : DebugFrameworksDynamicMenuCommand
+        //{
+        //    public TestDebugFrameworksDynamicMenuCommand(IStartupProjectHelper startupHelper)
+        //        : base(startupHelper)
+        //    {
+        //    }
+
+        //    protected override void ExecuteSynchronously(Func<Task> asyncFunction)
+        //    {
+        //        asyncFunction.Invoke().Wait();
+        //    }
+        //}
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/DebugTokenReplacerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/DebugTokenReplacerTests.cs
@@ -40,8 +40,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             IUnconfiguredProjectCommonServices services = IUnconfiguredProjectCommonServicesFactory.Create();
 
+            IActiveDebugFrameworkServices activeDebugFramework = Mock.Of<IActiveDebugFrameworkServices>();
 
-            var replacer = new DebugTokenReplacerUnderTest(IUnconfiguredProjectCommonServicesFactory.Create(), _envHelper.Object);
+            var replacer = new DebugTokenReplacerUnderTest(IUnconfiguredProjectCommonServicesFactory.Create(), _envHelper.Object, activeDebugFramework);
 
             // Tests all the possible replacements. env3 tests that enviroment vars are resolved before msbuild tokens
             var launchProfile = new LaunchProfile()
@@ -85,7 +86,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             IUnconfiguredProjectCommonServices services = IUnconfiguredProjectCommonServicesFactory.Create();
 
-            var replacer = new DebugTokenReplacerUnderTest(IUnconfiguredProjectCommonServicesFactory.Create(), _envHelper.Object);
+            IActiveDebugFrameworkServices activeDebugFramework = Mock.Of<IActiveDebugFrameworkServices>();
+            var replacer = new DebugTokenReplacerUnderTest(IUnconfiguredProjectCommonServicesFactory.Create(), _envHelper.Object, activeDebugFramework);
 
             // Test msbuild vars
             string result = await replacer.ReplaceTokensInStringAsync(input, expandEnvVars);
@@ -95,15 +97,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
     internal class DebugTokenReplacerUnderTest : DebugTokenReplacer
     {
-        public DebugTokenReplacerUnderTest(IUnconfiguredProjectCommonServices commonServices, IEnvironmentHelper envHelper)
-            : base(commonServices, envHelper)
+        public DebugTokenReplacerUnderTest(IUnconfiguredProjectCommonServices commonServices, IEnvironmentHelper envHelper, IActiveDebugFrameworkServices debugFramework)
+            : base(commonServices, envHelper, debugFramework)
         {
 
         }
 
-        protected override IProjectReadAccess AccessProject()
+        protected override Task<IProjectReadAccess> AccessProject()
         {
-            return new TestProjectReadAccessor();
+            return Task.FromResult((IProjectReadAccess)new TestProjectReadAccessor());
         }
 
         class TestProjectReadAccessor : IProjectReadAccess

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Mocks\ITextBufferStateListenerFactory.cs" />
     <Compile Include="Mocks\ITextDocumentFactory.cs" />
     <Compile Include="Mocks\ITextDocumentFactoryServiceFactory.cs" />
+    <Compile Include="Mocks\IActiveDebugFrameworkServicesFactory.cs" />
     <Compile Include="Mocks\IVsUpdateSolutionEventsFactory.cs" />
     <Compile Include="Mocks\IVsSolutionBuildManager2Factory.cs" />
     <Compile Include="Mocks\IVsEditorAdaptersFactoryServiceFactory.cs" />
@@ -131,6 +132,8 @@
     <Compile Include="ProjectSystem\VS\Generators\SingleFileGeneratorFactoryAggregatorTests.cs" />
     <Compile Include="ProjectSystem\VS\Generators\RemoteCodeGenerationRegistrationAttributeTests.cs" />
     <Compile Include="ProjectSystem\VS\Input\Commands\AbstractGenerateNuGetPackageCommandTests.cs" />
+    <Compile Include="ProjectSystem\VS\Input\Commands\DebugFrameworksDynamicMenuCommandTests.cs" />
+    <Compile Include="ProjectSystem\VS\Input\Commands\DebugFrameworksMenuTextUpdaterTests.cs" />
     <Compile Include="ProjectSystem\VS\Input\Commands\GenerateNuGetPackageProjectContextMenuCommandTests.cs" />
     <Compile Include="ProjectSystem\VS\Input\Commands\GenerateNuGetPackageTopLevelBuildMenuCommandTests.cs" />
     <Compile Include="ProjectSystem\VS\Input\Commands\EditProjectFileCommandTests.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveDebugFrameworkServicesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveDebugFrameworkServicesFactory.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    internal class IActiveDebugFrameworkServicesFactory
+    {
+        Mock<IActiveDebugFrameworkServices> _mock;
+        public IActiveDebugFrameworkServicesFactory(MockBehavior mockBehavior = MockBehavior.Strict)
+        {
+            _mock = new Mock<IActiveDebugFrameworkServices>(mockBehavior);
+        }
+
+        public IActiveDebugFrameworkServices Object => _mock.Object;
+
+        public void Verify()
+        {
+            _mock.Verify();
+        }
+
+        public IActiveDebugFrameworkServicesFactory ImplementGetActiveDebuggingFrameworkPropertyAsync(string activeFramework) 
+        {
+            _mock.Setup(x => x.GetActiveDebuggingFrameworkPropertyAsync())
+                              .Returns(Task.FromResult(activeFramework));
+            return this;
+        }
+
+        public IActiveDebugFrameworkServicesFactory ImplementGetConfiguredProjectForActiveFrameworkAsync(ConfiguredProject project) 
+        {
+            _mock.Setup(x => x.GetConfiguredProjectForActiveFrameworkAsync())
+                              .Returns(Task.FromResult(project));
+            return this;
+        }
+
+        public IActiveDebugFrameworkServicesFactory ImplementGetProjectFrameworksAsync(List<string> frameworsks) 
+        {
+            _mock.Setup(x => x.GetProjectFrameworksAsync())
+                              .Returns(Task.FromResult(frameworsks));
+            return this;
+        }
+
+        public IActiveDebugFrameworkServicesFactory ImplementSetActiveDebuggingFrameworkPropertyAsync(string aciiveFramework) 
+        {
+            _mock.Setup(x => x.SetActiveDebuggingFrameworkPropertyAsync(aciiveFramework))
+                              .Returns(Task.CompletedTask);
+            return this;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
@@ -69,11 +69,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
                 o.Services == configuredProjectServices);
             _mockTokenReplace.Setup(s => s.ReplaceTokensInProfileAsync(It.IsAny<ILaunchProfile>())).Returns<ILaunchProfile>(p => Task.FromResult(p));
 
+            IActiveDebugFrameworkServices activeDebugFramework = Mock.Of<IActiveDebugFrameworkServices>( o =>
+                o.GetConfiguredProjectForActiveFrameworkAsync() == Task.FromResult(configuredProject));
             var debugProvider = new ConsoleDebugTargetsProvider(
                                             configuredProject,
                                            _mockTokenReplace.Object,
                                            _mockFS,
                                            _mockEnvironment.Object,
+                                           activeDebugFramework,
                                            projectProperties);
             return debugProvider;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommandTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Debug;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommandTests.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+{
+    [ProjectSystemTrait]
+    public class DebugFrameworksDynamicMenuCommandTests
+    {
+        [Theory]
+        [InlineData(-1, false)]
+        [InlineData(2, false)]
+        [InlineData(0, true)]
+        [InlineData(1, true)]
+        public void ExecCommand_VerifyCorrectFrameworkSet(int cmdIndex, bool expected)
+        {
+            var frameworks = new List<string>(){"net461", "netcoreapp1.0"};
+            var activeDebugFrameworkSvcs = new IActiveDebugFrameworkServicesFactory()
+                                               .ImplementGetActiveDebuggingFrameworkPropertyAsync(null)
+                                               .ImplementGetProjectFrameworksAsync(frameworks);
+            if(expected)
+            {
+                activeDebugFrameworkSvcs.ImplementSetActiveDebuggingFrameworkPropertyAsync(frameworks[cmdIndex]);
+            }
+            var startupHelper = new Mock<IStartupProjectHelper>();
+                                startupHelper.Setup(x => x.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
+                                             .Returns(activeDebugFrameworkSvcs.Object);
+
+            var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+            Assert.Equal(expected, command.ExecCommand(cmdIndex, EventArgs.Empty));
+
+            startupHelper.Verify();
+            activeDebugFrameworkSvcs.Verify();
+        }
+
+        [Fact]
+        public void ExecCommand_HandleNullProject()
+        {
+            var startupHelper = new Mock<IStartupProjectHelper>();
+                                startupHelper.Setup(x => x.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
+                                             .Returns((IActiveDebugFrameworkServices)null);
+
+            var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+            Assert.Equal(false, command.ExecCommand(0, EventArgs.Empty));
+            startupHelper.Verify();
+        }
+
+        [Fact]
+        public void QueryStatus_HandleNullProject()
+        {
+            var startupHelper = new Mock<IStartupProjectHelper>();
+                                startupHelper.Setup(x => x.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
+                                             .Returns((IActiveDebugFrameworkServices)null);
+
+            var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+            Assert.Equal(false, command.QueryStatusCommand(0, EventArgs.Empty));
+            startupHelper.Verify();
+        }
+
+        [Fact]
+        public void QueryStatus_NullFrameworks()
+        {
+            var activeDebugFrameworkSvcs = new IActiveDebugFrameworkServicesFactory()
+                                               .ImplementGetProjectFrameworksAsync(null);
+            var startupHelper = new Mock<IStartupProjectHelper>();
+            startupHelper.Setup(x => x.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
+                         .Returns(activeDebugFrameworkSvcs.Object);
+
+            var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+            Assert.True(command.QueryStatusCommand(0, EventArgs.Empty));
+            Assert.False(command.Visible);
+            Assert.Equal("", command.Text);
+            Assert.False(command.Checked);
+            Assert.False(command.Enabled);
+
+            startupHelper.Verify();
+            activeDebugFrameworkSvcs.Verify();
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void QueryStatus_LessThan2Frameworks(bool createList)
+        {
+            var activeDebugFrameworkSvcs = new IActiveDebugFrameworkServicesFactory()
+                                               .ImplementGetProjectFrameworksAsync(createList? new List<string>(){"netcoreapp1.0"} : null);
+            var startupHelper = new Mock<IStartupProjectHelper>();
+            startupHelper.Setup(x => x.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
+                         .Returns(activeDebugFrameworkSvcs.Object);
+
+            var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+            Assert.True(command.QueryStatusCommand(0, EventArgs.Empty));
+            Assert.False(command.Visible);
+            Assert.Equal("", command.Text);
+            Assert.False(command.Checked);
+            Assert.False(command.Enabled);
+
+            startupHelper.Verify();
+            activeDebugFrameworkSvcs.Verify();
+        }
+
+        [Theory]
+        [InlineData(0, "netcoreapp1.0")]
+        [InlineData(1, "net461")]
+        [InlineData(2, "net461")]
+        [InlineData(2, "net462")]
+        public void QueryStatus_TestValidFrameworkIndexes(int cmdIndex, string activeFramework)
+        {
+            var frameworks = new List<string>(){"netcoreapp1.0", "net461", "net462"};
+
+            var activeDebugFrameworkSvcs = new IActiveDebugFrameworkServicesFactory()
+                                               .ImplementGetProjectFrameworksAsync(frameworks)
+                                               .ImplementGetActiveDebuggingFrameworkPropertyAsync(activeFramework);
+
+            var startupHelper = new Mock<IStartupProjectHelper>();
+            startupHelper.Setup(x => x.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
+                         .Returns(activeDebugFrameworkSvcs.Object);
+
+            var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+            Assert.True(command.QueryStatusCommand(cmdIndex, EventArgs.Empty));
+            Assert.True(command.Visible);
+            Assert.Equal(frameworks[cmdIndex], command.Text);
+            Assert.Equal(frameworks[cmdIndex] == activeFramework, command.Checked);
+            Assert.True(command.Enabled);
+
+            startupHelper.Verify();
+            activeDebugFrameworkSvcs.Verify();
+        }
+
+        class TestDebugFrameworksDynamicMenuCommand : DebugFrameworksDynamicMenuCommand
+        {
+            public TestDebugFrameworksDynamicMenuCommand(IStartupProjectHelper startupHelper)
+                : base(startupHelper)
+            {
+            }
+
+            protected override void ExecuteSynchronously(Func<Task> asyncFunction)
+            {
+                asyncFunction.Invoke().Wait();
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdaterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdaterTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Debug;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdaterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdaterTests.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+{
+    [ProjectSystemTrait]
+    public class DebugFrameworkMenuTextUpdaterTests
+    {
+        [Fact]
+        public void Exec_DoesNothing()
+        {
+            var command = new DebugFrameworkPropertyMenuTextUpdater(null);
+            DebugFrameworkPropertyMenuTextUpdater.ExecHandler(command, EventArgs.Empty);
+            Assert.Equal(true, command.Visible);
+            Assert.Equal("", command.Text);
+            Assert.Equal(false, command.Checked);
+            Assert.Equal(true, command.Enabled);
+        }
+
+        [Fact]
+        public void QueryStatusTests_NoActiveProject()
+        {
+            var startupHelper = new Mock<IStartupProjectHelper>();
+                                startupHelper.Setup(x => x.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
+                                             .Returns((IActiveDebugFrameworkServices)null);
+
+            var command = new TestDebugFrameworkPropertyMenuTextUpdater(startupHelper.Object);
+            command.QueryStatus();
+            Assert.Equal(true, command.Visible);
+            Assert.Equal("", command.Text);
+            Assert.Equal(false, command.Checked);
+            Assert.Equal(true, command.Enabled);
+        }
+
+        [Fact]
+        public void QueryStatusTests_NullFrameworks()
+        {
+            var activeDebugFrameworkSvcs = new IActiveDebugFrameworkServicesFactory()
+                                               .ImplementGetActiveDebuggingFrameworkPropertyAsync(null)
+                                               .ImplementGetProjectFrameworksAsync(null);
+            var startupHelper = new Mock<IStartupProjectHelper>();
+                                startupHelper.Setup(x => x.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
+                                             .Returns(activeDebugFrameworkSvcs.Object);
+
+            var command = new TestDebugFrameworkPropertyMenuTextUpdater(startupHelper.Object);
+            command.QueryStatus();
+            Assert.Equal(true, command.Visible);
+            Assert.Equal("", command.Text);
+            Assert.Equal(false, command.Checked);
+            Assert.Equal(true, command.Enabled);
+        }
+
+        [Fact]
+        public void QueryStatusTests_FrameworksLessThan2()
+        {
+            var activeDebugFrameworkSvcs = new IActiveDebugFrameworkServicesFactory()
+                                               .ImplementGetActiveDebuggingFrameworkPropertyAsync(null)
+                                               .ImplementGetProjectFrameworksAsync(new List<string>(){"net45"});
+            var startupHelper = new Mock<IStartupProjectHelper>();
+                                startupHelper.Setup(x => x.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
+                                             .Returns(activeDebugFrameworkSvcs.Object);
+
+            var command = new TestDebugFrameworkPropertyMenuTextUpdater(startupHelper.Object);
+            command.QueryStatus();
+            Assert.Equal(true, command.Visible);
+            Assert.Equal("", command.Text);
+            Assert.Equal(false, command.Checked);
+            Assert.Equal(true, command.Enabled);
+        }
+
+        [Fact]
+        public void QueryStatusTests_FrameworkNoAciive()
+        {
+            var activeDebugFrameworkSvcs = new IActiveDebugFrameworkServicesFactory()
+                                               .ImplementGetActiveDebuggingFrameworkPropertyAsync(null)
+                                               .ImplementGetProjectFrameworksAsync(new List<string>(){"net461", "netcoreapp1.0"});
+            var startupHelper = new Mock<IStartupProjectHelper>();
+                                startupHelper.Setup(x => x.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
+                                             .Returns(activeDebugFrameworkSvcs.Object);
+
+            var command = new TestDebugFrameworkPropertyMenuTextUpdater(startupHelper.Object);
+            command.QueryStatus();
+            Assert.Equal(true, command.Visible);
+            Assert.Equal(string.Format(VSResources.DebugFrameworkMenuText, "net461"), command.Text);
+            Assert.Equal(false, command.Checked);
+            Assert.Equal(true, command.Enabled);
+        }
+        [Fact]
+        public void QueryStatusTests_FrameworkNoMatchingAciive()
+        {
+            var activeDebugFrameworkSvcs = new IActiveDebugFrameworkServicesFactory()
+                                               .ImplementGetActiveDebuggingFrameworkPropertyAsync("net45")
+                                               .ImplementGetProjectFrameworksAsync(new List<string>(){"net461", "netcoreapp1.0"});
+            var startupHelper = new Mock<IStartupProjectHelper>();
+                                startupHelper.Setup(x => x.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
+                                             .Returns(activeDebugFrameworkSvcs.Object);
+
+            var command = new TestDebugFrameworkPropertyMenuTextUpdater(startupHelper.Object);
+            command.QueryStatus();
+            Assert.Equal(true, command.Visible);
+            Assert.Equal(string.Format(VSResources.DebugFrameworkMenuText, "net461"), command.Text);
+            Assert.Equal(false, command.Checked);
+            Assert.Equal(true, command.Enabled);
+        }
+
+        [Fact]
+        public void QueryStatusTests_FrameworkValidAciive()
+        {
+            var activeDebugFrameworkSvcs = new IActiveDebugFrameworkServicesFactory()
+                                               .ImplementGetActiveDebuggingFrameworkPropertyAsync("netcoreapp1.0")
+                                               .ImplementGetProjectFrameworksAsync(new List<string>(){"net461", "netcoreapp1.0"});
+            var startupHelper = new Mock<IStartupProjectHelper>();
+                                startupHelper.Setup(x => x.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
+                                             .Returns(activeDebugFrameworkSvcs.Object);
+
+            var command = new TestDebugFrameworkPropertyMenuTextUpdater(startupHelper.Object);
+            command.QueryStatus();
+            Assert.Equal(true, command.Visible);
+            Assert.Equal(string.Format(VSResources.DebugFrameworkMenuText, "netcoreapp1.0"), command.Text);
+            Assert.Equal(false, command.Checked);
+            Assert.Equal(true, command.Enabled);
+        }
+
+        class TestDebugFrameworkPropertyMenuTextUpdater : DebugFrameworkPropertyMenuTextUpdater
+        {
+            public TestDebugFrameworkPropertyMenuTextUpdater(IStartupProjectHelper startupHelper)
+                : base(startupHelper)
+            {
+            }
+
+            protected override void ExecuteSynchronously(Func<Task> asyncFunction)
+            {
+                asyncFunction.Invoke().Wait();
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Menus.vsct
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Menus.vsct
@@ -43,12 +43,27 @@
   </Commands>
 
   <Commands package="PackageGuidString">
+    <Menus>
+      <!-- Debugging Framework menu added to debug controller -->
+      <Menu guid="guidManagedProjectSystemCommandSet" id="DebugTargetMenuDebugFrameworkMenu" priority="0x00F1" type="Menu">
+        <Parent guid="guidDebugTargetHandlerPackage" id="DebugTargetMenuControllerFooterGroup"/>
+        <CommandFlag>TextChanges</CommandFlag>
+        <Strings>
+            <ButtonText>Framework</ButtonText>
+        </Strings>
+      </Menu>
+    </Menus>
+
     <Groups>
       <Group guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJECT_EDITFILE" priority="0x0180">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_PROJNODE"/>
       </Group>
       <Group guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJECT_EDITFILE" priority="0x0180">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_MENU_PROJECT"/>
+      </Group>
+      <!-- Group added to the Debugging Framework Type menu on the debug controller -->
+      <Group guid="guidManagedProjectSystemCommandSet" id="DebugTargetMenuDebugFrameworkGroup" priority="0x0100">
+        <Parent guid="guidManagedProjectSystemCommandSet" id="DebugTargetMenuDebugFrameworkMenu"/>
       </Group>
     </Groups>
 
@@ -78,6 +93,18 @@
           <CommandName>GenerateNuGetPackageTopLevelBuild</CommandName>
         </Strings>
       </Button>
+
+      <Button guid="guidManagedProjectSystemCommandSet" id="cmdidDebugFrameworks" priority="0x0100" type="Button">
+        <Parent guid="guidManagedProjectSystemCommandSet" id="DebugTargetMenuDebugFrameworkGroup"/>
+        <CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DefaultDisabled</CommandFlag>
+        <CommandFlag>DynamicItemStart</CommandFlag>
+        <Strings>
+          <ButtonText>Framework</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
   </Commands>
 
@@ -88,6 +115,7 @@
     <GuidSymbol name="guidDebugTargetHandlerPackage" value="{6e87cfad-6c05-4adf-9cd7-3b7943875b7c}">
       <IDSymbol name="DebugTargetMenuControllerGroup" value="0x1000" />
       <IDSymbol name="DebugTargetMenuControllerFooterGroup" value="0x2000" />
+
     </GuidSymbol>
 
     <GuidSymbol name="guidManagedProjectSystemCommandSet" value="{568ABDF7-D522-474D-9EED-34B5E5095BA5}">
@@ -95,6 +123,9 @@
       <IDSymbol name="cmdidProjectDebugger" value="0x0100" />
       <IDSymbol name="cmdidGenerateNuGetPackageProjectContextMenu" value="0x2000" />
       <IDSymbol name="cmdidGenerateNuGetPackageTopLevelBuild" value="0x2001" />
+      <IDSymbol name="DebugTargetMenuDebugFrameworkMenu" value="0x3000" />
+      <IDSymbol name="DebugTargetMenuDebugFrameworkGroup" value="0x3001" />
+      <IDSymbol name="cmdidDebugFrameworks" value="0x3050" />        <!--needs space to grow-->
     </GuidSymbol>
   </Symbols>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -49,6 +49,11 @@
     <Compile Include="ProjectSystem\VS\Editor\TempFileTextBufferManager.cs" />
     <Compile Include="ProjectSystem\VS\EditAndContinue\EditAndContinueProvider.cs" />
     <Compile Include="ProjectSystem\VS\ExportProjectNodeComServiceAttribute.cs" />
+    <Compile Include="ProjectSystem\VS\Input\Commands\IStartupProjectHelper.cs" />
+    <Compile Include="ProjectSystem\VS\Input\Commands\StartupProjectHelper.cs" />
+    <Compile Include="ProjectSystem\VS\Input\Commands\DebugFrameworksDynamicMenuCommand.cs" />
+    <Compile Include="ProjectSystem\VS\Input\Commands\DebugFrameworksMenuTextUpdater.cs" />
+    <Compile Include="ProjectSystem\VS\Input\Commands\DynamicMenuCommand.cs" />
     <Compile Include="ProjectSystem\VS\Input\Commands\GenerateNuGetPackageTopLevelBuildMenuCommand.cs" />
     <Compile Include="ProjectSystem\VS\Input\Commands\GenerateNuGetPackageProjectContextMenuCommand.cs" />
     <Compile Include="ProjectSystem\VS\Input\Commands\AbstractGenerateNuGetPackageCommand.cs" />
@@ -290,6 +295,7 @@
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
+    <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="WindowsBase" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
@@ -1,21 +1,39 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.ComponentModel.Composition;
+using System.ComponentModel.Design;
 using System.Runtime.InteropServices;
+using System.Threading;
+using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands;
 using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.Packaging
 {
     [Guid(PackageGuid)]
     [PackageRegistration(AllowsBackgroundLoading = true, RegisterUsing = RegistrationMethod.CodeBase, UseManagedResourcesOnly = true)]
+    [ProvideAutoLoad(ActivationContextGuid)]
+    [ProvideUIContextRule(ActivationContextGuid, "Load Managed Project Package",
+        "dotnetcore",
+        new string[] {"dotnetcore"},
+        new string[] {"SolutionHasProjectCapability:(CSharp | VB) & CPS"}
+        )]
+
     [ProvideMenuResource("Menus.ctmenu", 1)]
     internal class ManagedProjectSystemPackage : AsyncPackage
     {
+        public const string ActivationContextGuid = "E7DF1626-44DD-4E8C-A8A0-92EAB6DDC16E";
         public const string PackageGuid = "A4F9D880-9492-4072-8BF3-2B5EEEDC9E68";
         public const string ManagedProjectSystemCommandSet = "{568ABDF7-D522-474D-9EED-34B5E5095BA5}";
         public const long EditProjectFileCmdId = 0x1001;
         public const long GenerateNuGetPackageProjectContextMenuCmdId = 0x2000;
         public const long GenerateNuGetPackageTopLevelBuildCmdId = 0x2001;
+        public const int DebugTargetMenuDebugFrameworkMenu = 0x3000;
+        public const int DebugFrameworksCmdId = 0x3050;
+
         public const string DefaultCapabilities = ProjectCapability.AppDesigner + "; " +
                                                   ProjectCapability.EditAndContinue + "; " +
                                                   ProjectCapability.HandlesOwnReload + "; " +
@@ -24,6 +42,21 @@ namespace Microsoft.VisualStudio.Packaging
 
         public ManagedProjectSystemPackage()
         {
+        }
+
+        protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            IComponentModel componentModel = (IComponentModel)GetService(typeof(SComponentModel));
+            ICompositionService compositionService = componentModel.DefaultCompositionService;
+            var debugFrameworksCmd = componentModel.DefaultExportProvider.GetExport<DebugFrameworksDynamicMenuCommand>();
+
+            var mcs = GetService(typeof(IMenuCommandService)) as OleMenuCommandService;
+            mcs.AddCommand(debugFrameworksCmd.Value);
+
+            var debugFrameworksMenuTextUpdater = componentModel.DefaultExportProvider.GetExport<DebugFrameworkPropertyMenuTextUpdater>();
+            mcs.AddCommand(debugFrameworksMenuTextUpdater.Value);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -32,20 +32,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                                            IDebugTokenReplacer tokenReplacer,
                                            IFileSystem fileSystem,
                                            IEnvironmentHelper environment,
+                                           IActiveDebugFrameworkServices activeDebugFramework, 
                                            ProjectProperties properties)
         {
-            ConfiguredProject = configuredProject;
             TokenReplacer = tokenReplacer;
             TheFileSystem = fileSystem;
             TheEnvironment = environment;
+            ActiveDebugFramework = activeDebugFramework;
             Properties = properties;
+            UnconfiguredProject = configuredProject.UnconfiguredProject;
         }
 
-        private ConfiguredProject ConfiguredProject { get; }
         private IDebugTokenReplacer TokenReplacer { get; }
         private IFileSystem TheFileSystem { get; }
         private IEnvironmentHelper TheEnvironment { get; }
+        private IActiveDebugFrameworkServices ActiveDebugFramework { get; }
         private ProjectProperties Properties { get; }
+        private UnconfiguredProject UnconfiguredProject { get; }
+
+        private async Task<ConfiguredProject> GetConfiguredProjectForDebugAsync()
+        {
+            return await ActiveDebugFramework.GetConfiguredProjectForActiveFrameworkAsync().ConfigureAwait(false);
+        }
 
         /// <summary>
         /// This provider handles running the Project and empty commandName (this generally just runs the executable)
@@ -93,9 +101,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// </summary>
         public async Task<IReadOnlyList<IDebugLaunchSettings>> QueryDebugTargetsAsync(DebugLaunchOptions launchOptions, ILaunchProfile activeProfile)
         {
-
-            string projectFolder = Path.GetDirectoryName(ConfiguredProject.UnconfiguredProject.FullPath);
-
             List<DebugLaunchSettings> launchSettings = new List<DebugLaunchSettings>();
 
             var settings = new DebugLaunchSettings(launchOptions);
@@ -105,7 +110,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             // We want to launch the process via the command shell when not debugging, except when this debug session is being launched for profiling.
             bool useCmdShell = (launchOptions & (DebugLaunchOptions.NoDebug | DebugLaunchOptions.Profiling)) == DebugLaunchOptions.NoDebug;
-            var consoleTarget = await GetConsoleTargetForProfile(resolvedProfile, launchOptions, projectFolder, useCmdShell).ConfigureAwait(true);
+            var consoleTarget = await GetConsoleTargetForProfile(resolvedProfile, launchOptions, useCmdShell).ConfigureAwait(true);
 
             launchSettings.Add(consoleTarget);
 
@@ -155,12 +160,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// of project.
         /// </summary>
         private async Task<DebugLaunchSettings> GetConsoleTargetForProfile(ILaunchProfile resolvedProfile, DebugLaunchOptions launchOptions,
-                                                              string projectFolder, bool useCmdShell)
+                                                                           bool useCmdShell)
         {
             var settings = new DebugLaunchSettings(launchOptions);
 
             string executable, arguments;
             string commandLineArguments = resolvedProfile.CommandLineArgs;
+
+            string projectFolder = Path.GetDirectoryName(UnconfiguredProject.FullPath);
+            var configuredProject = await GetConfiguredProjectForDebugAsync().ConfigureAwait(false);
 
             // If no working directory specified in the profile, we default to the one returned from GetRunnableProjectInformationAsync (if running
             // the project), or the project folder.
@@ -176,7 +184,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 }
 
                 // Get the executable to run, the arguments and the default working directory
-                var runData = await GetRunnableProjectInformationAsync().ConfigureAwait(false);
+                var runData = await GetRunnableProjectInformationAsync(configuredProject).ConfigureAwait(false);
                 executable = runData.Item1;
                 arguments = runData.Item2;
                 if (!string.IsNullOrWhiteSpace(runData.Item3))
@@ -241,7 +249,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             settings.Arguments = finalArguments;
             settings.CurrentDirectory = workingDir;
             settings.LaunchOperation = DebugLaunchOperation.CreateProcess;
-            settings.LaunchDebugEngineGuid = await GetDebuggingEngineAsync().ConfigureAwait(false);
+            settings.LaunchDebugEngineGuid = await GetDebuggingEngineAsync(configuredProject).ConfigureAwait(false);
             settings.LaunchOptions = launchOptions | DebugLaunchOptions.StopDebuggingOnEnd;
             if (settings.Environment.Count > 0)
             {
@@ -255,9 +263,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// Queries properties from the project to get information on how to run the application. The returned Tuple contains:
         /// exeToRun, arguments, workingDir
         /// </summary>
-        private async Task<Tuple<string, string, string>> GetRunnableProjectInformationAsync()
+        private async Task<Tuple<string, string, string>> GetRunnableProjectInformationAsync(ConfiguredProject configuredProject)
         {
-            var properties = ConfiguredProject.Services.ProjectPropertiesProvider.GetCommonProperties();
+            var properties = configuredProject.Services.ProjectPropertiesProvider.GetCommonProperties();
 
             var runCommand = await properties.GetEvaluatedPropertyValueAsync("RunCommand").ConfigureAwait(false);
             var runWorkingDirectory = await properties.GetEvaluatedPropertyValueAsync("RunWorkingDirectory").ConfigureAwait(false);
@@ -288,14 +296,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             // If the working directory is relative, it will be relative to the project root so make it a full path
             if (!string.IsNullOrWhiteSpace(runWorkingDirectory) && !Path.IsPathRooted(runWorkingDirectory))
             {
-                runWorkingDirectory = Path.Combine(Path.GetDirectoryName(ConfiguredProject.UnconfiguredProject.FullPath), runWorkingDirectory);
+                runWorkingDirectory = Path.Combine(Path.GetDirectoryName(UnconfiguredProject.FullPath), runWorkingDirectory);
             }
             return new Tuple<string, string, string>(runCommand, runArguments, runWorkingDirectory);
         }
 
-        private async Task<Guid> GetDebuggingEngineAsync()
+        private async Task<Guid> GetDebuggingEngineAsync(ConfiguredProject configuredProject)
         {
-            var properties = ConfiguredProject.Services.ProjectPropertiesProvider.GetCommonProperties();
+            var properties = configuredProject.Services.ProjectPropertiesProvider.GetCommonProperties();
             var framework = await properties.GetEvaluatedPropertyValueAsync("TargetFrameworkIdentifier").ConfigureAwait(false);
 
             return ProjectDebuggerProvider.GetManagedDebugEngineForFramework(framework);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Extensibility/ProjectExportProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Extensibility/ProjectExportProvider.cs
@@ -4,7 +4,6 @@ using System;
 using System.ComponentModel.Composition;
 using System.Linq;
 using Microsoft.VisualStudio.Composition;
-using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Extensibility
 {
@@ -15,12 +14,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Extensibility
     [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
     internal class ProjectExportProvider : IProjectExportProvider
     {
-        private SVsServiceProvider ServiceProvider { get; set; }
+        private IProjectServiceAccessor ProjectServiceAccesspr { get; }
 
         [ImportingConstructor]
-        public ProjectExportProvider(SVsServiceProvider serviceProvider)
+        public ProjectExportProvider(IProjectServiceAccessor serviceAccessor)
         {
-            ServiceProvider = serviceProvider;
+            ProjectServiceAccesspr = serviceAccessor;
         }
 
         /// <summary>
@@ -35,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Extensibility
                 throw new ArgumentNullException(nameof(projectFilePath));
             }
 
-            var projectService = ServiceProvider.GetProjectService();
+            var projectService = ProjectServiceAccesspr.GetProjectService();
             if (projectService == null)
             {
                 return null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommand.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.ComponentModel.Design;
+using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+{
+
+    /// <summary>
+    /// Handles populating a menu command on the debug dropdown when the menu reflects the IEnumValues for
+    /// a debug property. It shows the active framework used for running the app (F5/Ctrl+F5).
+    /// </summary>
+    [Export(typeof(DebugFrameworksDynamicMenuCommand))]
+    internal class DebugFrameworksDynamicMenuCommand : DynamicMenuCommand
+    {
+        const int MaxFrameworks = 20;
+
+        [ImportingConstructor]
+        public DebugFrameworksDynamicMenuCommand(IStartupProjectHelper startupProjectHelper)
+          : base(new CommandID(new Guid(ManagedProjectSystemPackage.ManagedProjectSystemCommandSet), ManagedProjectSystemPackage.DebugFrameworksCmdId), MaxFrameworks)
+        {
+            StartupProjectHelper = startupProjectHelper;
+        }
+
+        IStartupProjectHelper StartupProjectHelper { get; }
+
+        /// <summary>
+        /// CAlled by the base when one if our menu ids is clicked. Need to return true if the command was handled
+        /// </summary>
+        public override bool ExecCommand(int cmdIndex, EventArgs e)
+        {
+            bool handled = false;
+            var activeDebugFramework = StartupProjectHelper.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles);
+            if(activeDebugFramework != null)
+            {
+                ExecuteSynchronously(async () =>
+                {
+                    var frameworks = await activeDebugFramework.GetProjectFrameworksAsync().ConfigureAwait(false);
+                    if(frameworks != null && cmdIndex >= 0 && cmdIndex < frameworks.Count)
+                    {
+                        await activeDebugFramework.SetActiveDebuggingFrameworkPropertyAsync(frameworks[cmdIndex]).ConfigureAwait(false);
+                        handled = true;
+                    }
+                });
+            }
+
+            return handled;
+        }
+        
+        /// <summary>
+        /// Called by the base when one of our menu ids is queried for. If the index is 
+        /// is greater than the count we want to return false
+        /// </summary>       
+        public override bool QueryStatusCommand(int cmdIndex, EventArgs e)
+        {
+            var activeDebugFramework = StartupProjectHelper.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles);
+            if(activeDebugFramework != null)
+            {
+                // See if this project supports at least two runtimes
+                List<string> frameworks = null;
+                string activeFramework = null;
+                ExecuteSynchronously(async () =>
+                {
+                    frameworks = await activeDebugFramework.GetProjectFrameworksAsync().ConfigureAwait(false);
+                    if(frameworks != null && frameworks.Count > 1 && cmdIndex < frameworks.Count)
+                    {
+                        // Only call this if we will need it down below.
+                        activeFramework = await activeDebugFramework.GetActiveDebuggingFrameworkPropertyAsync().ConfigureAwait(false);
+                    }
+                });
+
+                if(frameworks == null || frameworks.Count < 2)
+                {
+                    // Hide and disable the command
+                    Visible = false;
+                    Enabled = false;
+                    Checked = false;
+                    return true;
+                }
+                else if(cmdIndex >= 0 && cmdIndex < frameworks.Count)
+                {
+                    Text = frameworks[cmdIndex];
+                    Visible = true;
+                    Enabled = true;
+
+                    // Get's a check if it matches the active one, or there is no active one in which case the first one is the active one
+                    Checked = (string.IsNullOrEmpty(activeFramework) && cmdIndex == 0) || string.Equals(frameworks[cmdIndex], activeFramework, StringComparison.Ordinal);
+                    MatchedCommandId = 0;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// For unit testing to wrap the JTF.Run call.
+        /// </summary>
+        protected virtual void ExecuteSynchronously(Func<Task> asyncFunction)
+        {
+            ThreadHelper.JoinableTaskFactory.Run(async () =>
+            {   
+                await asyncFunction().ConfigureAwait(false);
+            });
+        }
+   }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdater.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdater.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.ComponentModel.Design;
+using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+{
+    /// <summary>
+    /// Updates the text of the Frameworks menu to include the current active framework. Instead of just saying
+    /// Frameworks it will say Frameworks (netcoreapp1.0).
+    /// </summary>
+    [Export(typeof(DebugFrameworkPropertyMenuTextUpdater))]
+    internal class DebugFrameworkPropertyMenuTextUpdater : OleMenuCommand
+    {
+        [ImportingConstructor]
+        public DebugFrameworkPropertyMenuTextUpdater(IStartupProjectHelper startupProjectHelper)
+                :base(ExecHandler, delegate { }, QueryStatusHandler, 
+                      new CommandID(new Guid(ManagedProjectSystemPackage.ManagedProjectSystemCommandSet), ManagedProjectSystemPackage.DebugTargetMenuDebugFrameworkMenu))
+        {
+            StartupProjectHelper = startupProjectHelper;
+        }
+
+        IStartupProjectHelper StartupProjectHelper { get; }
+
+        /// <summary>
+        /// Exec handler called when one of the menu items is selected. Does some
+        /// basic validation before calling the commands QueryStatusCommand to update
+        /// its state
+        /// </summary>
+        public static void ExecHandler(object sender, EventArgs e)
+        {
+            return;
+        }
+
+
+        /// <summary>
+        /// QueryStatus handler called to update the status of the menu items. Does some
+        /// basic validation before calling the commands QueryStatusCommand to update
+        /// its state
+        /// </summary>
+        public static void QueryStatusHandler(object sender, EventArgs e)
+        {   
+            var command = sender as DebugFrameworkPropertyMenuTextUpdater;
+            if(command == null)
+            {
+                return;
+            }
+
+            command.QueryStatus();
+        }
+
+        public void QueryStatus()
+        {
+            var activeDebugFramework = StartupProjectHelper.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles);
+            if(activeDebugFramework != null)
+            {
+                string activeFramework = null;
+                List<string> frameworks = null;
+                ExecuteSynchronously(async () =>
+                {
+                    frameworks = await activeDebugFramework.GetProjectFrameworksAsync().ConfigureAwait(false);
+                    if(frameworks != null && frameworks.Count > 1)
+                    {
+                        // Only get this if we will need it down below
+                        activeFramework = await activeDebugFramework.GetActiveDebuggingFrameworkPropertyAsync().ConfigureAwait(false);
+                    }
+                });
+
+                if(frameworks != null && frameworks.Count > 1)
+                {
+                    // If no active framework or the current active property doesn't match any of the frameworks, then
+                    // st it to the first one.
+                    if(!string.IsNullOrEmpty(activeFramework) && frameworks.Contains(activeFramework))
+                    {
+                        Text = string.Format(VSResources.DebugFrameworkMenuText, activeFramework);
+                    }
+                    else
+                    {
+                        Text = string.Format(VSResources.DebugFrameworkMenuText, frameworks[0]);
+                    }
+
+                    Visible = true;
+                    Enabled = true;
+                }
+            }
+        }
+
+        /// <summary>
+        /// For unit testing to wrap the JTF.Run call.
+        /// </summary>
+        protected virtual void ExecuteSynchronously(Func<Task> asyncFunction)
+        {
+            ThreadHelper.JoinableTaskFactory.Run(async () =>
+            {   
+                await asyncFunction().ConfigureAwait(false);
+            });
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DynamicMenuCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DynamicMenuCommand.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Design;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+{
+    /// <summary>
+    /// Implementation of an OleMenuCommand which supports the DynamicStart (like an MRU list) type 
+    /// of commands
+    /// </summary>
+    internal abstract class DynamicMenuCommand : OleMenuCommand
+    {
+        public int MaxCount { get; protected set; }
+
+        public DynamicMenuCommand(CommandID id, int maxCount) 
+            : base(ExecHandler, delegate { }, QueryStatusHandler, id)
+        {
+            MaxCount = maxCount;
+        }
+
+        /// <summary>
+        /// Derived classes need to implement the following two methods. They must return false
+        /// if the command is not handled (index is out of range)
+        /// </summary>
+        public abstract bool ExecCommand(int cmdIndex, EventArgs e);
+        public abstract bool QueryStatusCommand(int cmdIndex, EventArgs e);
+
+        /// <summary>
+        /// Overridden to set the MatchedCmdId. This is used later by QS\Exec when determining the
+        /// index of the current selection.
+        /// </summary>
+        public override bool DynamicItemMatch(int cmdId)
+        {
+            int index = cmdId - CommandID.ID;
+
+            // Is the index in range?
+            if (index >= 0 && index < MaxCount)
+            {
+                MatchedCommandId = cmdId;
+                return true;
+            }
+
+            // No match, clear command id and return false
+            MatchedCommandId = 0;
+            return false;
+        }
+
+        /// <summary>
+        /// Returns the current index (0 based) of the command that is currently selected (set by 
+        /// MatchedCommandId).
+        /// </summary>
+        public int CurrentIndex
+        {
+            get
+            {
+                // Index is the current matched ID minus the base
+                if (MatchedCommandId > 0)
+                {
+                    return MatchedCommandId - CommandID.ID;
+                }
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Exec handler called when one of the menu items is selected. Does some
+        /// basic validation before calling the commands QueryStatusCommand to update
+        /// its state
+        /// </summary>
+        protected static  void ExecHandler(object sender, EventArgs e)
+        {
+            DynamicMenuCommand command = sender as DynamicMenuCommand;
+            if (command == null)
+            {
+                return;
+            }
+
+            int cmdIndex = command.CurrentIndex;
+            if (cmdIndex >= 0 && cmdIndex < command.MaxCount)
+            {
+                // Only return if command was handled
+                if(command.ExecCommand(cmdIndex, e))
+                {
+                    return;
+                }
+            }
+
+            // We want to make sure to clear the matched commandid.
+            command.MatchedCommandId = 0;
+        }
+
+
+        /// <summary>
+        /// QueryStatus handler called to update the status of the menu items. Does some
+        /// basic validation before calling the commands QueryStatusCommand to update
+        /// its state
+        /// </summary>
+        protected static void QueryStatusHandler(object sender, EventArgs e)
+        {
+            DynamicMenuCommand command = sender as DynamicMenuCommand;
+            if (command == null)
+            {
+                return;
+            }
+
+            int cmdIndex = command.CurrentIndex;
+            if (cmdIndex >= 0 && cmdIndex < command.MaxCount)
+            {
+                // Only return if command was handled
+                if(command.QueryStatusCommand(cmdIndex, e))
+                {
+                    // We want to make sure to clear the matched commandid.
+                    command.MatchedCommandId = 0;
+                    return;
+                }
+            }
+            // If we get this far, hide the command
+            command.Visible = false;
+            command.Enabled = false;
+            command.MatchedCommandId = 0;
+        }
+    }
+}
+

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/IStartupProjectHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/IStartupProjectHelper.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+{
+    /// <summary>
+    /// Provides a mechanism to get an export from a DotNet project which is the only startup project. The capabilityMatch is  
+    /// used to refine the projects that are considered
+    /// </summary>
+    internal interface IStartupProjectHelper
+    {
+        T GetExportFromSingleDotNetStartupProject<T>(string capabilityMatch)  where T : class;
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/StartupProjectHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/StartupProjectHelper.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.VS.Extensibility;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+{
+    /// <summary>
+    /// Handles populating a menu command on the debug dropdown when the menu reflects the IEnumValues for
+    /// a debug property. It shows the active framework used for running the app (F5/Ctrl+F5).
+    /// </summary>
+    [Export(typeof(IStartupProjectHelper))]
+    internal class StartupProjectHelper : IStartupProjectHelper
+    {
+        const int MaxFrameworks = 20;
+
+        [ImportingConstructor]
+        public StartupProjectHelper([Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider, IProjectExportProvider projectExportProvider)
+        {
+            ServiceProvider = serviceProvider;
+            ProjectExportProvider = projectExportProvider;
+        }
+
+        IProjectExportProvider ProjectExportProvider { get; }
+        IServiceProvider ServiceProvider { get; }
+
+        /// <summary>
+        /// Returns the export T of the startup project if that project supports the specified capabilities
+        /// </summary>
+        public T GetExportFromSingleDotNetStartupProject<T>(string capabilityMatch) where T : class
+        {
+            EnvDTE.DTE dte = ServiceProvider.GetService<EnvDTE.DTE, EnvDTE.DTE>();
+            if(dte != null)
+            {
+                if (dte.Solution.SolutionBuild.StartupProjects is Array startupProjects && startupProjects.Length == 1)
+                {
+                    IVsSolution sln = ServiceProvider.GetService<IVsSolution, SVsSolution>();
+                    foreach (string projectName in startupProjects)
+                    {
+                        sln.GetProjectOfUniqueName(projectName, out IVsHierarchy hier);
+                        if (hier != null && hier.IsCapabilityMatch(capabilityMatch))
+                        {
+                            string projectPath = hier.GetProjectFilePath();
+                            return ProjectExportProvider.GetExport<T>(projectPath);
+                        }
+                    }
+                }
+            }
+            return null;
+        }   
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
     {
         private readonly IUnconfiguredProjectVsServices _projectVsServices;
         private readonly IVsSolutionRestoreService _solutionRestoreService;
-        private readonly ActiveConfiguredProjectsProvider _activeConfiguredProjectsProvider;
+        private readonly IActiveConfiguredProjectsProvider _activeConfiguredProjectsProvider;
         private readonly IActiveConfiguredProjectSubscriptionService _activeConfiguredProjectSubscriptionService;
         private readonly IActiveProjectConfigurationRefreshService _activeProjectConfigurationRefreshService;
         private IDisposable _designTimeBuildSubscriptionLink;
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             IVsSolutionRestoreService solutionRestoreService,
             IActiveConfiguredProjectSubscriptionService activeConfiguredProjectSubscriptionService,
             IActiveProjectConfigurationRefreshService activeProjectConfigurationRefreshService,
-            ActiveConfiguredProjectsProvider activeConfiguredProjectsProvider) 
+            IActiveConfiguredProjectsProvider activeConfiguredProjectsProvider) 
             : base(projectVsServices.ThreadingService.JoinableTaskContext)
         {
             _projectVsServices = projectVsServices;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/VsHierarchyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/VsHierarchyExtensions.cs
@@ -115,5 +115,18 @@ namespace Microsoft.VisualStudio.Shell.Interop
 
             return null;
         }
+        
+        /// <summary>
+        /// Returns the path to the project file. Assumes the hierarchy implements IVsProject. Returns null on failure
+        /// </summary>
+        public static string GetProjectFilePath(this IVsHierarchy hierarchy)
+        {
+            if(ErrorHandler.Succeeded(((IVsProject)hierarchy).GetMkDocument(VSConstants.VSITEMID_ROOT, out string projectPath)))
+            {
+                return projectPath;
+            }
+
+            return null;
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -139,6 +139,15 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Framework ({0}).
+        /// </summary>
+        internal static string DebugFrameworkMenuText {
+            get {
+                return ResourceManager.GetString("DebugFrameworkMenuText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to  (Loading...).
         /// </summary>
         internal static string DependenciesLoadingPostfix {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -276,4 +276,7 @@ In order to debug this project, add an executable project to this solution which
   <data name="XprojMigrationGeneralFailure" xml:space="preserve">
     <value>Failed to migrate XProj project {0}. '{1}' exited with error code {2}.</value>
   </data>
+  <data name="DebugFrameworkMenuText" xml:space="preserve">
+    <value>Framework ({0})</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -44,6 +44,8 @@
     <Compile Include="ProjectSystem\ContractNames.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="ProjectSystem\Build\PublishableProjectConfigProvider.cs" />
+    <Compile Include="ProjectSystem\Debug\ActiveDebugFrameworkServices.cs" />
+    <Compile Include="ProjectSystem\Debug\IActiveDebugFrameworkServices.cs" />
     <Compile Include="ProjectSystem\Debug\IDebugTokenReplacer.cs" />
     <Compile Include="ProjectSystem\Debug\DebugTokenReplacer.cs" />
     <Compile Include="ProjectSystem\Debug\IJsonSection.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -34,6 +34,7 @@
   <ItemGroup>
     <Compile Include="Extensions\SemaphoreSlimExtensions.cs" />
     <Compile Include="Extensions\ProjectConfigurationExtensions.cs" />
+    <Compile Include="ProjectSystem\IActiveConfiguredProjectsProvider.cs" />
     <Compile Include="ProjectSystem\Build\BuildProperty.cs" />
     <Compile Include="CommonConstants.cs" />
     <Compile Include="ProjectSystem\Build\TurnOffUseHostCompilerIfAvailableBuildPropertiesProvider.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
@@ -9,24 +9,11 @@ using Microsoft.VisualStudio.ProjectSystem.Build;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     /// <summary>
-    ///     Provides set of configured projects whose ProjectConfiguration has all dimensions (except the TargetFramework) matching the active VS configuration.
-    ///
-    ///     For example, for a cross-targeting project with TargetFrameworks = "net45;net46" we have:
-    ///     -> All known configurations:
-    ///         Debug | AnyCPU | net45
-    ///         Debug | AnyCPU | net46
-    ///         Release | AnyCPU | net45
-    ///         Release | AnyCPU | net46
-    ///         
-    ///     -> Say, active VS configuration = "Debug | AnyCPU"
-    ///       
-    ///     -> Active configurations returned by this provider:
-    ///         Debug | AnyCPU | net45
-    ///         Debug | AnyCPU | net46
+    ///<see cref="IActiveConfiguredProjectsProvider"/>
     /// </summary>
-    [Export(typeof(ActiveConfiguredProjectsProvider))]
+    [Export(typeof(IActiveConfiguredProjectsProvider))]
     [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
-    internal class ActiveConfiguredProjectsProvider
+    internal class ActiveConfiguredProjectsProvider : IActiveConfiguredProjectsProvider
     {
         private readonly IUnconfiguredProjectServices _services;
         private readonly IUnconfiguredProjectCommonServices _commonServices;
@@ -42,10 +29,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         /// <summary>
-        /// Gets all the active configured projects by TargetFramework dimension for the current unconfigured project.
-        /// If the current project is not a cross-targeting project, then it returns a singleton key-value pair with an ignorable key and single active configured project as value.
+        /// <see cref="IActiveConfiguredProjectsProvider.GetActiveConfiguredProjectsMapAsync"/> 
         /// </summary>
-        /// <returns>Map from TargetFramework dimension to active configured project.</returns>
         public async Task<ImmutableDictionary<string, ConfiguredProject>> GetActiveConfiguredProjectsMapAsync()
         {
             var builder = ImmutableDictionary.CreateBuilder<string, ConfiguredProject>();
@@ -74,9 +59,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         /// <summary>
-        /// Gets all the active configured projects for the current unconfigured project.
+        /// <see cref="IActiveConfiguredProjectsProvider.GetActiveConfiguredProjectsAsync"/> 
         /// </summary>
-        /// <returns>Set of active configured projects.</returns>
         public async Task<ImmutableArray<ConfiguredProject>> GetActiveConfiguredProjectsAsync()
         {
             var projectMap = await GetActiveConfiguredProjectsMapAsync().ConfigureAwait(false);
@@ -84,9 +68,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         /// <summary>
-        /// Gets all the active project configurations for the current unconfigured project.
+        /// <see cref="IActiveConfiguredProjectsProvider.GetActiveProjectConfigurationsAsync"/> 
         /// </summary>
-        /// <returns>Set of active project configurations.</returns>
         public async Task<ImmutableArray<ProjectConfiguration>> GetActiveProjectConfigurationsAsync()
         {
             var projectMap = await GetActiveConfiguredProjectsMapAsync().ConfigureAwait(false);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Build;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    /// <summary>
+    /// Providers a wrapper around the what is considered the active debugging framework.
+    /// </summary>
+    [Export(typeof(IActiveDebugFrameworkServices))]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
+    internal class ActiveDebugFrameworkServices : IActiveDebugFrameworkServices
+    {
+        const int MaxFrameworks = 20;
+
+        [ImportingConstructor]
+        public ActiveDebugFrameworkServices(ActiveConfiguredProjectsProvider configuredProjectsProvider, IUnconfiguredProjectCommonServices commonProjectServices)
+        {
+            ActiveConfiguredProjectsProvider = configuredProjectsProvider;
+            CommonProjectServices = commonProjectServices;
+        }
+
+        ActiveConfiguredProjectsProvider ActiveConfiguredProjectsProvider { get; }
+        IUnconfiguredProjectCommonServices CommonProjectServices { get; }
+
+        public async Task<List<string>> GetProjectFrameworksAsync()
+        {
+            // It is important that we return the frameworks in the order they are specified in the project to ensure the default is set
+            // correctly. 
+            var props = await CommonProjectServices.ActiveConfiguredProjectProperties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(false);
+
+            var targetFrameworks = (string)await props.TargetFrameworks.GetValueAsync().ConfigureAwait(false);
+
+            if(!string.IsNullOrWhiteSpace(targetFrameworks))
+            {
+                return TargetFrameworkProjectConfigurationDimensionProvider.ParseTargetFrameworks(targetFrameworks).ToList();
+            }
+            return null;
+        }
+
+        public async Task SetActiveDebuggingFrameworkPropertyAsync(string activeFramework)
+        {
+            var props = await CommonProjectServices.ActiveConfiguredProjectProperties.GetProjectDebuggerPropertiesAsync().ConfigureAwait(false);
+            await props.ActiveDebugFramework.SetValueAsync(activeFramework).ConfigureAwait(true);
+        }
+
+        public async Task<string> GetActiveDebuggingFrameworkPropertyAsync()
+        {
+            var props = await CommonProjectServices.ActiveConfiguredProjectProperties.GetProjectDebuggerPropertiesAsync().ConfigureAwait(false);
+            var activeValue = await props.ActiveDebugFramework.GetValueAsync().ConfigureAwait(true) as string;
+            return activeValue;
+        }
+
+        public async Task<ConfiguredProject> GetConfiguredProjectForActiveFrameworkAsync()
+        {
+            var configProjects = await ActiveConfiguredProjectsProvider.GetActiveConfiguredProjectsMapAsync().ConfigureAwait(false);
+
+            // If there is only one we are done
+            if(configProjects.Count == 1)
+            {
+                return configProjects.First().Value;
+            }
+            
+            var activeFramework = await GetActiveDebuggingFrameworkPropertyAsync().ConfigureAwait(false);
+            if(!string.IsNullOrWhiteSpace(activeFramework))
+            {
+                if(configProjects.TryGetValue(activeFramework, out ConfiguredProject configuredProject))
+                {
+                    return configuredProject;
+                }
+            }
+
+            // We can't just select the first one. If activeFramework is not set we must pick the first one as defined by the 
+            // targetFrameworks property. So we need the order as returned by GetProjectFrameworks()
+            var frameworks = await GetProjectFrameworksAsync().ConfigureAwait(false);
+            if(frameworks != null &&  frameworks.Count > 0)
+            {
+                if(configProjects.TryGetValue(frameworks[0], out ConfiguredProject configuredProject))
+                {
+                    return configuredProject;
+                }
+
+            }
+
+            // All that is left is to return the first one.
+            return configProjects.First().Value;
+        }
+   }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
@@ -18,15 +18,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         const int MaxFrameworks = 20;
 
         [ImportingConstructor]
-        public ActiveDebugFrameworkServices(ActiveConfiguredProjectsProvider configuredProjectsProvider, IUnconfiguredProjectCommonServices commonProjectServices)
+        public ActiveDebugFrameworkServices(IActiveConfiguredProjectsProvider configuredProjectsProvider, IUnconfiguredProjectCommonServices commonProjectServices)
         {
             ActiveConfiguredProjectsProvider = configuredProjectsProvider;
             CommonProjectServices = commonProjectServices;
         }
 
-        ActiveConfiguredProjectsProvider ActiveConfiguredProjectsProvider { get; }
+        IActiveConfiguredProjectsProvider ActiveConfiguredProjectsProvider { get; }
         IUnconfiguredProjectCommonServices CommonProjectServices { get; }
 
+        /// <summary>
+        /// <see cref="IActiveDebugFrameworkServices.GetProjectFrameworksAsync"/>
+        /// </summary>
         public async Task<List<string>> GetProjectFrameworksAsync()
         {
             // It is important that we return the frameworks in the order they are specified in the project to ensure the default is set
@@ -42,12 +45,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             return null;
         }
 
+        /// <summary>
+        /// <see cref="IActiveDebugFrameworkServices.SetActiveDebuggingFrameworkPropertyAsync"/>
+        /// </summary>
         public async Task SetActiveDebuggingFrameworkPropertyAsync(string activeFramework)
         {
             var props = await CommonProjectServices.ActiveConfiguredProjectProperties.GetProjectDebuggerPropertiesAsync().ConfigureAwait(false);
             await props.ActiveDebugFramework.SetValueAsync(activeFramework).ConfigureAwait(true);
         }
 
+        /// <summary>
+        /// <see cref="IActiveDebugFrameworkServices.GetActiveDebuggingFrameworkPropertyAsync"/>
+        /// </summary>
         public async Task<string> GetActiveDebuggingFrameworkPropertyAsync()
         {
             var props = await CommonProjectServices.ActiveConfiguredProjectProperties.GetProjectDebuggerPropertiesAsync().ConfigureAwait(false);
@@ -55,6 +64,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             return activeValue;
         }
 
+        /// <summary>
+        /// <see cref="IActiveDebugFrameworkServices.GetConfiguredProjectForActiveFrameworkAsync"/>
+        /// </summary>
         public async Task<ConfiguredProject> GetConfiguredProjectForActiveFrameworkAsync()
         {
             var configProjects = await ActiveConfiguredProjectsProvider.GetActiveConfiguredProjectsMapAsync().ConfigureAwait(false);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IActiveDebugFrameworkServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IActiveDebugFrameworkServices.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    /// <summary>
+    /// Wrapper around the active debug framework to provide a single implementation of what is considered the active fraemowrk. If there is
+    /// only one framework
+    /// </summary>
+    public interface IActiveDebugFrameworkServices
+    {
+        /// <summary>
+        /// Returns the set of frameworks in the order defined in msbuild. If not multi-targeting it returns null.
+        /// </summary>
+        Task<List<string>> GetProjectFrameworksAsync();
+
+        /// <summary>
+        /// Sets the value of the active debugging target framework property
+        /// </summary>
+        Task SetActiveDebuggingFrameworkPropertyAsync(string activeFramework);
+
+        /// <summary>
+        /// Returns the value of the propety, or empty string/null if the property has never been set
+        /// </summary>
+        Task<string> GetActiveDebuggingFrameworkPropertyAsync();
+
+        /// <summary>
+        /// Returns the configured project which respresents the active framework. This is valid whether multi-targeting or not
+        /// </summary>
+        Task<ConfiguredProject> GetConfiguredProjectForActiveFrameworkAsync();
+   }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IActiveConfiguredProjectsProvider.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    /// <summary>
+    ///     Provides set of configured projects whose ProjectConfiguration has all dimensions (except the TargetFramework) matching the active VS configuration.
+    ///
+    ///     For example, for a cross-targeting project with TargetFrameworks = "net45;net46" we have:
+    ///     -> All known configurations:
+    ///         Debug | AnyCPU | net45
+    ///         Debug | AnyCPU | net46
+    ///         Release | AnyCPU | net45
+    ///         Release | AnyCPU | net46
+    ///         
+    ///     -> Say, active VS configuration = "Debug | AnyCPU"
+    ///       
+    ///     -> Active configurations returned by this provider:
+    ///         Debug | AnyCPU | net45
+    ///         Debug | AnyCPU | net46
+    /// </summary>
+    internal interface IActiveConfiguredProjectsProvider
+    {
+
+        /// <summary>
+        /// Gets all the active configured projects by TargetFramework dimension for the current unconfigured project.
+        /// If the current project is not a cross-targeting project, then it returns a singleton key-value pair with an ignorable key and single active configured project as value.
+        /// </summary>
+        /// <returns>Map from TargetFramework dimension to active configured project.</returns>
+        Task<ImmutableDictionary<string, ConfiguredProject>> GetActiveConfiguredProjectsMapAsync();
+
+        /// <summary>
+        /// Gets all the active configured projects for the current unconfigured project.
+        /// </summary>
+        /// <returns>Set of active configured projects.</returns>
+        Task<ImmutableArray<ConfiguredProject>> GetActiveConfiguredProjectsAsync();
+
+        /// <summary>
+        /// Gets all the active project configurations for the current unconfigured project.
+        /// </summary>
+        /// <returns>Set of active project configurations.</returns>
+        Task<ImmutableArray<ProjectConfiguration>> GetActiveProjectConfigurationsAsync();
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         private readonly ITaskScheduler _taskScheduler;
         private readonly List<AggregateWorkspaceProjectContext> _contexts = new List<AggregateWorkspaceProjectContext>();
         private readonly IProjectHostProvider _projectHostProvider;
-        private readonly ActiveConfiguredProjectsProvider _activeConfiguredProjectsProvider;
+        private readonly IActiveConfiguredProjectsProvider _activeConfiguredProjectsProvider;
         private readonly IUnconfiguredProjectHostObject _unconfiguredProjectHostObject;
         private readonly Dictionary<ConfiguredProject, IWorkspaceProjectContext> _configuredProjectContextsMap = new Dictionary<ConfiguredProject, IWorkspaceProjectContext>();
         private readonly Dictionary<ConfiguredProject, IConfiguredProjectHostObject> _configuredProjectHostObjectsMap = new Dictionary<ConfiguredProject, IConfiguredProjectHostObject>();
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
                                                  IProjectAsyncLoadDashboard asyncLoadDashboard,
                                                  ITaskScheduler taskScheduler,
                                                  IProjectHostProvider projectHostProvider,
-                                                 ActiveConfiguredProjectsProvider activeConfiguredProjectsProvider)
+                                                 IActiveConfiguredProjectsProvider activeConfiguredProjectsProvider)
         {
             Requires.NotNull(commonServices, nameof(commonServices));
             Requires.NotNull(contextFactory, nameof(contextFactory));


### PR DESCRIPTION
PR for post dev15 RTW.
Implemented the design that was available in Dev14:
1.	Added a new menu item to the debug dropdown which shows the currently active framework being used for debugging. 
a.	The selected framework appears in the Framework menu name so that you don’t have to expand the menu to see the active one.
b.	The frameworks appear in the menu in the order they are defined in the <TargetFrameworks> property
c.	The current active framework is remembered in the .user file so it persists across VS sessions. It defaults to the first one if there is no existing setting or the existing setting doesn’t match any the frameworks being targeted.
d.	The framework names are displayed as they exist in the project file. I’d like to display something better but I didn’t have any code to convert the short name to a friendly name.  We could possible resolve to the TargetFrameworkMoniker property and display that - but that requires more evaluation. Certainly something to address later.
2.	Added an IActiveDebugFrameworkServices public interface which exposes access to the ConfiguredProject for the active debug framework. 
3.	Updated the Debugger providers and (token replacer) to resolve properties against the active debug frameworks ConfiguredProject. 
4. Unit test coverage for the new components
5. Fixed a problem with ProjectExportProvider. It claims it can be called on a background thread but doing so deadlocked as it was using QueryService to get to ProjectServices. Fixed it to just import the ProjectServices MEF component.

@davkean @srivatsn @abpiskunov 