### PR TITLE
Fix build outputpath browse crash

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
@@ -57,4 +57,9 @@
   <StringProperty Name="DebugSymbols" DisplayName="Debug symbols" Visible="False"/>
   <EnumProperty Name="FileAlignment" DisplayName="File Alignment" Visible="False"/>
   <StringProperty Name="BaseAddress" DisplayName="Base address" Visible="False"/>
+  <StringProperty Name="FullPath" DisplayName="Project Folder" ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/GeneralConfiguredBrowseObject.xaml
@@ -47,4 +47,9 @@
   <StringProperty Name="DebugSymbols" DisplayName="Symboly ladění" Visible="False" />
   <EnumProperty Name="FileAlignment" DisplayName="Zarovnání souboru" Visible="False" />
   <StringProperty Name="BaseAddress" DisplayName="Základní adresa" Visible="False" />
+  <StringProperty Name="FullPath" DisplayName="Project Folder" ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/GeneralConfiguredBrowseObject.xaml
@@ -47,4 +47,9 @@
   <StringProperty Name="DebugSymbols" DisplayName="Debugsymbole" Visible="False" />
   <EnumProperty Name="FileAlignment" DisplayName="Dateianordnung" Visible="False" />
   <StringProperty Name="BaseAddress" DisplayName="Basisadresse" Visible="False" />
+  <StringProperty Name="FullPath" DisplayName="Project Folder" ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/GeneralConfiguredBrowseObject.xaml
@@ -47,4 +47,9 @@
   <StringProperty Name="DebugSymbols" DisplayName="Símbolos de depuración" Visible="False" />
   <EnumProperty Name="FileAlignment" DisplayName="Alineación de archivo" Visible="False" />
   <StringProperty Name="BaseAddress" DisplayName="Dirección base" Visible="False" />
+  <StringProperty Name="FullPath" DisplayName="Project Folder" ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/GeneralConfiguredBrowseObject.xaml
@@ -47,4 +47,9 @@
   <StringProperty Name="DebugSymbols" DisplayName="Symboles de débogage" Visible="False" />
   <EnumProperty Name="FileAlignment" DisplayName="Alignement des fichiers" Visible="False" />
   <StringProperty Name="BaseAddress" DisplayName="Adresse de base" Visible="False" />
+  <StringProperty Name="FullPath" DisplayName="Project Folder" ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/GeneralConfiguredBrowseObject.xaml
@@ -47,4 +47,9 @@
   <StringProperty Name="DebugSymbols" DisplayName="Simboli di debug" Visible="False" />
   <EnumProperty Name="FileAlignment" DisplayName="Allineamento file" Visible="False" />
   <StringProperty Name="BaseAddress" DisplayName="Indirizzo di base" Visible="False" />
+  <StringProperty Name="FullPath" DisplayName="Project Folder" ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/GeneralConfiguredBrowseObject.xaml
@@ -47,4 +47,9 @@
   <StringProperty Name="DebugSymbols" DisplayName="デバッグ シンボル" Visible="False" />
   <EnumProperty Name="FileAlignment" DisplayName="ファイルの配置" Visible="False" />
   <StringProperty Name="BaseAddress" DisplayName="ベース アドレス" Visible="False" />
+  <StringProperty Name="FullPath" DisplayName="Project Folder" ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/GeneralConfiguredBrowseObject.xaml
@@ -47,4 +47,9 @@
   <StringProperty Name="DebugSymbols" DisplayName="디버그 기호" Visible="False" />
   <EnumProperty Name="FileAlignment" DisplayName="파일 맞춤" Visible="False" />
   <StringProperty Name="BaseAddress" DisplayName="기준 주소" Visible="False" />
+  <StringProperty Name="FullPath" DisplayName="Project Folder" ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/GeneralConfiguredBrowseObject.xaml
@@ -47,4 +47,9 @@
   <StringProperty Name="DebugSymbols" DisplayName="Symbole debugowania" Visible="False" />
   <EnumProperty Name="FileAlignment" DisplayName="Wyrównanie pliku" Visible="False" />
   <StringProperty Name="BaseAddress" DisplayName="Adres podstawowy" Visible="False" />
+  <StringProperty Name="FullPath" DisplayName="Project Folder" ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/GeneralConfiguredBrowseObject.xaml
@@ -47,4 +47,9 @@
   <StringProperty Name="DebugSymbols" DisplayName="Símbolos de depuração" Visible="False" />
   <EnumProperty Name="FileAlignment" DisplayName="Alinhamento de Arquivo" Visible="False" />
   <StringProperty Name="BaseAddress" DisplayName="Endereço básico" Visible="False" />
+  <StringProperty Name="FullPath" DisplayName="Project Folder" ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/GeneralConfiguredBrowseObject.xaml
@@ -47,4 +47,9 @@
   <StringProperty Name="DebugSymbols" DisplayName="Символы отладки" Visible="False" />
   <EnumProperty Name="FileAlignment" DisplayName="Выравнивание файла" Visible="False" />
   <StringProperty Name="BaseAddress" DisplayName="Базовый адрес" Visible="False" />
+  <StringProperty Name="FullPath" DisplayName="Project Folder" ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/GeneralConfiguredBrowseObject.xaml
@@ -47,4 +47,9 @@
   <StringProperty Name="DebugSymbols" DisplayName="Hata ayıklama simgeleri" Visible="False" />
   <EnumProperty Name="FileAlignment" DisplayName="Dosya Hizalama" Visible="False" />
   <StringProperty Name="BaseAddress" DisplayName="Temel adres" Visible="False" />
+  <StringProperty Name="FullPath" DisplayName="Project Folder" ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.cs.xlf
@@ -133,6 +133,11 @@
         <target state="translated">Obecné</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="StringProperty|FullPath|DisplayName">
+        <source>Project Folder</source>
+        <target state="new">Project Folder</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.de.xlf
@@ -133,6 +133,11 @@
         <target state="translated">Allgemein</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="StringProperty|FullPath|DisplayName">
+        <source>Project Folder</source>
+        <target state="new">Project Folder</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.es.xlf
@@ -133,6 +133,11 @@
         <target state="translated">General</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="StringProperty|FullPath|DisplayName">
+        <source>Project Folder</source>
+        <target state="new">Project Folder</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.fr.xlf
@@ -133,6 +133,11 @@
         <target state="translated">Général</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="StringProperty|FullPath|DisplayName">
+        <source>Project Folder</source>
+        <target state="new">Project Folder</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.it.xlf
@@ -133,6 +133,11 @@
         <target state="translated">Generale</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="StringProperty|FullPath|DisplayName">
+        <source>Project Folder</source>
+        <target state="new">Project Folder</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.ja.xlf
@@ -133,6 +133,11 @@
         <target state="translated">全般</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="StringProperty|FullPath|DisplayName">
+        <source>Project Folder</source>
+        <target state="new">Project Folder</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.ko.xlf
@@ -133,6 +133,11 @@
         <target state="translated">일반</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="StringProperty|FullPath|DisplayName">
+        <source>Project Folder</source>
+        <target state="new">Project Folder</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.pl.xlf
@@ -133,6 +133,11 @@
         <target state="translated">Ogólne</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="StringProperty|FullPath|DisplayName">
+        <source>Project Folder</source>
+        <target state="new">Project Folder</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.pt-BR.xlf
@@ -133,6 +133,11 @@
         <target state="translated">Geral</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="StringProperty|FullPath|DisplayName">
+        <source>Project Folder</source>
+        <target state="new">Project Folder</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.ru.xlf
@@ -133,6 +133,11 @@
         <target state="translated">Общие</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="StringProperty|FullPath|DisplayName">
+        <source>Project Folder</source>
+        <target state="new">Project Folder</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.tr.xlf
@@ -133,6 +133,11 @@
         <target state="translated">Общие</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="StringProperty|FullPath|DisplayName">
+        <source>Project Folder</source>
+        <target state="new">Project Folder</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.xlf
@@ -107,6 +107,10 @@
         <source>General</source>
         <note></note>
       </trans-unit>
+      <trans-unit id="StringProperty|FullPath|DisplayName">
+        <source>Project Folder</source>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.zh-Hans.xlf
@@ -133,6 +133,11 @@
         <target state="translated">常规</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="StringProperty|FullPath|DisplayName">
+        <source>Project Folder</source>
+        <target state="new">Project Folder</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.zh-Hant.xlf
@@ -133,6 +133,11 @@
         <target state="translated">一般</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="StringProperty|FullPath|DisplayName">
+        <source>Project Folder</source>
+        <target state="new">Project Folder</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/GeneralConfiguredBrowseObject.xaml
@@ -47,4 +47,9 @@
   <StringProperty Name="DebugSymbols" DisplayName="调试符号" Visible="False" />
   <EnumProperty Name="FileAlignment" DisplayName="文件对齐" Visible="False" />
   <StringProperty Name="BaseAddress" DisplayName="基址" Visible="False" />
+  <StringProperty Name="FullPath" DisplayName="Project Folder" ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/GeneralConfiguredBrowseObject.xaml
@@ -47,4 +47,9 @@
   <StringProperty Name="DebugSymbols" DisplayName="偵錯符號" Visible="False" />
   <EnumProperty Name="FileAlignment" DisplayName="檔案記憶體對齊" Visible="False" />
   <StringProperty Name="BaseAddress" DisplayName="基底位址" Visible="False" />
+  <StringProperty Name="FullPath" DisplayName="Project Folder" ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 </Rule>


### PR DESCRIPTION
**Customer scenario**

When you click on .net core projects properties -> Build properties , output path browse button.
you get a VS Crash.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems?id=384363&_a=edit
https://github.com/dotnet/roslyn-project-system/issues/1589 

**Workarounds, if any**

none

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

low

**Performance impact**

low

**Is this a regression from a previous update?**

yes 

**Root cause analysis:**

we split the properties to configuration specific file and missed to carry this property over.

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

dogfooding