### PR TITLE
Fix for 1581 show linear search results instead of hierarchy to avoid progression delays

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProviderTests.cs
@@ -627,14 +627,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             await provider.BeginGetGraphDataAsync(mockGraphContext);
 
             // Assert
-            Assert.Equal(5, outputNodes.Count);
+            Assert.Equal(4, outputNodes.Count);
 
             var topNode1Result = GetNodeById(projectPath, outputNodes, topNode1.Id);
             Assert.True(topNode1Result.HasCategory(CodeNodeCategories.ProjectItem));
             Assert.Equal(1, topNode1Result.OutgoingLinkCount);
 
             var topNode2Result = GetNodeById(projectPath, outputNodes, topNode2.Id);
-            Assert.Equal(2, topNode2Result.OutgoingLinkCount);
+            Assert.Equal(1, topNode2Result.OutgoingLinkCount);
             Assert.True(topNode2Result.HasCategory(CodeNodeCategories.ProjectItem));
 
             var childNode1Result = GetNodeById(projectPath, outputNodes, childNode1.Id);
@@ -644,10 +644,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var childNode2Result = GetNodeById(projectPath, outputNodes, childNode2.Id);
             Assert.Equal(0, childNode2Result.OutgoingLinkCount);
             Assert.False(childNode2Result.HasCategory(CodeNodeCategories.ProjectItem));
-
-            var childNode3Result = GetNodeById(projectPath, outputNodes, childNode3.Id);
-            Assert.Equal(0, childNode3Result.OutgoingLinkCount);
-            Assert.False(childNode3Result.HasCategory(CodeNodeCategories.ProjectItem));
         }
 
         private GraphNode GetNodeById(string projectPath, IEnumerable<GraphNode> nodes, DependencyNodeId id)


### PR DESCRIPTION
**Customer scenario**

Search in the Solution Explorer tree was super slow and looked like a UI hang when user had some common query strings like "system"

**Bugs this fixes:**

https://github.com/dotnet/roslyn-project-system/issues/1581

**Workarounds, if any**

N/A

**Risk**

Minimal

**Performance impact**

Perf is improved, however results are linear and not as informative as hierarchies that we showed for dependencies before

**Is this a regression from a previous update?**

No

**Root cause analysis:**

Progression code that does search in Solution explorer was not designed to work well with deeper hierarchies and becomes very slow with depth increasing

**How was the bug found?**

Internal dogfooding - it was known for a while, however no improvemennts were planned in Dev15 in Solution Explorer