### PR TITLE
Add PackageId to NuGetRestore rules

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -66,6 +66,10 @@
                     Visible="False" 
                     ReadOnly="True" />
 
+    <StringProperty Name="PackageId" 
+                    Visible="False" 
+                    ReadOnly="True" />
+
     <StringProperty Name="PackageVersion" 
                     Visible="False" 
                     ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/NuGetRestore.xaml
@@ -40,6 +40,7 @@
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/NuGetRestore.xaml
@@ -40,6 +40,7 @@
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/NuGetRestore.xaml
@@ -40,6 +40,7 @@
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/NuGetRestore.xaml
@@ -40,6 +40,7 @@
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/NuGetRestore.xaml
@@ -40,6 +40,7 @@
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/NuGetRestore.xaml
@@ -40,6 +40,7 @@
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/NuGetRestore.xaml
@@ -40,6 +40,7 @@
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/NuGetRestore.xaml
@@ -40,6 +40,7 @@
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/NuGetRestore.xaml
@@ -40,6 +40,7 @@
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/NuGetRestore.xaml
@@ -40,6 +40,7 @@
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/NuGetRestore.xaml
@@ -40,6 +40,7 @@
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/NuGetRestore.xaml
@@ -40,6 +40,7 @@
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/NuGetRestore.xaml
@@ -40,6 +40,7 @@
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
+  <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />


### PR DESCRIPTION
Fixes  #1532 

**Customer scenario**

PackageId is not honored when restoring from Visual Studio (but is honored by `msbuild /t:restore` and `dotnet restore`). Hence given two projects, one with PackageId:
```xml
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <TargetFramework>netstandard1.4</TargetFramework>
    <PackageId>ReferencedProjectPackageID</PackageId>
  </PropertyGroup>
</Project>
```
and a second project referencing this by package id:
```xml
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <TargetFramework>netstandard1.4</TargetFramework>
  </PropertyGroup>
  <ItemGroup>
    <ProjectReference Include="..\ReferencedProject\ReferencedProject.csproj" />
    <PackageReference Include="ReferencedProjectPackageID" Version="1.0.0" />
  </ItemGroup>
</Project>
```
opening in Visual Studio produces a restore error:
`Unable to resolve 'ReferencedProjectPackageID (>= 1.0.0)' for '.NETStandard,Version=v1.4'.`

This is the ProjectSystem-side of the fix (add PackageId to NuGetRestore rules). A NuGet-side fix is also needed to consume the PackageId.

**Bugs this fixes:**

#1532

**Workarounds, if any**

Use `msbuild /t:restore` or `dotnet restore` instead

**Risk**

Low.

**Performance impact**

Low

**Is this a regression from a previous update?**

No

**How was the bug found?**

Directed testing

/cc @srivatsn @dsplaisted @nguerrera 
/cc NuGet @rrelyea @doronmotter @alpaix
/cc @Pilchie for Escrow consideration