### PR TITLE
Ensure that the LangaugeServiceHost is initialized when attempting to…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/LanguageServices/CSharpVsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/LanguageServices/CSharpVsContainedLanguageComponentsFactory.cs
@@ -13,10 +13,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
     {
         private static Guid CSharpLanguageServiceGuid = new Guid("694dd9b6-b865-4c5b-ad85-86356e9c88dc");
         [ImportingConstructor]
-        public CSharpVsContainedLanguageComponentsFactory(SVsServiceProvider serviceProvider,
-                                                        IUnconfiguredProjectVsServices projectServices,
-                                                        IProjectHostProvider projectHostProvider)
-            : base(serviceProvider, projectServices, projectHostProvider, CSharpLanguageServiceGuid)
+        public CSharpVsContainedLanguageComponentsFactory(
+            IUnconfiguredProjectCommonServices commonServices,
+            SVsServiceProvider serviceProvider,
+            IUnconfiguredProjectVsServices projectServices,
+            IProjectHostProvider projectHostProvider,
+            ILanguageServiceHost languageServiceHost)
+            : base(commonServices, serviceProvider, projectServices, projectHostProvider, languageServiceHost, CSharpLanguageServiceGuid)
         {
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ILanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ILanguageServiceHost.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
@@ -41,5 +43,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         {
             get;
         }
+
+        /// <summary>
+        ///     Initializes the langauge service host.
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task InitializeAsync(CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -110,6 +110,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             await UpdateProjectContextAndSubscriptionsAsync().ConfigureAwait(false);
         }
 
+        Task ILanguageServiceHost.InitializeAsync(CancellationToken cancellationToken)
+        {
+            return InitializeAsync(cancellationToken);
+        }
+
         private async Task OnProjectChangedAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e, RuleHandlerType handlerType)
         {
             if (IsDisposing || IsDisposed)
@@ -186,6 +191,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             AggregateWorkspaceProjectContext previousContextToDispose = null;
             return await ExecuteWithinLockAsync(async () =>
             {
+                await _commonServices.ThreadingService.SwitchToUIThread();
+
                 string newTargetFramework = null;
                 var projectProperties = await _commonServices.ActiveConfiguredProjectProperties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(false);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/LanguageServices/VisualBasicVsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/LanguageServices/VisualBasicVsContainedLanguageComponentsFactory.cs
@@ -14,10 +14,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         private static Guid VisualBasicLanguageServiceGuid = new Guid("e34acdc0-baae-11d0-88bf-00a0c9110049");
 
         [ImportingConstructor]
-        public VisualBasicVsContainedLanguageComponentsFactory(SVsServiceProvider serviceProvider,
-                                                        IUnconfiguredProjectVsServices projectServices,
-                                                        IProjectHostProvider projectHostProvider)
-            : base(serviceProvider, projectServices, projectHostProvider, VisualBasicLanguageServiceGuid)
+        public VisualBasicVsContainedLanguageComponentsFactory(
+            IUnconfiguredProjectCommonServices commonServices,
+            SVsServiceProvider serviceProvider,
+            IUnconfiguredProjectVsServices projectServices,
+            IProjectHostProvider projectHostProvider,
+            ILanguageServiceHost languageServiceHost)
+            : base(commonServices, serviceProvider, projectServices, projectHostProvider, languageServiceHost, VisualBasicLanguageServiceGuid)
         {
         }
     }


### PR DESCRIPTION
… fetch the contained langauge factory for a venus file.

**Customer scenario**

User opens a cshtml file in an asp.net core project while the project is still loading and this causes broken intellisense/language service for the project.

**Bugs this fixes:**

Fixes #1617

**Workarounds, if any**

Users need to close and re-open the solution.

**Risk**

Low risk.
This is a race condition where we are attempting to get the contained language factory before our language service host has been initialized. The fix is to ensure that we explicitly await langauge service host initialization at the beginning of GetContainedLanguageFactoryForFile.

**Performance impact**

Low

**Is this a regression from a previous update?**

Yes. Seems like this race condition has been exposed by some of our recent changes, though the race has existed in the code base since the initial implementation

**Root cause analysis:**

Noted above.

**How was the bug found?**

Automated tests.