### PR TITLE
Project file cleanup of all the projects in the repo

### DIFF
--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -66,7 +66,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <EnableDefaultItems>false</EnableDefaultItems>
     <VisualStudioReferenceMajorVersion Condition="'$(VisualStudioReferenceMajorVersion)' == ''">$(VisualStudioVersion.Substring(0, $(VisualStudioVersion.IndexOf('.'))))</VisualStudioReferenceMajorVersion>
     <VisualStudioReferenceAssemblyVersion Condition="'$(VisualStudioReferenceAssemblyVersion)' == ''">$(VisualStudioReferenceMajorVersion).0.0.0</VisualStudioReferenceAssemblyVersion>
     <VisualStudioCodename>Dev$(VisualStudioReferenceMajorVersion)</VisualStudioCodename>

--- a/src/Dependencies/CPS/CPS.csproj
+++ b/src/Dependencies/CPS/CPS.csproj
@@ -1,3 +1,4 @@
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>

--- a/src/Dependencies/CPS/CPS.csproj
+++ b/src/Dependencies/CPS/CPS.csproj
@@ -8,10 +8,7 @@
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="15.0.661-pre-g3d0c752f96" PrivateAssets="None" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Immutable\Immutable.csproj">
-      <Project>{dcda908d-ef5e-494b-addc-c26f5fd610ca}</Project>
-      <Name>Immutable</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Immutable\Immutable.csproj" />
   </ItemGroup>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Imports.targets" />
 </Project>

--- a/src/Dependencies/CPS/CPS.csproj
+++ b/src/Dependencies/CPS/CPS.csproj
@@ -1,12 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <IsPortable>false</IsPortable>
-  </PropertyGroup>
+<Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>
-    <ProjectGuid>{03AB838C-1B9D-4ECA-856F-476616C35F0C}</ProjectGuid>
-    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectSystemLayer>Dependency</ProjectSystemLayer>
     <TargetFramework>net46</TargetFramework>
   </PropertyGroup>

--- a/src/Dependencies/Composition/Composition.csproj
+++ b/src/Dependencies/Composition/Composition.csproj
@@ -1,3 +1,4 @@
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>

--- a/src/Dependencies/Composition/Composition.csproj
+++ b/src/Dependencies/Composition/Composition.csproj
@@ -1,9 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>
-    <ProjectGuid>{A57DDFE5-AB0E-4371-98E5-11B9218DF11C}</ProjectGuid>
-    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectSystemLayer>Dependency</ProjectSystemLayer>
     <TargetFramework>netstandard1.0</TargetFramework>
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wpa81+wp8</PackageTargetFallback>

--- a/src/Dependencies/CoreFX/CoreFX.csproj
+++ b/src/Dependencies/CoreFX/CoreFX.csproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>
     <ProjectSystemLayer>Dependency</ProjectSystemLayer>

--- a/src/Dependencies/CoreFX/CoreFX.csproj
+++ b/src/Dependencies/CoreFX/CoreFX.csproj
@@ -1,11 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <IsPortable>false</IsPortable>
-  </PropertyGroup>
+﻿<Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>
-    <ProjectGuid>{88DDC6CF-7FD2-4201-A626-9412183067B7}</ProjectGuid>
     <ProjectSystemLayer>Dependency</ProjectSystemLayer>
     <TargetFramework>net46</TargetFramework>
   </PropertyGroup>

--- a/src/Dependencies/Immutable/Immutable.csproj
+++ b/src/Dependencies/Immutable/Immutable.csproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>
     <ProjectSystemLayer>Dependency</ProjectSystemLayer>

--- a/src/Dependencies/Immutable/Immutable.csproj
+++ b/src/Dependencies/Immutable/Immutable.csproj
@@ -1,8 +1,6 @@
-﻿<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>
-    <ProjectGuid>{DCDA908D-EF5E-494B-ADDC-C26F5FD610CA}</ProjectGuid>
-    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectSystemLayer>Dependency</ProjectSystemLayer>
     <TargetFramework>netstandard1.0</TargetFramework>
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wpa81+wp8</PackageTargetFallback>

--- a/src/Dependencies/Json.net/Json.net.csproj
+++ b/src/Dependencies/Json.net/Json.net.csproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>
     <ProjectSystemLayer>Dependency</ProjectSystemLayer>

--- a/src/Dependencies/Json.net/Json.net.csproj
+++ b/src/Dependencies/Json.net/Json.net.csproj
@@ -1,12 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <IsPortable>false</IsPortable>
-  </PropertyGroup>
+﻿<Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>
-    <ProjectGuid>{CA374AF1-C983-4019-8FD0-01FA510C6E56}</ProjectGuid>
-    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectSystemLayer>Dependency</ProjectSystemLayer>
     <TargetFramework>net46</TargetFramework>
   </PropertyGroup>

--- a/src/Dependencies/MSBuild/MSBuild.csproj
+++ b/src/Dependencies/MSBuild/MSBuild.csproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>
     <ProjectSystemLayer>Dependency</ProjectSystemLayer>

--- a/src/Dependencies/MSBuild/MSBuild.csproj
+++ b/src/Dependencies/MSBuild/MSBuild.csproj
@@ -1,12 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <IsPortable>false</IsPortable>
-  </PropertyGroup>
+﻿<Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>
-    <ProjectGuid>{83B4B0CC-33C2-46E3-A330-DFF43A0EC18D}</ProjectGuid>
-    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectSystemLayer>Dependency</ProjectSystemLayer>
     <TargetFramework>net46</TargetFramework>
   </PropertyGroup>

--- a/src/Dependencies/Metadata/Metadata.csproj
+++ b/src/Dependencies/Metadata/Metadata.csproj
@@ -1,3 +1,4 @@
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>

--- a/src/Dependencies/Metadata/Metadata.csproj
+++ b/src/Dependencies/Metadata/Metadata.csproj
@@ -1,9 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>
-    <ProjectGuid>{E6796B97-D5C6-45B2-AE46-351D15DCFC71}</ProjectGuid>
-    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectSystemLayer>Dependency</ProjectSystemLayer>
     <TargetFramework>netstandard1.0</TargetFramework>
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8</PackageTargetFallback>

--- a/src/Dependencies/Moq.net/Moq.net.csproj
+++ b/src/Dependencies/Moq.net/Moq.net.csproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>
     <ProjectSystemLayer>Dependency</ProjectSystemLayer>

--- a/src/Dependencies/Moq.net/Moq.net.csproj
+++ b/src/Dependencies/Moq.net/Moq.net.csproj
@@ -1,12 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <IsPortable>false</IsPortable>
-  </PropertyGroup>
+﻿<Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>
-    <ProjectGuid>{A32EAB7F-691C-4D00-98C4-F50C37BB4754}</ProjectGuid>
-    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectSystemLayer>Dependency</ProjectSystemLayer>
     <TargetFramework>net46</TargetFramework>
   </PropertyGroup>

--- a/src/Dependencies/Roslyn/Roslyn.csproj
+++ b/src/Dependencies/Roslyn/Roslyn.csproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>
     <ProjectSystemLayer>Dependency</ProjectSystemLayer>

--- a/src/Dependencies/Roslyn/Roslyn.csproj
+++ b/src/Dependencies/Roslyn/Roslyn.csproj
@@ -1,11 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <IsPortable>false</IsPortable>
-  </PropertyGroup>
+﻿<Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>
-    <ProjectGuid>{CF97A73F-F2F1-4893-960C-9C2B95738870}</ProjectGuid>
     <ProjectSystemLayer>Dependency</ProjectSystemLayer>
     <TargetFramework>net46</TargetFramework>
   </PropertyGroup>

--- a/src/Dependencies/Toolset/Toolset.csproj
+++ b/src/Dependencies/Toolset/Toolset.csproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>
     <ProjectSystemLayer>Toolset</ProjectSystemLayer>

--- a/src/Dependencies/Toolset/Toolset.csproj
+++ b/src/Dependencies/Toolset/Toolset.csproj
@@ -1,9 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>
-    <ProjectGuid>{4D52C1E5-6F4B-4CDE-8149-AC374F018245}</ProjectGuid>
-    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectSystemLayer>Toolset</ProjectSystemLayer>
     <TargetFramework>netstandard1.0</TargetFramework>
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wpa81+wp8;net461</PackageTargetFallback>

--- a/src/Dependencies/VisualStudio/VisualStudio.csproj
+++ b/src/Dependencies/VisualStudio/VisualStudio.csproj
@@ -1,3 +1,4 @@
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>

--- a/src/Dependencies/VisualStudio/VisualStudio.csproj
+++ b/src/Dependencies/VisualStudio/VisualStudio.csproj
@@ -26,10 +26,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" Version="15.0.691-master31907920" ExcludeAssets="Build" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Json.net\Json.net.csproj">
-      <Project>{ca374af1-c983-4019-8fd0-01fa510c6e56}</Project>
-      <Name>Json.net</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Json.net\Json.net.csproj" />
   </ItemGroup>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Imports.targets" />
 </Project>

--- a/src/Dependencies/VisualStudio/VisualStudio.csproj
+++ b/src/Dependencies/VisualStudio/VisualStudio.csproj
@@ -1,12 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <IsPortable>false</IsPortable>
-  </PropertyGroup>
+<Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>
-    <ProjectGuid>{8DA861D8-0CCE-4334-B6C0-01A846C881EC}</ProjectGuid>
-    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectSystemLayer>Dependency</ProjectSystemLayer>
     <TargetFramework>net46</TargetFramework>
   </PropertyGroup>

--- a/src/Dependencies/xUnit.net/xUnit.net.csproj
+++ b/src/Dependencies/xUnit.net/xUnit.net.csproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>
     <ProjectSystemLayer>Dependency</ProjectSystemLayer>

--- a/src/Dependencies/xUnit.net/xUnit.net.csproj
+++ b/src/Dependencies/xUnit.net/xUnit.net.csproj
@@ -1,9 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>
-    <ProjectGuid>{8635CB8F-D210-41ED-B4FF-71502CDB475C}</ProjectGuid>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectSystemLayer>Dependency</ProjectSystemLayer>
     <TargetFramework>net46</TargetFramework>
   </PropertyGroup>

--- a/src/DeployTestDependencies/DeployTestDependencies.csproj
+++ b/src/DeployTestDependencies/DeployTestDependencies.csproj
@@ -1,13 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <PropertyGroup>
-    <IsPortable>false</IsPortable>
     <IsDeployment>true</IsDeployment>
   </PropertyGroup>
   <Import Project="..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>
-    <ProjectGuid>{37BA82E6-9ABD-4ACA-AA26-2DFD39A359A5}</ProjectGuid>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFramework>net46</TargetFramework>
     <OutDir>$(OutDir)Tests\</OutDir>

--- a/src/DeployTestDependencies/DeployTestDependencies.csproj
+++ b/src/DeployTestDependencies/DeployTestDependencies.csproj
@@ -17,42 +17,15 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.VisualStudio.AppDesigner\Microsoft.VisualStudio.AppDesigner.vbproj">
-      <Project>{19725d6f-4690-412b-934a-fc48d752b802}</Project>
-      <Name>Microsoft.VisualStudio.AppDesigner</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.Editors\Microsoft.VisualStudio.Editors.vbproj">
-      <Project>{cd6e5d00-7b0b-442d-9f5d-eaec1a71838a}</Project>
-      <Name>Microsoft.VisualStudio.Editors</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp.VS\Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj">
-      <Project>{765ef6eb-9f36-4d68-8c3d-9e11cd49e0bc}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.CSharp.VS</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp\Microsoft.VisualStudio.ProjectSystem.CSharp.csproj">
-      <Project>{7d150b7b-ce02-4cd4-8ec9-6a7c18727a36}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.CSharp</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj">
-      <Project>{23bcbc90-ed65-4ee3-8af1-dd7caefdbee9}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.TestServices</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS\Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj">
-      <Project>{1c5666ea-24a4-4ec2-b8fb-faedf6b14697}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.VS</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj">
-      <Project>{6c6a41ce-72c5-4d77-8208-d01693f9bc88}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS\Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.csproj">
-      <Project>{15dcb34c-b628-49b8-b472-bba65a0ab6a5}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.VisualBasic\Microsoft.VisualStudio.ProjectSystem.VisualBasic.csproj">
-      <Project>{04aa393a-48c2-424d-985c-77385a962019}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.VisualBasic</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.VisualStudio.AppDesigner\Microsoft.VisualStudio.AppDesigner.vbproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.Editors\Microsoft.VisualStudio.Editors.vbproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp.VS\Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp\Microsoft.VisualStudio.ProjectSystem.CSharp.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS\Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS\Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.VisualBasic\Microsoft.VisualStudio.ProjectSystem.VisualBasic.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.1.0" />

--- a/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
+++ b/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
   <PropertyGroup>
     <UseVisualStudioVersion>true</UseVisualStudioVersion>
   </PropertyGroup>
@@ -7,7 +6,6 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{19725D6F-4690-412B-934A-FC48D752B802}</ProjectGuid>
     <AssemblyName>Microsoft.VisualStudio.AppDesigner</AssemblyName>
     <OutputType>Library</OutputType>
     <RootNamespace>

--- a/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
+++ b/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
@@ -13,7 +13,6 @@
     <SignAssembly>true</SignAssembly>
     <NoWarn>$(NoWarn);42105;42107;42353;42307</NoWarn>
     <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
-    <EnableDefaultItems>true</EnableDefaultItems>
     <!-- Override Roslyn which embeds by default -->
     <VBRuntime>Default</VBRuntime>
     <TargetFramework>net46</TargetFramework>

--- a/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
+++ b/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <PropertyGroup>
     <UseVisualStudioVersion>true</UseVisualStudioVersion>
   </PropertyGroup>

--- a/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
+++ b/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
@@ -65,6 +65,7 @@
     <Compile Include="ApplicationDesigner\PropertyPageSite.vb" />
     <Compile Include="ApplicationDesigner\SpecialFileCustomView.Designer.vb">
       <DependentUpon>SpecialFileCustomView.vb</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="ApplicationDesigner\SpecialFileCustomView.vb">
       <SubType>UserControl</SubType>
@@ -88,6 +89,7 @@
     <Compile Include="DesignerFramework\DesignUtil.vb" />
     <Compile Include="DesignerFramework\ErrorControl.Designer.vb">
       <DependentUpon>ErrorControl.vb</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="DesignerFramework\ErrorControl.vb">
       <SubType>UserControl</SubType>

--- a/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
+++ b/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
@@ -4,12 +4,7 @@
   </PropertyGroup>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <AssemblyName>Microsoft.VisualStudio.AppDesigner</AssemblyName>
-    <OutputType>Library</OutputType>
-    <RootNamespace>
-    </RootNamespace>
+    <RootNamespace></RootNamespace>
     <OptionCompare>binary</OptionCompare>
     <OptionExplicit>On</OptionExplicit>
     <OptionStrict>On</OptionStrict>
@@ -17,10 +12,9 @@
     <SignAssembly>true</SignAssembly>
     <NoWarn>$(NoWarn);42105;42107;42353;42307</NoWarn>
     <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
+    <EnableDefaultItems>true</EnableDefaultItems>
     <!-- Override Roslyn which embeds by default -->
     <VBRuntime>Default</VBRuntime>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-    <TargetFrameworkProfile />
     <TargetFramework>net46</TargetFramework>
     <ProjectSystemLayer>VisualStudioDesigner</ProjectSystemLayer>
     <StrongNameCertificate>Microsoft</StrongNameCertificate>
@@ -33,182 +27,116 @@
     <Compile Include="..\Common\ManagedCodeMarkers.vb">
       <Link>ManagedCodeMarkers.vb</Link>
     </Compile>
-    <Compile Include="ApplicationDesigner\ApplicationDesignerEditorFactory.vb" />
-    <Compile Include="ApplicationDesigner\ApplicationDesignerLoader.vb" />
-    <Compile Include="ApplicationDesigner\ApplicationDesignerPanel.vb">
+    <Compile Update="ApplicationDesigner\ApplicationDesignerPanel.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="ApplicationDesigner\ApplicationDesignerRootComponent.vb">
+    <Compile Update="ApplicationDesigner\ApplicationDesignerRootComponent.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="ApplicationDesigner\ApplicationDesignerRootDesigner.vb" />
-    <Compile Include="ApplicationDesigner\ApplicationDesignerView.vb">
+    <Compile Update="ApplicationDesigner\ApplicationDesignerView.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="ApplicationDesigner\ApplicationDesignerWindowPane.vb" />
-    <Compile Include="ApplicationDesigner\ApplicationDesignerWindowPaneControl.vb">
+    <Compile Update="ApplicationDesigner\ApplicationDesignerWindowPaneControl.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="ApplicationDesigner\CmdTargetHelper.vb" />
-    <Compile Include="ApplicationDesigner\CustomViewProvider.vb" />
-    <Compile Include="ApplicationDesigner\DeferrableWindowPaneProviderService.vb" />
-    <Compile Include="ApplicationDesigner\DesignerTabButton.vb">
+    <Compile Update="ApplicationDesigner\DesignerTabButton.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="ApplicationDesigner\DesignerTabControl.vb">
+    <Compile Update="ApplicationDesigner\DesignerTabControl.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="ApplicationDesigner\DesignerTabControlRenderer.vb" />
-    <Compile Include="ApplicationDesigner\ErrorControlCustomViewProvider.vb" />
-    <Compile Include="ApplicationDesigner\IVsEditWindowNotify.vb" />
-    <Compile Include="ApplicationDesigner\PropertyPageInfo.vb" />
-    <Compile Include="ApplicationDesigner\PropertyPageSite.vb" />
-    <Compile Include="ApplicationDesigner\SpecialFileCustomView.Designer.vb">
-      <DependentUpon>SpecialFileCustomView.vb</DependentUpon>
+    <Compile Update="ApplicationDesigner\SpecialFileCustomView.Designer.vb">
+      <DependentUpon>SpecialFileCustomView.vb</DependentUpon>    
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="ApplicationDesigner\SpecialFileCustomView.vb">
+    <Compile Update="ApplicationDesigner\SpecialFileCustomView.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="ApplicationDesigner\SpecialFileCustomViewProvider.vb" />
-    <Compile Include="Common\ArgumentValidation.vb" />
-    <Compile Include="Common\DTEUtils.vb" />
-    <Compile Include="Common\ShellUtil.vb" />
-    <Compile Include="Common\switches.vb" />
-    <Compile Include="Common\Utils.vb" />
-    <Compile Include="Common\WaitCursor.vb" />
-    <Compile Include="Common\wmuserconstants.vb" />
-    <Compile Include="Constants.vb" />
-    <Compile Include="DesignerFramework\BaseDialog.vb">
+    <Compile Update="DesignerFramework\BaseDialog.vb">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="DesignerFramework\BaseRootDesigner.vb" />
-    <Compile Include="DesignerFramework\DesignerMenuCommand.vb" />
-    <Compile Include="DesignerFramework\DesignerMessageBox.vb" />
-    <Compile Include="DesignerFramework\DesignerWindowPaneProviderBase.vb" />
-    <Compile Include="DesignerFramework\DesignUtil.vb" />
-    <Compile Include="DesignerFramework\ErrorControl.Designer.vb">
-      <DependentUpon>ErrorControl.vb</DependentUpon>
+    <Compile Update="DesignerFramework\ErrorControl.Designer.vb">
+      <DependentUpon>ErrorControl.vb</DependentUpon>    
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="DesignerFramework\ErrorControl.vb">
+    <Compile Update="DesignerFramework\ErrorControl.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="DesignerFramework\SourceCodeControlManager.vb" />
-    <Compile Include="GlobalSuppressions.vb" />
-    <Compile Include="InternalException.vb" />
-    <Compile Include="interop\ILangInactiveCfgPropertyNotifySink.vb" />
-    <Compile Include="interop\ISpecifyPropertyPages.vb" />
-    <Compile Include="interop\IVsAppId.vb" />
-    <Compile Include="interop\LOGVIEWID.vb" />
-    <Compile Include="interop\NativeMethods.vb" />
-    <Compile Include="interop\win.vb" />
-    <Compile Include="IVBPackage.vb" />
-    <Compile Include="My Project\AssemblyInfo.vb" />
-    <Compile Include="MyApplicationProperties.vb" />
-    <Compile Include="PropPageDesigner\ConfigurationState.vb" />
-    <Compile Include="PropPageDesigner\DeferrableWindowPaneProviderService.vb" />
-    <Compile Include="PropPageDesigner\MultipleValuesStore.vb" />
-    <Compile Include="PropPageDesigner\PropertyPagePropertyDescriptor.vb" />
-    <Compile Include="PropPageDesigner\PropertyPageSerializationService.vb" />
-    <Compile Include="PropPageDesigner\PropertyPageSerializationService_Store.vb" />
-    <Compile Include="PropPageDesigner\PropPageDesignerDocData.vb" />
-    <Compile Include="PropPageDesigner\PropPageDesignerEditorFactory.vb" />
-    <Compile Include="PropPageDesigner\PropPageDesignerLoader.vb" />
-    <Compile Include="PropPageDesigner\PropPageDesignerRootComponent.vb">
+    <Compile Update="PropPageDesigner\PropPageDesignerRootComponent.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="PropPageDesigner\PropPageDesignerRootDesigner.vb" />
-    <Compile Include="PropPageDesigner\PropPageDesignerView.vb">
+    <Compile Update="PropPageDesigner\PropPageDesignerView.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPageDesigner\PropPageDesignerWindowPane.vb" />
-    <Compile Include="PropPages\ChildPageSite.vb" />
-    <Compile Include="PropPages\ControlDataFlags.vb" />
-    <Compile Include="PropPages\CpsPropertyDescriptorWrapper.vb" />
-    <Compile Include="PropPages\HiddenIfMissingPropertyControlData.vb" />
-    <Compile Include="PropPages\ProjectReloadedException.vb" />
-    <Compile Include="PropPages\PropertyControlData.vb" />
-    <Compile Include="PropPages\PropertyListener.vb" />
-    <Compile Include="PropPages\PropertyPageException.vb" />
-    <Compile Include="PropPages\PropPage.vb" />
-    <Compile Include="PropPages\PropPageHostDialog.vb">
+    <Compile Update="PropPages\PropPageHostDialog.vb">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="PropPages\PropPageUserControlBase.vb">
+    <Compile Update="PropPages\PropPageUserControlBase.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\SKUMatrix.vb" />
-    <Compile Include="PropPages\ValidationException.vb" />
-    <Compile Include="PropPages\ValidationResult.vb" />
-    <Compile Include="PropPages\VSThemedLinkLabel.vb">
+    <Compile Update="PropPages\VSThemedLinkLabel.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="Resources\Designer.Designer.vb">
+    <Compile Update="Resources\Designer.Designer.vb">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>Designer.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Resources\Resources.vb" />
-    <Compile Include="VisualStudioEditorsID.vb" />
-    <Compile Include="VSProductSKU.vb" />
+    </Compile>    
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="ApplicationDesigner\ApplicationDesignerView.resx">
+    <EmbeddedResource Update="ApplicationDesigner\ApplicationDesignerView.resx">
       <DependentUpon>ApplicationDesignerView.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="ApplicationDesigner\ApplicationDesignerView.*.resx">
+    <EmbeddedResource Update="ApplicationDesigner\ApplicationDesignerView.*.resx">
       <DependentUpon>ApplicationDesignerView.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="ApplicationDesigner\SpecialFileCustomView.resx">
+    <EmbeddedResource Update="ApplicationDesigner\SpecialFileCustomView.resx">
       <DependentUpon>SpecialFileCustomView.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="ApplicationDesigner\SpecialFileCustomView.*.resx">
+    <EmbeddedResource Update="ApplicationDesigner\SpecialFileCustomView.*.resx">
       <DependentUpon>SpecialFileCustomView.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPageDesigner\PropPageDesignerView.resx">
+    <EmbeddedResource Update="PropPageDesigner\PropPageDesignerView.resx">
       <DependentUpon>PropPageDesignerView.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPageDesigner\PropPageDesignerView.*.resx">
+    <EmbeddedResource Update="PropPageDesigner\PropPageDesignerView.*.resx">
       <DependentUpon>PropPageDesignerView.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\PropPageHostDialog.resx">
+    <EmbeddedResource Update="PropPages\PropPageHostDialog.resx">
       <DependentUpon>PropPageHostDialog.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\PropPageHostDialog.*.resx">
+    <EmbeddedResource Update="PropPages\PropPageHostDialog.*.resx">
       <DependentUpon>PropPageHostDialog.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\PropPageUserControlBase.resx">
+    <EmbeddedResource Update="PropPages\PropPageUserControlBase.resx">
       <DependentUpon>PropPageUserControlBase.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="Resources\Designer.resx">
+    <EmbeddedResource Update="Resources\Designer.resx">
       <LogicalName>Microsoft.VisualStudio.AppDesigner.Designer.resources</LogicalName>
       <CustomToolNamespace>My.Resources</CustomToolNamespace>
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Designer.Designer.vb</LastGenOutput>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="Resources\Designer.*.resx">
+    <EmbeddedResource Update="Resources\Designer.*.resx">
       <LogicalName>Microsoft.VisualStudio.AppDesigner.%(Filename).resources</LogicalName>
       <DependentUpon>Designer.resx</DependentUpon>
     </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="DesignerFramework\ErrorControl.resx">
+    <EmbeddedResource Update="DesignerFramework\ErrorControl.resx">
       <DependentUpon>ErrorControl.vb</DependentUpon>
     </EmbeddedResource>
-    <EmbeddedResource Include="DesignerFramework\ErrorControl.*.resx">
+    <EmbeddedResource Update="DesignerFramework\ErrorControl.*.resx">
       <DependentUpon>ErrorControl.vb</DependentUpon>
-    </EmbeddedResource>
+    </EmbeddedResource>    
     <EmbeddedResource Include="Resources\ApplicationDesigner\OverflowImage.png">
       <LogicalName>Microsoft.VisualStudio.Editors.ApplicationDesigner.OverflowImage</LogicalName>
     </EmbeddedResource>

--- a/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
+++ b/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
@@ -4,7 +4,8 @@
   </PropertyGroup>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
-    <RootNamespace></RootNamespace>
+    <RootNamespace>
+    </RootNamespace>
     <OptionCompare>binary</OptionCompare>
     <OptionExplicit>On</OptionExplicit>
     <OptionStrict>On</OptionStrict>

--- a/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
+++ b/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
@@ -4,10 +4,6 @@
   </PropertyGroup>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <AssemblyName>Microsoft.VisualStudio.Editors</AssemblyName>
-    <OutputType>Library</OutputType>
     <RootNamespace>
     </RootNamespace>
     <OptionCompare>binary</OptionCompare>
@@ -17,10 +13,9 @@
     <SignAssembly>true</SignAssembly>
     <NoWarn>$(NoWarn);42105;42107;42353;42355</NoWarn>
     <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
+    <EnableDefaultItems>true</EnableDefaultItems>
     <!-- Override Roslyn which embeds by default -->
     <VBRuntime>Default</VBRuntime>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-    <TargetFrameworkProfile />
     <TargetFramework>net46</TargetFramework>
     <ProjectSystemLayer>VisualStudioDesigner</ProjectSystemLayer>
     <StrongNameCertificate>Microsoft</StrongNameCertificate>
@@ -42,323 +37,323 @@
     <RCResourceFile Include="native.rc" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="AddImportsDialogs\AddImports.resx">
+    <EmbeddedResource Update="AddImportsDialogs\AddImports.resx">
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="AddImportsDialogs\AddImports.*.resx">
+    <EmbeddedResource Update="AddImportsDialogs\AddImports.*.resx">
       <SubType>Designer</SubType>
       <DependentUpon>AddImports.resx</DependentUpon>
     </EmbeddedResource>
-    <EmbeddedResource Include="AddImportsDialogs\AutoAddImportsCollisionDialog.resx">
+    <EmbeddedResource Update="AddImportsDialogs\AutoAddImportsCollisionDialog.resx">
       <DependentUpon>AutoAddImportsCollisionDialog.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="AddImportsDialogs\AutoAddImportsCollisionDialog.*.resx">
+    <EmbeddedResource Update="AddImportsDialogs\AutoAddImportsCollisionDialog.*.resx">
       <DependentUpon>AutoAddImportsCollisionDialog.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="AddImportsDialogs\AutoAddImportsExtensionCollisionDialog.resx">
+    <EmbeddedResource Update="AddImportsDialogs\AutoAddImportsExtensionCollisionDialog.resx">
       <DependentUpon>AutoAddImportsExtensionCollisionDialog.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="AddImportsDialogs\AutoAddImportsExtensionCollisionDialog.*.resx">
+    <EmbeddedResource Update="AddImportsDialogs\AutoAddImportsExtensionCollisionDialog.*.resx">
       <DependentUpon>AutoAddImportsExtensionCollisionDialog.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="DesignerFramework\ErrorControl.resx">
+    <EmbeddedResource Update="DesignerFramework\ErrorControl.resx">
       <DependentUpon>ErrorControl.vb</DependentUpon>
     </EmbeddedResource>
-    <EmbeddedResource Include="DesignerFramework\ErrorControl.*.resx">
+    <EmbeddedResource Update="DesignerFramework\ErrorControl.*.resx">
       <DependentUpon>ErrorControl.vb</DependentUpon>
     </EmbeddedResource>
-    <EmbeddedResource Include="MyExtensibility\AddMyExtensionsDialog.resx">
+    <EmbeddedResource Update="MyExtensibility\AddMyExtensionsDialog.resx">
       <DependentUpon>AddMyExtensionsDialog.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="MyExtensibility\AddMyExtensionsDialog.*.resx">
+    <EmbeddedResource Update="MyExtensibility\AddMyExtensionsDialog.*.resx">
       <DependentUpon>AddMyExtensionsDialog.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="MyExtensibility\AssemblyOptionDialog.resx">
+    <EmbeddedResource Update="MyExtensibility\AssemblyOptionDialog.resx">
       <DependentUpon>AssemblyOptionDialog.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="MyExtensibility\AssemblyOptionDialog.*.resx">
+    <EmbeddedResource Update="MyExtensibility\AssemblyOptionDialog.*.resx">
       <DependentUpon>AssemblyOptionDialog.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="MyExtensibility\MyExtensibilityPropPage.resx">
+    <EmbeddedResource Update="MyExtensibility\MyExtensibilityPropPage.resx">
       <DependentUpon>MyExtensibilityPropPage.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="MyExtensibility\MyExtensibilityPropPage.*.resx">
+    <EmbeddedResource Update="MyExtensibility\MyExtensibilityPropPage.*.resx">
       <DependentUpon>MyExtensibilityPropPage.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="Package\EditorToolsOptionsPanel.resx">
+    <EmbeddedResource Update="Package\EditorToolsOptionsPanel.resx">
       <DependentUpon>EditorToolsOptionsPanel.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.Package.EditorToolsOptionsPanel.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="Package\EditorToolsOptionsPanel.*.resx">
+    <EmbeddedResource Update="Package\EditorToolsOptionsPanel.*.resx">
       <DependentUpon>EditorToolsOptionsPanel.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.Package.EditorToolsOptionsPanel.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\AdvancedServicesDialog.resx">
+    <EmbeddedResource Update="PropPages\AdvancedServicesDialog.resx">
       <DependentUpon>AdvancedServicesDialog.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.AdvancedServicesDialog.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\AdvancedServicesDialog.*.resx">
+    <EmbeddedResource Update="PropPages\AdvancedServicesDialog.*.resx">
       <DependentUpon>AdvancedServicesDialog.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\AdvBuildSettingsPropPage.resx">
+    <EmbeddedResource Update="PropPages\AdvBuildSettingsPropPage.resx">
       <DependentUpon>AdvBuildSettingsPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.AdvBuildSettingsPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\AdvBuildSettingsPropPage.*.resx">
+    <EmbeddedResource Update="PropPages\AdvBuildSettingsPropPage.*.resx">
       <DependentUpon>AdvBuildSettingsPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\AdvCompilerSettingsPropPage.resx">
+    <EmbeddedResource Update="PropPages\AdvCompilerSettingsPropPage.resx">
       <DependentUpon>AdvCompilerSettingsPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.AdvCompilerSettingsPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\AdvCompilerSettingsPropPage.*.resx">
+    <EmbeddedResource Update="PropPages\AdvCompilerSettingsPropPage.*.resx">
       <DependentUpon>AdvCompilerSettingsPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\ApplicationPropPage.resx">
+    <EmbeddedResource Update="PropPages\ApplicationPropPage.resx">
       <DependentUpon>ApplicationPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.ApplicationPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\ApplicationPropPage.*.resx">
+    <EmbeddedResource Update="PropPages\ApplicationPropPage.*.resx">
       <DependentUpon>ApplicationPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\ApplicationPropPageBase.resx">
+    <EmbeddedResource Update="PropPages\ApplicationPropPageBase.resx">
       <DependentUpon>ApplicationPropPageBase.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\ApplicationPropPageBase.*.resx">
+    <EmbeddedResource Update="PropPages\ApplicationPropPageBase.*.resx">
       <DependentUpon>ApplicationPropPageBase.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\ApplicationPropPageVBBase.resx">
+    <EmbeddedResource Update="PropPages\ApplicationPropPageVBBase.resx">
       <DependentUpon>ApplicationPropPageVBBase.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\ApplicationPropPageVBBase.*.resx">
+    <EmbeddedResource Update="PropPages\ApplicationPropPageVBBase.*.resx">
       <DependentUpon>ApplicationPropPageVBBase.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\ApplicationPropPageVBWinForms.resx">
+    <EmbeddedResource Update="PropPages\ApplicationPropPageVBWinForms.resx">
       <DependentUpon>ApplicationPropPageVBWinForms.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\ApplicationPropPageVBWinForms.*.resx">
+    <EmbeddedResource Update="PropPages\ApplicationPropPageVBWinForms.*.resx">
       <DependentUpon>ApplicationPropPageVBWinForms.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\PackagePropPage.resx">
+    <EmbeddedResource Update="PropPages\PackagePropPage.resx">
       <DependentUpon>PackagePropPage.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\PackagePropPage.*.resx">
+    <EmbeddedResource Update="PropPages\PackagePropPage.*.resx">
       <DependentUpon>PackagePropPage.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\AssemblyInfoPropPage.resx">
+    <EmbeddedResource Update="PropPages\AssemblyInfoPropPage.resx">
       <DependentUpon>AssemblyInfoPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.AssemblyInfoPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\AssemblyInfoPropPage.*.resx">
+    <EmbeddedResource Update="PropPages\AssemblyInfoPropPage.*.resx">
       <DependentUpon>AssemblyInfoPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\BuildEventCommandLineDialog.resx">
+    <EmbeddedResource Update="PropPages\BuildEventCommandLineDialog.resx">
       <DependentUpon>BuildEventCommandLineDialog.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.BuildEventCommandLineDialog.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\BuildEventCommandLineDialog.*.resx">
+    <EmbeddedResource Update="PropPages\BuildEventCommandLineDialog.*.resx">
       <DependentUpon>BuildEventCommandLineDialog.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\BuildEventsPropPage.resx">
+    <EmbeddedResource Update="PropPages\BuildEventsPropPage.resx">
       <DependentUpon>BuildEventsPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.BuildEventsPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\BuildEventsPropPage.*.resx">
+    <EmbeddedResource Update="PropPages\BuildEventsPropPage.*.resx">
       <DependentUpon>BuildEventsPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\BuildPropPage.resx">
+    <EmbeddedResource Update="PropPages\BuildPropPage.resx">
       <DependentUpon>BuildPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.BuildPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\BuildPropPage.*.resx">
+    <EmbeddedResource Update="PropPages\BuildPropPage.*.resx">
       <DependentUpon>BuildPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\CompilePropPage2.resx">
+    <EmbeddedResource Update="PropPages\CompilePropPage2.resx">
       <DependentUpon>CompilePropPage2.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.CompilePropPage2.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\CompilePropPage2.*.resx">
+    <EmbeddedResource Update="PropPages\CompilePropPage2.*.resx">
       <DependentUpon>CompilePropPage2.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\CSharpApplicationPropPage.resx">
+    <EmbeddedResource Update="PropPages\CSharpApplicationPropPage.resx">
       <DependentUpon>CSharpApplicationPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.CSharpApplicationPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\CSharpApplicationPropPage.*.resx">
+    <EmbeddedResource Update="PropPages\CSharpApplicationPropPage.*.resx">
       <DependentUpon>CSharpApplicationPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\DebugPropPage.resx">
+    <EmbeddedResource Update="PropPages\DebugPropPage.resx">
       <DependentUpon>DebugPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.DebugPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\DebugPropPage.*.resx">
+    <EmbeddedResource Update="PropPages\DebugPropPage.*.resx">
       <DependentUpon>DebugPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\ReferencePathsPropPage.resx">
+    <EmbeddedResource Update="PropPages\ReferencePathsPropPage.resx">
       <DependentUpon>ReferencePathsPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.ReferencePathsPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\ReferencePathsPropPage.*.resx">
+    <EmbeddedResource Update="PropPages\ReferencePathsPropPage.*.resx">
       <DependentUpon>ReferencePathsPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\ReferencePropPage.resx">
+    <EmbeddedResource Update="PropPages\ReferencePropPage.resx">
       <DependentUpon>ReferencePropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.ReferencePropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\ReferencePropPage.*.resx">
+    <EmbeddedResource Update="PropPages\ReferencePropPage.*.resx">
       <DependentUpon>ReferencePropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\ServicesAuthenticationForm.resx">
+    <EmbeddedResource Update="PropPages\ServicesAuthenticationForm.resx">
       <DependentUpon>ServicesAuthenticationForm.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.ServicesAuthenticationForm.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\ServicesAuthenticationForm.*.resx">
+    <EmbeddedResource Update="PropPages\ServicesAuthenticationForm.*.resx">
       <DependentUpon>ServicesAuthenticationForm.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\ServicesPropPage.resx">
+    <EmbeddedResource Update="PropPages\ServicesPropPage.resx">
       <DependentUpon>ServicesPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.ServicesPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\ServicesPropPage.*.resx">
+    <EmbeddedResource Update="PropPages\ServicesPropPage.*.resx">
       <DependentUpon>ServicesPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\Strings.resx">
+    <EmbeddedResource Update="PropPages\Strings.resx">
       <SubType>Designer</SubType>
       <CustomToolNamespace>My.Resources</CustomToolNamespace>
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Strings.Designer.vb</LastGenOutput>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\Strings.*.resx">
+    <EmbeddedResource Update="PropPages\Strings.*.resx">
       <DependentUpon>Strings.resx</DependentUpon>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\UnusedReferencePropPage.resx">
+    <EmbeddedResource Update="PropPages\UnusedReferencePropPage.resx">
       <DependentUpon>UnusedReferencePropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.UnusedReferencePropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\UnusedReferencePropPage.*.resx">
+    <EmbeddedResource Update="PropPages\UnusedReferencePropPage.*.resx">
       <DependentUpon>UnusedReferencePropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\WPF\AppDotXamlErrorControl.resx">
+    <EmbeddedResource Update="PropPages\WPF\AppDotXamlErrorControl.resx">
       <DependentUpon>AppDotXamlErrorControl.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\WPF\AppDotXamlErrorControl.*.resx">
+    <EmbeddedResource Update="PropPages\WPF\AppDotXamlErrorControl.*.resx">
       <DependentUpon>AppDotXamlErrorControl.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\WPF\ApplicationPropPageVBWPF.resx">
+    <EmbeddedResource Update="PropPages\WPF\ApplicationPropPageVBWPF.resx">
       <DependentUpon>ApplicationPropPageVBWPF.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="PropPages\WPF\ApplicationPropPageVBWPF.*.resx">
+    <EmbeddedResource Update="PropPages\WPF\ApplicationPropPageVBWPF.*.resx">
       <DependentUpon>ApplicationPropPageVBWPF.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="ResourceEditor\DialogQueryName.resx">
+    <EmbeddedResource Update="ResourceEditor\DialogQueryName.resx">
       <DependentUpon>DialogQueryName.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.ResourceEditor.DialogQueryName.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="ResourceEditor\DialogQueryName.*.resx">
+    <EmbeddedResource Update="ResourceEditor\DialogQueryName.*.resx">
       <DependentUpon>DialogQueryName.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.ResourceEditor.DialogQueryName.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="ResourceEditor\OpenFileWarningDialog.resx">
+    <EmbeddedResource Update="ResourceEditor\OpenFileWarningDialog.resx">
       <DependentUpon>OpenFileWarningDialog.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.ResourceEditor.OpenFileWarningDialog.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="ResourceEditor\OpenFileWarningDialog.*.resx">
+    <EmbeddedResource Update="ResourceEditor\OpenFileWarningDialog.*.resx">
       <DependentUpon>OpenFileWarningDialog.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.ResourceEditor.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="Resources\Designer.resx">
+    <EmbeddedResource Update="Resources\Designer.resx">
       <LogicalName>Microsoft.VisualStudio.Editors.Designer.resources</LogicalName>
       <SubType>Designer</SubType>
       <CustomToolNamespace>My.Resources</CustomToolNamespace>
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Designer.Designer.vb</LastGenOutput>
     </EmbeddedResource>
-    <EmbeddedResource Include="Resources\Designer.*.resx">
+    <EmbeddedResource Update="Resources\Designer.*.resx">
       <LogicalName>Microsoft.VisualStudio.Editors.%(Filename).resources</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="Resources\MyExtensibilityRes.resx">
+    <EmbeddedResource Update="Resources\MyExtensibilityRes.resx">
       <SubType>Designer</SubType>
       <CustomToolNamespace>My.Resources</CustomToolNamespace>
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>MyExtensibilityRes.Designer.vb</LastGenOutput>
     </EmbeddedResource>
-    <EmbeddedResource Include="Resources\MyExtensibilityRes.*.resx">
+    <EmbeddedResource Update="Resources\MyExtensibilityRes.*.resx">
       <DependentUpon>MyExtensibilityRes.resx</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Resources\ResourceEditor\BlankBmp.bmp">
@@ -385,540 +380,390 @@
     <EmbeddedResource Include="Resources\SettingsDesigner\assembly.bmp" />
     <EmbeddedResource Include="Resources\SettingsDesigner\namespace.bmp" />
     <EmbeddedResource Include="Resources\SettingsDesigner\object.bmp" />
-    <EmbeddedResource Include="SettingsDesigner\SettingsDesignerView.resx">
+    <EmbeddedResource Update="SettingsDesigner\SettingsDesignerView.resx">
       <DependentUpon>SettingsDesignerView.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsDesignerView.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="SettingsDesigner\SettingsDesignerView.*.resx">
+    <EmbeddedResource Update="SettingsDesigner\SettingsDesignerView.*.resx">
       <DependentUpon>SettingsDesignerView.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.SettingsDesigner.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="SettingsDesigner\TypeEditorHostControl.resx">
+    <EmbeddedResource Update="SettingsDesigner\TypeEditorHostControl.resx">
       <DependentUpon>TypeEditorHostControl.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.SettingsDesigner.TypeEditorHostControl.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="SettingsDesigner\TypeEditorHostControl.*.resx">
+    <EmbeddedResource Update="SettingsDesigner\TypeEditorHostControl.*.resx">
       <DependentUpon>TypeEditorHostControl.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.SettingsDesigner.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="SettingsDesigner\TypePickerDialog.resx">
+    <EmbeddedResource Update="SettingsDesigner\TypePickerDialog.resx">
       <DependentUpon>TypePickerDialog.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.SettingsDesigner.TypePickerDialog.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="SettingsDesigner\TypePickerDialog.*.resx">
+    <EmbeddedResource Update="SettingsDesigner\TypePickerDialog.*.resx">
       <DependentUpon>TypePickerDialog.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.SettingsDesigner.%(Filename).resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="XmlToSchema\InputXmlForm.resx">
+    <EmbeddedResource Update="XmlToSchema\InputXmlForm.resx">
       <DependentUpon>InputXmlForm.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="XmlToSchema\InputXmlForm.*.resx">
+    <EmbeddedResource Update="XmlToSchema\InputXmlForm.*.resx">
       <DependentUpon>InputXmlForm.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="XmlToSchema\PasteXmlDialog.resx">
+    <EmbeddedResource Update="XmlToSchema\PasteXmlDialog.resx">
       <DependentUpon>PasteXmlDialog.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="XmlToSchema\PasteXmlDialog.*.resx">
+    <EmbeddedResource Update="XmlToSchema\PasteXmlDialog.*.resx">
       <DependentUpon>PasteXmlDialog.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="XmlToSchema\WebUrlDialog.resx">
+    <EmbeddedResource Update="XmlToSchema\WebUrlDialog.resx">
       <DependentUpon>WebUrlDialog.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="XmlToSchema\WebUrlDialog.*.resx">
+    <EmbeddedResource Update="XmlToSchema\WebUrlDialog.*.resx">
       <DependentUpon>WebUrlDialog.vb</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ComponentModel\AbstractControlTypeDescriptionProvider.vb" />
-    <Compile Include="ProjectCapability.vb" />
-    <Compile Include="PropPages\AdvancedServicesDialog.Designer.vb">
+    <Compile Update="PropPages\AdvancedServicesDialog.Designer.vb">
       <DependentUpon>AdvancedServicesDialog.vb</DependentUpon>
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\AdvBuildSettingsPropPage.Designer.vb">
+    <Compile Update="PropPages\AdvBuildSettingsPropPage.Designer.vb">
       <DependentUpon>AdvBuildSettingsPropPage.vb</DependentUpon>
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\AdvCompilerSettingsPropPage.Designer.vb">
+    <Compile Update="PropPages\AdvCompilerSettingsPropPage.Designer.vb">
       <DependentUpon>AdvCompilerSettingsPropPage.vb</DependentUpon>
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\ApplicationPropPageVBBase.Designer.vb">
+    <Compile Update="PropPages\ApplicationPropPageVBBase.Designer.vb">
       <DependentUpon>ApplicationPropPageVBBase.vb</DependentUpon>
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\AssemblyInfoUtils.vb" />
-    <Compile Include="PropPages\ApplicationPropPageVBWinForms.Designer.vb">
+    <Compile Update="PropPages\ApplicationPropPageVBWinForms.Designer.vb">
       <DependentUpon>ApplicationPropPageVBWinForms.vb</DependentUpon>
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\PackagePropPage.Designer.vb">
+    <Compile Update="PropPages\PackagePropPage.Designer.vb">
       <DependentUpon>PackagePropPage.vb</DependentUpon>
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\PackagePropPage.vb">
+    <Compile Update="PropPages\PackagePropPage.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\AssemblyInfoPropPage.Designer.vb">
+    <Compile Update="PropPages\AssemblyInfoPropPage.Designer.vb">
       <DependentUpon>AssemblyInfoPropPage.vb</DependentUpon>
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\BuildEventCommandLineDialog.Designer.vb">
+    <Compile Update="PropPages\BuildEventCommandLineDialog.Designer.vb">
       <DependentUpon>BuildEventCommandLineDialog.vb</DependentUpon>
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="PropPages\BuildEventsPropPage.Designer.vb">
+    <Compile Update="PropPages\BuildEventsPropPage.Designer.vb">
       <DependentUpon>BuildEventsPropPage.vb</DependentUpon>
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\BuildPropPage.Designer.vb">
+    <Compile Update="PropPages\BuildPropPage.Designer.vb">
       <DependentUpon>BuildPropPage.vb</DependentUpon>
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\CompilePropPage2.Designer.vb">
+    <Compile Update="PropPages\CompilePropPage2.Designer.vb">
       <DependentUpon>CompilePropPage2.vb</DependentUpon>
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\CSharpApplicationPropPage.Designer.vb">
+    <Compile Update="PropPages\CSharpApplicationPropPage.Designer.vb">
       <DependentUpon>CSharpApplicationPropPage.vb</DependentUpon>
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\DebugPropPage.Designer.vb">
+    <Compile Update="PropPages\DebugPropPage.Designer.vb">
       <DependentUpon>DebugPropPage.vb</DependentUpon>
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\ReferencePathsPropPage.Designer.vb">
+    <Compile Update="PropPages\ReferencePathsPropPage.Designer.vb">
       <DependentUpon>ReferencePathsPropPage.vb</DependentUpon>
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\ReferencePropPage.Designer.vb">
+    <Compile Update="PropPages\ReferencePropPage.Designer.vb">
       <DependentUpon>ReferencePropPage.vb</DependentUpon>
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\ServicesAuthenticationForm.Designer.vb">
+    <Compile Update="PropPages\ServicesAuthenticationForm.Designer.vb">
       <DependentUpon>ServicesAuthenticationForm.vb</DependentUpon>
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="PropPages\ServicesPropPage.Designer.vb">
+    <Compile Update="PropPages\ServicesPropPage.Designer.vb">
       <DependentUpon>ServicesPropPage.vb</DependentUpon>
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\TextBoxWithWorkaroundForAutoCompleteAppend.vb">
+    <Compile Update="PropPages\TextBoxWithWorkaroundForAutoCompleteAppend.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="PropPages\UnusedReferencePropPage.Designer.vb">
+    <Compile Update="PropPages\UnusedReferencePropPage.Designer.vb">
       <DependentUpon>UnusedReferencePropPage.vb</DependentUpon>
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\WPF\ApplicationPropPageVBWPF.Designer.vb">
+    <Compile Update="PropPages\WPF\ApplicationPropPageVBWPF.Designer.vb">
       <DependentUpon>ApplicationPropPageVBWPF.vb</DependentUpon>
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="StrongNameHelpers.vb" />
     <Compile Include="..\Common\ManagedCodeMarkers.vb">
       <Link>ManagedCodeMarkers.vb</Link>
     </Compile>
-    <Compile Include="DesignerUI\VisualStudioEditorsID.vb" />
-    <Compile Include="AddImportsDialogs\AddImportDialogBase.vb">
+    <Compile Update="AddImportsDialogs\AddImportDialogBase.vb">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="AddImportsDialogs\AddImports.Designer.vb">
+    <Compile Update="AddImportsDialogs\AddImports.Designer.vb">
       <DependentUpon>AddImports.resx</DependentUpon>
     </Compile>
-    <Compile Include="AddImportsDialogs\AddImportsDialogService.vb" />
-    <Compile Include="AddImportsDialogs\AutoAddImportsCollisionDialog.Designer.vb">
+    <Compile Update="AddImportsDialogs\AutoAddImportsCollisionDialog.Designer.vb">
       <DependentUpon>AutoAddImportsCollisionDialog.vb</DependentUpon>
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="AddImportsDialogs\AutoAddImportsCollisionDialog.vb">
+    <Compile Update="AddImportsDialogs\AutoAddImportsCollisionDialog.vb">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="AddImportsDialogs\AutoAddImportsExtensionCollisionDialog.Designer.vb">
+    <Compile Update="AddImportsDialogs\AutoAddImportsExtensionCollisionDialog.Designer.vb">
       <DependentUpon>AutoAddImportsExtensionCollisionDialog.vb</DependentUpon>
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="AddImportsDialogs\AutoAddImportsExtensionCollisionDialog.vb">
+    <Compile Update="AddImportsDialogs\AutoAddImportsExtensionCollisionDialog.vb">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="AddImportsDialogs\ControlNavigationInfo.vb" />
-    <Compile Include="AddImportsDialogs\Interop.vb" />
-    <Compile Include="AddImportsDialogs\Util.vb" />
-    <Compile Include="AttributeEditor\Interop.vb" />
-    <Compile Include="AttributeEditor\PermissionSetService.vb" />
-    <Compile Include="Common\ArgumentValidation.vb" />
-    <Compile Include="Common\CodeMarkers.vb" />
-    <Compile Include="Common\CodeModelUtils.vb" />
-    <Compile Include="Common\DTEUtils.vb" />
-    <Compile Include="Common\ProjectBatchEdit.vb" />
-    <Compile Include="Common\ShellUtil.vb" />
-    <Compile Include="Common\SplitButton.vb" />
-    <Compile Include="Common\ListViewComparer.vb" />
-    <Compile Include="Common\switches.vb" />
-    <Compile Include="Common\Utils.vb" />
-    <Compile Include="Common\VsStatusBarWrapper.vb" />
-    <Compile Include="Common\WaitCursor.vb" />
-    <Compile Include="Common\wmuserconstants.vb" />
-    <Compile Include="DesignerFramework\AccessModifierComboBox.vb" />
-    <Compile Include="DesignerFramework\BaseDesignerLoader.vb" />
-    <Compile Include="DesignerFramework\BaseDesignerView.vb">
+    <Compile Update="DesignerFramework\BaseDesignerView.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="DesignerFramework\BaseDialog.vb">
+    <Compile Update="DesignerFramework\BaseDialog.vb">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="DesignerFramework\BaseEditorFactory.vb" />
-    <Compile Include="DesignerFramework\BaseRootDesigner.vb" />
-    <Compile Include="DesignerFramework\DesignerDataGridView.vb">
+    <Compile Update="DesignerFramework\DesignerDataGridView.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="DesignerFramework\DesignerListView.vb">
+    <Compile Update="DesignerFramework\DesignerListView.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="DesignerFramework\DesignerMenuCommand.vb" />
-    <Compile Include="DesignerFramework\DesignerMessageBox.vb" />
-    <Compile Include="DesignerFramework\DesignerToolbarPanel.vb">
+    <Compile Update="DesignerFramework\DesignerToolbarPanel.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="DesignerFramework\DesignerTypeDiscoveryService.vb" />
-    <Compile Include="DesignerFramework\DesignerWindowPaneProviderBase.vb" />
-    <Compile Include="DesignerFramework\DesignUtil.vb" />
-    <Compile Include="DesignerFramework\ErrorControl.Designer.vb">
+    <Compile Update="DesignerFramework\ErrorControl.Designer.vb">
       <DependentUpon>ErrorControl.vb</DependentUpon>
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="DesignerFramework\ErrorControl.vb">
+    <Compile Update="DesignerFramework\ErrorControl.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="DesignerFramework\GenericComponentSerializationService.vb" />
-    <Compile Include="DesignerFramework\GenericComponentSerializationStore.vb" />
-    <Compile Include="DesignerFramework\SourceCodeControlManager.vb" />
-    <Compile Include="DesignerFramework\ThemedBorderUserControl.Designer.vb">
+    <Compile Update="DesignerFramework\ThemedBorderUserControl.Designer.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="DesignerFramework\ThemedBorderUserControl.vb">
+    <Compile Update="DesignerFramework\ThemedBorderUserControl.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="DesignerFramework\UserCanceledException.vb" />
-    <Compile Include="DesignerFramework\WrapCheckBox.vb">
+    <Compile Update="DesignerFramework\WrapCheckBox.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="GlobalSuppressions.vb" />
-    <Compile Include="HelpKeywords.vb" />
-    <Compile Include="interop\IInternetSecurityManager.vb" />
-    <Compile Include="interop\IVBEntryPointProvider.vb" />
-    <Compile Include="interop\IVBReferenceUsageProvider.vb" />
-    <Compile Include="interop\IVsAppId.vb" />
-    <Compile Include="interop\IVsBuildEventCommandLineDialogService.vb" />
-    <Compile Include="interop\IVsBuildEventMacroProvider.vb" />
-    <Compile Include="interop\LOGVIEWID.vb" />
-    <Compile Include="interop\NativeMethods.vb" />
-    <Compile Include="interop\win.vb" />
-    <Compile Include="My Project\AssemblyInfo.vb" />
-    <Compile Include="MyApplication\MyApplicationCodeGenerator.vb" />
-    <Compile Include="MyApplication\MyApplicationData.vb" />
-    <Compile Include="MyApplication\MyApplicationDataSerializer.vb" />
-    <Compile Include="MyApplication\MyApplicationProperties.vb" />
-    <Compile Include="MyApplication\MyApplicationSerializer.vb" />
-    <Compile Include="MyExtensibility\AddMyExtensionsDialog.vb">
+    <Compile Update="MyExtensibility\AddMyExtensionsDialog.vb">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="MyExtensibility\AssemblyOptionDialog.vb">
+    <Compile Update="MyExtensibility\AssemblyOptionDialog.vb">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="MyExtensibility\INamedDescribedObject.vb" />
-    <Compile Include="MyExtensibility\MyExtensibilityProjectService.vb" />
-    <Compile Include="MyExtensibility\MyExtensibilityProjectSettings.vb" />
-    <Compile Include="MyExtensibility\MyExtensibilityPropPage.vb">
+    <Compile Update="MyExtensibility\MyExtensibilityPropPage.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="MyExtensibility\MyExtensibilityPropPageComClass.vb" />
-    <Compile Include="MyExtensibility\MyExtensibilitySettings.vb" />
-    <Compile Include="MyExtensibility\MyExtensibilitySettingsHelper.vb" />
-    <Compile Include="MyExtensibility\MyExtensibilitySolutionService.vb" />
-    <Compile Include="MyExtensibility\MyExtensibilityUtil.vb" />
-    <Compile Include="MyExtensibility\MyExtensionListView.vb">
+    <Compile Update="MyExtensibility\MyExtensionListView.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="MyExtensibility\MyExtensionProjectItemGroup.vb" />
-    <Compile Include="MyExtensibility\MyExtensionTemplate.vb" />
-    <Compile Include="MyExtensibility\TrackProjectDocumentsEventsHelper.vb" />
-    <Compile Include="Package\Constants.vb" />
-    <Compile Include="package\EditorToolsOptionsPage.vb">
+    <Compile Update="package\EditorToolsOptionsPage.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="package\EditorToolsOptionsPanel.Designer.vb">
+    <Compile Update="package\EditorToolsOptionsPanel.Designer.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="package\EditorToolsOptionsPanel.vb">
+    <Compile Update="package\EditorToolsOptionsPanel.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="package\InternalException.vb" />
-    <Compile Include="package\ScalingDialogPage.vb">
+    <Compile Update="package\ScalingDialogPage.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="package\vbpackage.vb" />
-    <Compile Include="PropPages\AdvancedServicesDialog.vb">
+    <Compile Update="PropPages\AdvancedServicesDialog.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="proppages\AdvBuildSettingsPropPage.vb">
+    <Compile Update="proppages\AdvBuildSettingsPropPage.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="proppages\AdvCompilerSettingsPropPage.vb">
+    <Compile Update="proppages\AdvCompilerSettingsPropPage.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="proppages\ApplicationPropPage.vb">
+    <Compile Update="proppages\ApplicationPropPage.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\ApplicationPropPage.Designer.vb">
+    <Compile Update="PropPages\ApplicationPropPage.Designer.vb">
       <DependentUpon>ApplicationPropPage.vb</DependentUpon>
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="proppages\ApplicationPropPageBase.vb">
+    <Compile Update="proppages\ApplicationPropPageBase.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="proppages\ApplicationPropPageInternalBase.vb">
+    <Compile Update="proppages\ApplicationPropPageInternalBase.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\ApplicationPropPageVBBase.vb">
+    <Compile Update="PropPages\ApplicationPropPageVBBase.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\ApplicationPropPageVBWinForms.vb">
+    <Compile Update="PropPages\ApplicationPropPageVBWinForms.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="proppages\AssemblyInfoPropPage.vb">
+    <Compile Update="proppages\AssemblyInfoPropPage.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="proppages\BuildEventCommandLineDialog.vb">
+    <Compile Update="proppages\BuildEventCommandLineDialog.vb">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="proppages\BuildEventCommandLineDialogService.vb" />
-    <Compile Include="proppages\BuildEventsPropPage.vb">
+    <Compile Update="proppages\BuildEventsPropPage.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="proppages\BuildPropPage.vb">
+    <Compile Update="proppages\BuildPropPage.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="proppages\BuildPropPageBase.vb">
+    <Compile Update="proppages\BuildPropPageBase.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="proppages\CompilePropPage2.vb">
+    <Compile Update="proppages\CompilePropPage2.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="proppages\ComponentWrapper.vb">
+    <Compile Update="proppages\ComponentWrapper.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="proppages\CSharpApplicationPropPage.vb">
+    <Compile Update="proppages\CSharpApplicationPropPage.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="proppages\CSharpLanguageVersion.vb" />
-    <Compile Include="proppages\CSharpLanguageVersionUtilities.vb" />
-    <Compile Include="proppages\DebugPropPage.vb">
+    <Compile Update="proppages\DebugPropPage.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="proppages\InstallOtherFrameworksComboBoxValue.vb" />
-    <Compile Include="proppages\OutputTypeComboBoxValue.vb" />
-    <Compile Include="proppages\proppage.vb" />
-    <Compile Include="proppages\ReferenceComponent.vb">
+    <Compile Update="proppages\ReferenceComponent.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="proppages\ReferencePathsPropPage.vb">
+    <Compile Update="proppages\ReferencePathsPropPage.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="proppages\ReferencePropPage.vb">
+    <Compile Update="proppages\ReferencePropPage.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="proppages\ServiceReferenceComponent.vb">
+    <Compile Update="proppages\ServiceReferenceComponent.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="proppages\ServicesAuthenticationForm.vb">
+    <Compile Update="proppages\ServicesAuthenticationForm.vb">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="proppages\ServicesPropPage.vb">
+    <Compile Update="proppages\ServicesPropPage.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="proppages\ServicesPropPageConfigHelper.vb" />
-    <Compile Include="proppages\SingleConfigPropertyControlData.vb" />
-    <Compile Include="proppages\SKUMatrix.vb" />
-    <Compile Include="PropPages\Strings.Designer.vb">
+    <Compile Update="PropPages\Strings.Designer.vb">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>Strings.resx</DependentUpon>
     </Compile>
-    <Compile Include="PropPages\TargetFrameworkAssemblies.vb" />
-    <Compile Include="PropPages\TargetFrameworkMoniker.vb" />
-    <Compile Include="PropPages\TargetFrameworkPropertyControlData.vb" />
-    <Compile Include="proppages\UnusedReferencePropPage.vb">
+    <Compile Update="proppages\UnusedReferencePropPage.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="proppages\UserPropertyDescriptor.vb" />
-    <Compile Include="proppages\VBDescriptionAttribute.vb" />
-    <Compile Include="proppages\VBDisplayNameAttribute.vb" />
-    <Compile Include="proppages\WebReferenceComponent.vb">
+    <Compile Update="proppages\WebReferenceComponent.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="PropPages\WPF\AppDotXamlDocument.vb" />
-    <Compile Include="PropPages\WPF\AppDotXamlErrorControl.Designer.vb">
+    <Compile Update="PropPages\WPF\AppDotXamlErrorControl.Designer.vb">
       <DependentUpon>AppDotXamlErrorControl.vb</DependentUpon>
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\WPF\AppDotXamlErrorControl.vb">
+    <Compile Update="PropPages\WPF\AppDotXamlErrorControl.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\WPF\ApplicationPropPageVBWPF.vb">
+    <Compile Update="PropPages\WPF\ApplicationPropPageVBWPF.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="PropPages\WPF\XamlReadWriteException.vb" />
-    <Compile Include="ResourceEditor\Category.vb" />
-    <Compile Include="ResourceEditor\CategoryCollection.vb" />
-    <Compile Include="ResourceEditor\CsvEncoder.vb" />
-    <Compile Include="ResourceEditor\DialogQueryName.vb">
+    <Compile Update="ResourceEditor\DialogQueryName.vb">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="ResourceEditor\FileWatcher.vb" />
-    <Compile Include="ResourceEditor\FindReplace.vb" />
-    <Compile Include="ResourceEditor\OpenFileWarningDialog.vb">
+    <Compile Update="ResourceEditor\OpenFileWarningDialog.vb">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="ResourceEditor\Resource.vb" />
-    <Compile Include="ResourceEditor\ResourceComparer.vb" />
-    <Compile Include="ResourceEditor\ResourceComparerForFind.vb" />
-    <Compile Include="ResourceEditor\ResourceEditorDesignerLoader.vb" />
-    <Compile Include="ResourceEditor\ResourceEditorFactory.vb" />
-    <Compile Include="ResourceEditor\ResourceEditorRefactorNotify.vb" />
-    <Compile Include="ResourceEditor\ResourceEditorRootComponent.vb">
+    <Compile Update="ResourceEditor\ResourceEditorRootComponent.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="ResourceEditor\ResourceEditorRootDesigner.vb" />
-    <Compile Include="ResourceEditor\ResourceEditorView.vb">
+    <Compile Update="ResourceEditor\ResourceEditorView.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="ResourceEditor\ResourceEditorView_EditorState.vb">
+    <Compile Update="ResourceEditor\ResourceEditorView_EditorState.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="ResourceEditor\ResourceFile.vb" />
-    <Compile Include="ResourceEditor\ResourceListView.vb">
+    <Compile Update="ResourceEditor\ResourceListView.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="ResourceEditor\ResourcePropertyDescriptor.vb" />
-    <Compile Include="ResourceEditor\ResourceSerializationService.vb" />
-    <Compile Include="ResourceEditor\ResourceSerializationService_Store.vb" />
-    <Compile Include="ResourceEditor\ResourcesFolderService.vb" />
-    <Compile Include="ResourceEditor\ResourcesFolderService_ResourceEditor.vb" />
-    <Compile Include="ResourceEditor\ResourceStringTable.vb">
+    <Compile Update="ResourceEditor\ResourceStringTable.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="ResourceEditor\ResourceTypeDescriptionProvider.vb" />
-    <Compile Include="ResourceEditor\ResourceTypeDescriptor.vb" />
-    <Compile Include="ResourceEditor\ResourceTypeEditor.vb" />
-    <Compile Include="ResourceEditor\ResourceTypeEditorAudio.vb" />
-    <Compile Include="ResourceEditor\ResourceTypeEditorBinaryFile.vb" />
-    <Compile Include="ResourceEditor\ResourceTypeEditorBitmap.vb" />
-    <Compile Include="ResourceEditor\ResourceTypeEditorFileBase.vb" />
-    <Compile Include="ResourceEditor\ResourceTypeEditorIcon.vb" />
-    <Compile Include="ResourceEditor\ResourceTypeEditorImageBase.vb" />
-    <Compile Include="ResourceEditor\ResourceTypeEditorInternalBase.vb" />
-    <Compile Include="ResourceEditor\ResourceTypeEditorNonStringConvertible.vb" />
-    <Compile Include="ResourceEditor\ResourceTypeEditorNothing.vb" />
-    <Compile Include="ResourceEditor\ResourceTypeEditors.vb" />
-    <Compile Include="ResourceEditor\ResourceTypeEditorString.vb" />
-    <Compile Include="ResourceEditor\ResourceTypeEditorStringBase.vb" />
-    <Compile Include="ResourceEditor\ResourceTypeEditorStringConvertible.vb" />
-    <Compile Include="ResourceEditor\ResourceTypeEditorTextFile.vb" />
-    <Compile Include="ResourceEditor\ResxItemWizard.vb" />
-    <Compile Include="ResourceEditor\SerializableEncoding.vb" />
-    <Compile Include="ResourceEditor\SerializableEncodingConverter.vb" />
-    <Compile Include="ResourceEditor\ThumbnailCache.vb" />
-    <Compile Include="ResourceEditor\Utility.vb" />
-    <Compile Include="Resources\Designer.Designer.vb">
+    <Compile Update="Resources\Designer.Designer.vb">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>Designer.resx</DependentUpon>
     </Compile>
-    <Compile Include="Resources\MyExtensibilityRes.Designer.vb">
+    <Compile Update="Resources\MyExtensibilityRes.Designer.vb">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>MyExtensibilityRes.resx</DependentUpon>
     </Compile>
-    <Compile Include="Resources\Resources.vb" />
-    <Compile Include="SettingsDesigner\AppConfigSerializer.vb" />
-    <Compile Include="SettingsDesigner\ConnectionStringUITypeEditor.vb" />
-    <Compile Include="SettingsDesigner\DataGridViewUITypeEditorCell.vb" />
-    <Compile Include="SettingsDesigner\DataGridViewUITypeEditorEditingControl.vb">
+    <Compile Update="SettingsDesigner\DataGridViewUITypeEditorEditingControl.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="SettingsDesigner\DesignTimeSettingInstance.vb">
+    <Compile Update="SettingsDesigner\DesignTimeSettingInstance.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="SettingsDesigner\DesignTimeSettings.vb">
+    <Compile Update="SettingsDesigner\DesignTimeSettings.vb">
       <SubType>Designer</SubType>
     </Compile>
-    <Compile Include="SettingsDesigner\FakeCollectionEditor.vb" />
-    <Compile Include="SettingsDesigner\ProjectUtils.vb" />
-    <Compile Include="SettingsDesigner\PublicSettingsSingleFileGenerator.vb" />
-    <Compile Include="SettingsDesigner\SettingsDesigner.vb" />
-    <Compile Include="SettingsDesigner\SettingsDesignerEditorFactory.vb" />
-    <Compile Include="SettingsDesigner\SettingsDesignerLoader.vb" />
-    <Compile Include="SettingsDesigner\SettingsDesignerUndoTransaction.vb" />
-    <Compile Include="SettingsDesigner\SettingsDesignerView.vb">
+    <Compile Update="SettingsDesigner\SettingsDesignerView.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="SettingsDesigner\SettingsSerializer.vb" />
-    <Compile Include="SettingsDesigner\SettingsSingleFileGenerator.vb" />
-    <Compile Include="SettingsDesigner\SettingsSingleFileGeneratorBase.vb" />
-    <Compile Include="SettingsDesigner\SettingsTypeCache.vb" />
-    <Compile Include="SettingsDesigner\SettingsValueCache.vb" />
-    <Compile Include="SettingsDesigner\SettingsValueSerializer.vb" />
-    <Compile Include="SettingsDesigner\SettingTypeNameResolutionService.vb" />
-    <Compile Include="SettingsDesigner\SettingTypeValidator.vb" />
-    <Compile Include="SettingsDesigner\TypeEditorDataGridViewColumn.vb" />
-    <Compile Include="SettingsDesigner\TypeEditorHostControl.vb">
+    <Compile Update="SettingsDesigner\TypeEditorHostControl.vb">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="SettingsDesigner\TypePickerDialog.vb">
+    <Compile Update="SettingsDesigner\TypePickerDialog.vb">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="SettingsGlobalObject\SettingsGlobalObjectProvider.vb" />
-    <Compile Include="VBRefChangedSvc\Interop.vb" />
-    <Compile Include="VBRefChangedSvc\VBReferenceChangedService.vb" />
-    <Compile Include="XmlIntellisense\XmlIntellisense.vb" />
-    <Compile Include="XmlIntellisense\XmlIntellisenseInterop.vb" />
-    <Compile Include="XmlToSchema\InputXmlForm.Designer.vb">
+    <Compile Update="XmlToSchema\InputXmlForm.Designer.vb">
       <DependentUpon>InputXmlForm.vb</DependentUpon>
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="XmlToSchema\InputXmlForm.vb">
+    <Compile Update="XmlToSchema\InputXmlForm.vb">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="XmlToSchema\PasteXmlDialog.Designer.vb">
+    <Compile Update="XmlToSchema\PasteXmlDialog.Designer.vb">
       <DependentUpon>PasteXmlDialog.vb</DependentUpon>
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="XmlToSchema\PasteXmlDialog.vb">
+    <Compile Update="XmlToSchema\PasteXmlDialog.vb">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="XmlToSchema\Utilities.vb">
+    <Compile Update="XmlToSchema\Utilities.vb">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="XmlToSchema\WebUrlDialog.Designer.vb">
+    <Compile Update="XmlToSchema\WebUrlDialog.Designer.vb">
       <DependentUpon>WebUrlDialog.vb</DependentUpon>
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="XmlToSchema\WebUrlDialog.vb">
+    <Compile Update="XmlToSchema\WebUrlDialog.vb">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="XmlToSchema\Wizard.vb" />
+    <Compile Update="XmlToSchema\Wizard.vb" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Docs\app-designer-visual-spec-1.png" />

--- a/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
+++ b/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
@@ -13,7 +13,6 @@
     <SignAssembly>true</SignAssembly>
     <NoWarn>$(NoWarn);42105;42107;42353;42355</NoWarn>
     <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
-    <EnableDefaultItems>true</EnableDefaultItems>
     <!-- Override Roslyn which embeds by default -->
     <VBRuntime>Default</VBRuntime>
     <TargetFramework>net46</TargetFramework>

--- a/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
+++ b/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
   <PropertyGroup>
     <UseVisualStudioVersion>true</UseVisualStudioVersion>
   </PropertyGroup>
@@ -7,7 +6,6 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{CD6E5D00-7B0B-442D-9F5D-EAEC1A71838A}</ProjectGuid>
     <AssemblyName>Microsoft.VisualStudio.Editors</AssemblyName>
     <OutputType>Library</OutputType>
     <RootNamespace>

--- a/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
+++ b/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
@@ -32,10 +32,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.VisualStudio.AppDesigner\Microsoft.VisualStudio.AppDesigner.vbproj">
-      <Project>{19725D6F-4690-412B-934A-FC48D752B802}</Project>
-      <Name>Microsoft.VisualStudio.AppDesigner</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.VisualStudio.AppDesigner\Microsoft.VisualStudio.AppDesigner.vbproj" />
   </ItemGroup>
   <ItemGroup>
     <Import Include="VSConstants=Microsoft.VisualStudio.VSConstants" />

--- a/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
+++ b/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <PropertyGroup>
     <UseVisualStudioVersion>true</UseVisualStudioVersion>
   </PropertyGroup>

--- a/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
+++ b/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
@@ -445,67 +445,86 @@
     <Compile Include="ProjectCapability.vb" />
     <Compile Include="PropPages\AdvancedServicesDialog.Designer.vb">
       <DependentUpon>AdvancedServicesDialog.vb</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="PropPages\AdvBuildSettingsPropPage.Designer.vb">
       <DependentUpon>AdvBuildSettingsPropPage.vb</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="PropPages\AdvCompilerSettingsPropPage.Designer.vb">
       <DependentUpon>AdvCompilerSettingsPropPage.vb</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="PropPages\ApplicationPropPageVBBase.Designer.vb">
       <DependentUpon>ApplicationPropPageVBBase.vb</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="PropPages\AssemblyInfoUtils.vb" />
     <Compile Include="PropPages\ApplicationPropPageVBWinForms.Designer.vb">
       <DependentUpon>ApplicationPropPageVBWinForms.vb</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="PropPages\PackagePropPage.Designer.vb">
       <DependentUpon>PackagePropPage.vb</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="PropPages\PackagePropPage.vb">
       <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="PropPages\AssemblyInfoPropPage.Designer.vb">
       <DependentUpon>AssemblyInfoPropPage.vb</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="PropPages\BuildEventCommandLineDialog.Designer.vb">
       <DependentUpon>BuildEventCommandLineDialog.vb</DependentUpon>
+      <SubType>Form</SubType>
     </Compile>
     <Compile Include="PropPages\BuildEventsPropPage.Designer.vb">
       <DependentUpon>BuildEventsPropPage.vb</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="PropPages\BuildPropPage.Designer.vb">
       <DependentUpon>BuildPropPage.vb</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="PropPages\CompilePropPage2.Designer.vb">
       <DependentUpon>CompilePropPage2.vb</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="PropPages\CSharpApplicationPropPage.Designer.vb">
       <DependentUpon>CSharpApplicationPropPage.vb</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="PropPages\DebugPropPage.Designer.vb">
       <DependentUpon>DebugPropPage.vb</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="PropPages\ReferencePathsPropPage.Designer.vb">
       <DependentUpon>ReferencePathsPropPage.vb</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="PropPages\ReferencePropPage.Designer.vb">
       <DependentUpon>ReferencePropPage.vb</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="PropPages\ServicesAuthenticationForm.Designer.vb">
       <DependentUpon>ServicesAuthenticationForm.vb</DependentUpon>
+      <SubType>Form</SubType>
     </Compile>
     <Compile Include="PropPages\ServicesPropPage.Designer.vb">
       <DependentUpon>ServicesPropPage.vb</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="PropPages\TextBoxWithWorkaroundForAutoCompleteAppend.vb">
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="PropPages\UnusedReferencePropPage.Designer.vb">
       <DependentUpon>UnusedReferencePropPage.vb</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="PropPages\WPF\ApplicationPropPageVBWPF.Designer.vb">
       <DependentUpon>ApplicationPropPageVBWPF.vb</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="StrongNameHelpers.vb" />
     <Compile Include="..\Common\ManagedCodeMarkers.vb">
@@ -521,12 +540,14 @@
     <Compile Include="AddImportsDialogs\AddImportsDialogService.vb" />
     <Compile Include="AddImportsDialogs\AutoAddImportsCollisionDialog.Designer.vb">
       <DependentUpon>AutoAddImportsCollisionDialog.vb</DependentUpon>
+      <SubType>Form</SubType>
     </Compile>
     <Compile Include="AddImportsDialogs\AutoAddImportsCollisionDialog.vb">
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="AddImportsDialogs\AutoAddImportsExtensionCollisionDialog.Designer.vb">
       <DependentUpon>AutoAddImportsExtensionCollisionDialog.vb</DependentUpon>
+      <SubType>Form</SubType>
     </Compile>
     <Compile Include="AddImportsDialogs\AutoAddImportsExtensionCollisionDialog.vb">
       <SubType>Form</SubType>
@@ -575,6 +596,7 @@
     <Compile Include="DesignerFramework\DesignUtil.vb" />
     <Compile Include="DesignerFramework\ErrorControl.Designer.vb">
       <DependentUpon>ErrorControl.vb</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="DesignerFramework\ErrorControl.vb">
       <SubType>UserControl</SubType>
@@ -582,7 +604,9 @@
     <Compile Include="DesignerFramework\GenericComponentSerializationService.vb" />
     <Compile Include="DesignerFramework\GenericComponentSerializationStore.vb" />
     <Compile Include="DesignerFramework\SourceCodeControlManager.vb" />
-    <Compile Include="DesignerFramework\ThemedBorderUserControl.Designer.vb" />
+    <Compile Include="DesignerFramework\ThemedBorderUserControl.Designer.vb">
+      <SubType>UserControl</SubType>
+    </Compile>
     <Compile Include="DesignerFramework\ThemedBorderUserControl.vb">
       <SubType>UserControl</SubType>
     </Compile>
@@ -634,7 +658,9 @@
     <Compile Include="package\EditorToolsOptionsPage.vb">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="package\EditorToolsOptionsPanel.Designer.vb" />
+    <Compile Include="package\EditorToolsOptionsPanel.Designer.vb">
+      <SubType>UserControl</SubType>
+    </Compile>
     <Compile Include="package\EditorToolsOptionsPanel.vb">
       <SubType>UserControl</SubType>
     </Compile>
@@ -657,6 +683,7 @@
     </Compile>
     <Compile Include="PropPages\ApplicationPropPage.Designer.vb">
       <DependentUpon>ApplicationPropPage.vb</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="proppages\ApplicationPropPageBase.vb">
       <SubType>UserControl</SubType>
@@ -744,6 +771,7 @@
     <Compile Include="PropPages\WPF\AppDotXamlDocument.vb" />
     <Compile Include="PropPages\WPF\AppDotXamlErrorControl.Designer.vb">
       <DependentUpon>AppDotXamlErrorControl.vb</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="PropPages\WPF\AppDotXamlErrorControl.vb">
       <SubType>UserControl</SubType>
@@ -868,12 +896,14 @@
     <Compile Include="XmlIntellisense\XmlIntellisenseInterop.vb" />
     <Compile Include="XmlToSchema\InputXmlForm.Designer.vb">
       <DependentUpon>InputXmlForm.vb</DependentUpon>
+      <SubType>Form</SubType>
     </Compile>
     <Compile Include="XmlToSchema\InputXmlForm.vb">
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="XmlToSchema\PasteXmlDialog.Designer.vb">
       <DependentUpon>PasteXmlDialog.vb</DependentUpon>
+      <SubType>Form</SubType>
     </Compile>
     <Compile Include="XmlToSchema\PasteXmlDialog.vb">
       <SubType>Form</SubType>
@@ -883,6 +913,7 @@
     </Compile>
     <Compile Include="XmlToSchema\WebUrlDialog.Designer.vb">
       <DependentUpon>WebUrlDialog.vb</DependentUpon>
+      <SubType>Form</SubType>
     </Compile>
     <Compile Include="XmlToSchema\WebUrlDialog.vb">
       <SubType>Form</SubType>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests.csproj
@@ -22,26 +22,12 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DeployTestDependencies\DeployTestDependencies.csproj">
-      <Project>{37ba82e6-9abd-4aca-aa26-2dfd39a359a5}</Project>
-      <Name>DeployTestDependencies</Name>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp\Microsoft.VisualStudio.ProjectSystem.CSharp.csproj">
-      <Project>{7d150b7b-ce02-4cd4-8ec9-6a7c18727a36}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.CSharp</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj">
-      <Project>{23bcbc90-ed65-4ee3-8af1-dd7caefdbee9}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.TestServices</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj">
-      <Project>{c7ec63f8-f96a-4a8f-b879-d572516746b4}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj">
-      <Project>{6c6a41ce-72c5-4d77-8208-d01693f9bc88}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp\Microsoft.VisualStudio.ProjectSystem.CSharp.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests.csproj
@@ -1,13 +1,7 @@
 ﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
-    <AssemblyName>Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFramework>net46</TargetFramework>  
     <SignAssembly>true</SignAssembly>
     <Nonshipping>true</Nonshipping>
@@ -15,6 +9,7 @@
     <OutDir>$(OutDir)Tests\</OutDir>
     <ProjectSystemLayer>HostAgnostic</ProjectSystemLayer>
     <ProjectSystemProjectType>Test</ProjectSystemProjectType>
+    <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleToTest Include="Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests.csproj
@@ -9,7 +9,6 @@
     <OutDir>$(OutDir)Tests\</OutDir>
     <ProjectSystemLayer>HostAgnostic</ProjectSystemLayer>
     <ProjectSystemProjectType>Test</ProjectSystemProjectType>
-    <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleToTest Include="Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests.csproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{F81A2B36-6763-42B8-8F4D-5199325D40C1}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests.csproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests.csproj
@@ -1,13 +1,7 @@
 ﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
-    <AssemblyName>Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFramework>net46</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <Nonshipping>true</Nonshipping>
@@ -15,6 +9,7 @@
     <OutDir>$(OutDir)Tests\</OutDir>
     <ProjectSystemLayer>VisualStudio</ProjectSystemLayer>
     <ProjectSystemProjectType>Test</ProjectSystemProjectType>
+    <EnableDefaultItems>true</EnableDefaultItems>    
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleToMoq Include="DynamicProxyGenAssembly2" />
@@ -38,23 +33,11 @@
     <Compile Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Properties\AssemblyAttributes.cs">
       <Link>Properties\AssemblyAttributes.cs</Link>
     </Compile>
-    <Compile Include="Mocks\IVsUpgradeLoggerFactory.cs" />
-    <Compile Include="Mocks\ProcessRunnerFactory.cs" />
-    <Compile Include="Packaging\CSharpProjectSystemPackageTests.cs" />
-    <Compile Include="ProjectSystem\VS\LanguageServices\CSharpLanguageFeaturesProviderTests.cs" />
-    <Compile Include="ProjectSystem\VS\Properties\CSharpProjectDesignerPageProviderTests.cs" />
-    <Compile Include="ProjectSystem\VS\Imaging\CSharpProjectImageProviderTests.cs" />
-    <Compile Include="ProjectSystem\VS\LanguageServices\CSharpCodeDomProviderTests.cs" />
-    <Compile Include="ProjectSystem\VS\Properties\CSharpProjectGuidProviderTests.cs" />
-    <Compile Include="ProjectSystem\VS\CSharpProjectCompatibilityProviderTests.cs" />
-    <Compile Include="ProjectSystem\VS\Xproj\GlobalJsonRemoverTests.cs" />
-    <Compile Include="ProjectSystem\VS\Xproj\MigrateXprojProjectFactoryTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\Common\Test\App.config">
       <Link>App.config</Link>
     </None>
-    <Compile Include="Mocks\GlobalJsonSetupFactory.cs" />
   </ItemGroup>
   <Import Project="..\..\build\Targets\VSL.Imports.targets" />
   <Import Project="..\..\build\Targets\Roslyn.Toolsets.Xunit.targets" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests.csproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{8123135E-B2A1-4CD1-9658-DDACABEAB8FC}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests.csproj
@@ -21,38 +21,15 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DeployTestDependencies\DeployTestDependencies.csproj">
-      <Project>{37ba82e6-9abd-4aca-aa26-2dfd39a359a5}</Project>
-      <Name>DeployTestDependencies</Name>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp.VS\Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj">
-      <Project>{765ef6eb-9f36-4d68-8c3d-9e11cd49e0bc}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.CSharp.VS</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp\Microsoft.VisualStudio.ProjectSystem.CSharp.csproj">
-      <Project>{7d150b7b-ce02-4cd4-8ec9-6a7c18727a36}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.CSharp</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj">
-      <Project>{23bcbc90-ed65-4ee3-8af1-dd7caefdbee9}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.TestServices</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj">
-      <Project>{c7ec63f8-f96a-4a8f-b879-d572516746b4}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj">
-      <Project>{469b50e9-fe67-459e-8afa-44cbe523dbf6}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS\Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj">
-      <Project>{1c5666ea-24a4-4ec2-b8fb-faedf6b14697}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.VS</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj">
-      <Project>{6c6a41ce-72c5-4d77-8208-d01693f9bc88}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp.VS\Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp\Microsoft.VisualStudio.ProjectSystem.CSharp.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS\Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests.csproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests.csproj
@@ -9,7 +9,6 @@
     <OutDir>$(OutDir)Tests\</OutDir>
     <ProjectSystemLayer>VisualStudio</ProjectSystemLayer>
     <ProjectSystemProjectType>Test</ProjectSystemProjectType>
-    <EnableDefaultItems>true</EnableDefaultItems>    
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleToMoq Include="DynamicProxyGenAssembly2" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj
@@ -1,13 +1,7 @@
 ﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
-    <AssemblyName>Microsoft.VisualStudio.ProjectSystem.CSharp.VS</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFramework>net46</TargetFramework>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <ImportVSSDKTargets>true</ImportVSSDKTargets>
@@ -17,6 +11,7 @@
     <SignAssembly>true</SignAssembly>
     <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
     <ProjectSystemLayer>VisualStudio</ProjectSystemLayer>
+    <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleToTest Include="Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests" />
@@ -31,28 +26,12 @@
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Packaging\CSharpProjectSystemPackage.cs" />
-    <Compile Include="GlobalSuppressions.cs" />
-    <Compile Include="ProjectSystem\VS\CSharpProjectCompatibilityProvider.cs" />
-    <Compile Include="ProjectSystem\VS\LanguageServices\CSharpVsContainedLanguageComponentsFactory.cs" />
-    <Compile Include="ProjectSystem\VS\Properties\CSharpProjectDesignerPage.cs" />
-    <Compile Include="ProjectSystem\VS\Properties\CSharpProjectDesignerPageProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Imaging\CSharpProjectImageProvider.cs" />
-    <Compile Include="ProjectSystem\VS\LanguageServices\CSharpCodeDomProvider.cs">
+    <Compile Update="ProjectSystem\VS\LanguageServices\CSharpCodeDomProvider.cs">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="ProjectSystem\VS\LanguageServices\CSharpLanguageFeaturesProvider.cs" />
-    <Compile Include="ProjectSystem\VS\CSharpProjectGuidProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Xproj\GlobalJsonRemover.cs" />
-    <Compile Include="ProjectSystem\VS\Xproj\MigrateXprojProjectFactory.cs" />
-    <Compile Include="ProjectSystem\VS\Xproj\MigrationError.cs" />
-    <Compile Include="ProjectSystem\VS\Xproj\MigrationReport.cs" />
-    <Compile Include="ProjectSystem\VS\Xproj\ProcessRunner.cs" />
-    <Compile Include="ProjectSystem\VS\Xproj\ProjectMigrationReport.cs" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="VSPackage.resx" />
-    <EmbeddedResource Include="VSPackage.*.resx">
+    <EmbeddedResource Update="VSPackage.*.resx">
       <DependentUpon>VSPackage.resx</DependentUpon>
     </EmbeddedResource>
   </ItemGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj
@@ -11,7 +11,6 @@
     <SignAssembly>true</SignAssembly>
     <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
     <ProjectSystemLayer>VisualStudio</ProjectSystemLayer>
-    <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleToTest Include="Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj
@@ -26,18 +26,9 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp\Microsoft.VisualStudio.ProjectSystem.CSharp.csproj">
-      <Project>{7d150b7b-ce02-4cd4-8ec9-6a7c18727a36}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.CSharp</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS\Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj">
-      <Project>{1c5666ea-24a4-4ec2-b8fb-faedf6b14697}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.VS</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj">
-      <Project>{6c6a41ce-72c5-4d77-8208-d01693f9bc88}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp\Microsoft.VisualStudio.ProjectSystem.CSharp.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS\Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Packaging\CSharpProjectSystemPackage.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{765EF6EB-9F36-4D68-8C3D-9E11CD49E0BC}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp/Microsoft.VisualStudio.ProjectSystem.CSharp.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp/Microsoft.VisualStudio.ProjectSystem.CSharp.csproj
@@ -27,10 +27,7 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj">
-      <Project>{6c6a41ce-72c5-4d77-8208-d01693f9bc88}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="GlobalSuppressions.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp/Microsoft.VisualStudio.ProjectSystem.CSharp.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp/Microsoft.VisualStudio.ProjectSystem.CSharp.csproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{7D150B7B-CE02-4CD4-8EC9-6A7C18727A36}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp/Microsoft.VisualStudio.ProjectSystem.CSharp.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp/Microsoft.VisualStudio.ProjectSystem.CSharp.csproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp/Microsoft.VisualStudio.ProjectSystem.CSharp.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp/Microsoft.VisualStudio.ProjectSystem.CSharp.csproj
@@ -10,7 +10,6 @@
     <SignAssembly>true</SignAssembly>
     <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
     <ProjectSystemLayer>HostAgnostic</ProjectSystemLayer>
-    <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.CSharp.VS" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp/Microsoft.VisualStudio.ProjectSystem.CSharp.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp/Microsoft.VisualStudio.ProjectSystem.CSharp.csproj
@@ -1,13 +1,7 @@
 ﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
-    <AssemblyName>Microsoft.VisualStudio.ProjectSystem.CSharp</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFramework>net46</TargetFramework>
     <ImportVSSDKTargets>false</ImportVSSDKTargets>
     <CreateVsixContainer>false</CreateVsixContainer>
@@ -16,6 +10,7 @@
     <SignAssembly>true</SignAssembly>
     <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
     <ProjectSystemLayer>HostAgnostic</ProjectSystemLayer>
+    <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.CSharp.VS" />
@@ -28,11 +23,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="GlobalSuppressions.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\CSharpCommandLineParserProvider.cs" />
-    <Compile Include="ProjectSystem\SpecialFileProviders\CSharpAssemblyInfoSpecialFileProvider.cs" />
   </ItemGroup>
   <Import Project="..\..\build\Targets\VSL.Imports.targets" />
   <ItemDefinitionGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests.csproj
@@ -26,18 +26,10 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DeployTestDependencies\DeployTestDependencies.csproj">
-      <Project>{37ba82e6-9abd-4aca-aa26-2dfd39a359a5}</Project>
-      <Name>DeployTestDependencies</Name>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj">
-      <Project>{23bcbc90-ed65-4ee3-8af1-dd7caefdbee9}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.TestServices</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj">
-      <Project>{6c6a41ce-72c5-4d77-8208-d01693f9bc88}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\Common\Test\App.config">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests.csproj
@@ -1,13 +1,7 @@
 ﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
-    <AssemblyName>Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFramework>net46</TargetFramework>    
     <SignAssembly>true</SignAssembly>
     <Nonshipping>true</Nonshipping>
@@ -15,6 +9,7 @@
     <OutDir>$(OutDir)Tests\</OutDir>
     <ProjectSystemLayer>HostAgnostic</ProjectSystemLayer>
     <ProjectSystemProjectType>Test</ProjectSystemProjectType>
+    <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleToTest Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests" />
@@ -35,9 +30,6 @@
     <None Include="..\Common\Test\App.config">
       <Link>App.config</Link>
     </None>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="ProjectSystem\ProjectTreeParserTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests.csproj
@@ -9,7 +9,6 @@
     <OutDir>$(OutDir)Tests\</OutDir>
     <ProjectSystemLayer>HostAgnostic</ProjectSystemLayer>
     <ProjectSystemProjectType>Test</ProjectSystemProjectType>
-    <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleToTest Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests.csproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests.csproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{369DCA0F-A079-4D0C-8B32-53879199B681}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{23BCBC90-ED65-4EE3-8AF1-DD7CAEFDBEE9}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj
@@ -1,13 +1,7 @@
 ﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
-    <AssemblyName>Microsoft.VisualStudio.ProjectSystem.Managed.TestServices</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFramework>net46</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <Nonshipping>true</Nonshipping>
@@ -15,6 +9,7 @@
     <OutDir>$(OutDir)Tests\</OutDir>
     <ProjectSystemLayer>HostAgnostic</ProjectSystemLayer>
     <ProjectSystemProjectType>Test</ProjectSystemProjectType>
+    <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleToTest Include="Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests" />
@@ -25,28 +20,6 @@
     <InternalsVisibleToTest Include="Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests" />
     <InternalsVisibleToTest Include="Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests" />
     <InternalsVisibleToMoq Include="DynamicProxyGenAssembly2" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Diagnostics\ThrowingTraceListener.cs" />
-    <Compile Include="FuncWithOut.cs" />
-    <Compile Include="Moq\ReturnsExtensions.cs" />
-    <Compile Include="ProjectSystem\ProjectSystemTraitAttribute.cs" />
-    <Compile Include="ProjectSystem\ProjectSystemTraitDiscover.cs" />
-    <Compile Include="ProjectSystem\ProjectTreeParser\Delimiters.cs" />
-    <Compile Include="ProjectSystem\ProjectTreeParser\ProjectTreeFormatError.cs" />
-    <Compile Include="ProjectSystem\ProjectTreeParser\ProjectTreeFormatException.cs" />
-    <Compile Include="ProjectSystem\ProjectTreeParser\ProjectTreeParser.cs" />
-    <Compile Include="ProjectSystem\ProjectTreeParser\ProjectTreeParser.MutableProjectTree.cs" />
-    <Compile Include="ProjectSystem\ProjectTreeParser\StringReader.cs" />
-    <Compile Include="ProjectSystem\ProjectTreeParser\Tokenizer.cs" />
-    <Compile Include="ProjectSystem\ProjectTreeParser\Tokenizer.IdentifierParseOptions.cs" />
-    <Compile Include="ProjectSystem\ProjectTreeParser\Tokenizer.Token.cs" />
-    <Compile Include="ProjectSystem\ProjectTreeParser\Tokenizer.TokenType.cs" />
-    <Compile Include="ProjectSystem\ProjectTreePropertiesProviderExtensions.cs" />
-    <Compile Include="ProjectSystem\ProjectTreeProvider.cs" />
-    <Compile Include="ProjectSystem\ProjectTreeWriter.cs" />
-    <Compile Include="ProjectSystem\ProjectTreeWriterOptions.cs" />
-    <Compile Include="Workspaces\WorkspaceFactory.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj
@@ -9,7 +9,6 @@
     <OutDir>$(OutDir)Tests\</OutDir>
     <ProjectSystemLayer>HostAgnostic</ProjectSystemLayer>
     <ProjectSystemProjectType>Test</ProjectSystemProjectType>
-    <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleToTest Include="Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
@@ -9,7 +9,6 @@
     <OutDir>$(OutDir)Tests\</OutDir>
     <ProjectSystemLayer>HostAgnostic</ProjectSystemLayer>
     <ProjectSystemProjectType>Test</ProjectSystemProjectType>
-    <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleToTest Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
@@ -26,18 +26,10 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DeployTestDependencies\DeployTestDependencies.csproj">
-      <Project>{37ba82e6-9abd-4aca-aa26-2dfd39a359a5}</Project>
-      <Name>DeployTestDependencies</Name>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj">
-      <Project>{23bcbc90-ed65-4ee3-8af1-dd7caefdbee9}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.TestServices</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj">
-      <Project>{6c6a41ce-72c5-4d77-8208-d01693f9bc88}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Mocks\ConfiguredProjectFactory.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
@@ -1,13 +1,7 @@
 ﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
-    <AssemblyName>Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFramework>net46</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <Nonshipping>true</Nonshipping>
@@ -15,6 +9,7 @@
     <OutDir>$(OutDir)Tests\</OutDir>
     <ProjectSystemLayer>HostAgnostic</ProjectSystemLayer>
     <ProjectSystemProjectType>Test</ProjectSystemProjectType>
+    <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleToTest Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests" />
@@ -30,82 +25,6 @@
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Mocks\ConfiguredProjectFactory.cs" />
-    <Compile Include="Mocks\DispatchThread.cs" />
-    <Compile Include="Mocks\IFolderManagerFactory.cs" />
-    <Compile Include="Mocks\IProjectLockServiceFactory.cs" />
-    <Compile Include="Mocks\ActiveConfiguredProjectFactory.cs" />
-    <Compile Include="Mocks\ICreateFileFromTemplateServiceFactory.cs" />
-    <Compile Include="Mocks\IFileSystemMock.cs" />
-    <Compile Include="Mocks\IProjectFaultHandlerServiceFactory.cs" />
-    <Compile Include="Mocks\IProjectServicesFactory.cs" />
-    <Compile Include="Mocks\IProjectServiceFactory.cs" />
-    <Compile Include="Mocks\IPhysicalProjectTreeStorageFactory.cs" />
-    <Compile Include="Mocks\ISourceCodeControlIntegrationFactory.cs" />
-    <Compile Include="Mocks\IProjectThreadingServiceMock.cs" />
-    <Compile Include="Mocks\IFileSystemFactory.cs" />
-    <Compile Include="Mocks\IInterceptingPropertyValueProviderFactory.cs" />
-    <Compile Include="Mocks\IOrderPrecedenceMetadataViewFactory.cs" />
-    <Compile Include="Mocks\IPhysicalProjectTreeFactory.cs" />
-    <Compile Include="Mocks\IProjectCapabilitiesServiceFactory.cs" />
-    <Compile Include="Mocks\IProjectInstancePropertiesProviderFactory.cs" />
-    <Compile Include="Mocks\IProjectPropertiesFactory.cs" />
-    <Compile Include="Mocks\IProjectRuleSnapshotFactory.cs" />
-    <Compile Include="Mocks\IProjectRuleSnapshotsFactory.cs" />
-    <Compile Include="Mocks\IProjectItemProviderFactory.cs" />
-    <Compile Include="Mocks\IProjectThreadingServiceFactory.cs" />
-    <Compile Include="Mocks\IProjectTreeCustomizablePropertyContextFactory.cs" />
-    <Compile Include="Mocks\IProjectTreeCustomizablePropertyValuesFactory.cs" />
-    <Compile Include="Mocks\IProjectPropertiesProviderFactory.cs" />
-    <Compile Include="Mocks\IInterceptingPropertyValueProviderMetadataFactory.cs" />
-    <Compile Include="Mocks\IProjectTreeServiceStateFactory.cs" />
-    <Compile Include="Mocks\IProjectTreeServiceFactory.cs" />
-    <Compile Include="Mocks\IProjectTreeSnapshotFactory.cs" />
-    <Compile Include="Mocks\IProjectVersionedValueFactory.cs" />
-    <Compile Include="Mocks\IProjectAsynchronousTasksServiceFactory.cs" />
-    <Compile Include="Mocks\ISpecialFilesManagerFactory.cs" />
-    <Compile Include="Mocks\IWorkspaceProjectContextFactory.cs" />
-    <Compile Include="Mocks\IUnconfiguredProjectServicesFactory.cs" />
-    <Compile Include="Mocks\PropertyPageData.cs" />
-    <Compile Include="Mocks\IUnconfiguredProjectCommonServicesFactory.cs" />
-    <Compile Include="Mocks\ProjectPropertiesFactory.cs" />
-    <Compile Include="Mocks\IProjectImageProviderFactory.cs" />
-    <Compile Include="Mocks\IProjectTreeProviderFactory.cs" />
-    <Compile Include="Mocks\UnconfiguredProjectFactory.cs" />
-    <Compile Include="Mocks\IProjectDesignerServiceFactory.cs" />
-    <Compile Include="OrderPrecedenceImportCollectionExtensions.cs" />
-    <Compile Include="ProjectSystem\AppDesignerFolderProjectTreePropertiesProviderTests.cs" />
-    <Compile Include="ProjectSystem\Build\TargetFrameworkGlobalBuildPropertyProviderTests.cs" />
-    <Compile Include="ProjectSystem\Debug\LaunchProfileDataTests.cs" />
-    <Compile Include="ProjectSystem\Debug\LaunchProfileTests.cs" />
-    <Compile Include="ProjectSystem\Debug\DebugTokenReplacerTests.cs" />
-    <Compile Include="ProjectSystem\Debug\LaunchSettingsProviderTests.cs" />
-    <Compile Include="ProjectSystem\Debug\LaunchSettingsTests.cs" />
-    <Compile Include="ProjectSystem\Imaging\ProjectImageProviderAggregatorTests.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\Handlers\MetadataReferenceItemHandlerTests.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\Handlers\SourceItemHandlerTests.cs" />
-    <Compile Include="ProjectSystem\PhysicalProjectTreeStorageTests.cs" />
-    <Compile Include="ProjectSystem\Properties\AssemblyInfoPropertiesProviderTests.cs" />
-    <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\ApplicationManifestValueProviderTests.cs" />
-    <Compile Include="ProjectSystem\Properties\ImplicitProjectPropertiesProviderTests.cs" />
-    <Compile Include="ProjectSystem\ProjectRootImageProjectTreeModifierTests.cs" />
-    <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\InterceptedProjectPropertiesProviderTests.cs" />
-    <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\AssemblyOriginatorKeyFileValueProviderTests.cs" />
-    <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\TargetFrameworkValueProviderTests.cs" />
-    <Compile Include="ProjectSystem\Properties\OutputTypeEnumProviderTests.cs" />
-    <Compile Include="ProjectSystem\References\AlwaysAllowValidProjectReferenceCheckerTests.cs" />
-    <Compile Include="ProjectSystem\Reload\ProjectReloadInterceptorTests.cs" />
-    <Compile Include="ProjectSystem\SpecialFileProviders\AppDesignerFolderSpecialFileProviderTests.cs" />
-    <Compile Include="ProjectSystem\SpecialFileProviderTests.cs" />
-    <Compile Include="ProjectSystem\PhysicalProjectTreeTests.cs" />
-    <Compile Include="ProjectSystem\UnconfiguredProjectCommonServicesTests.cs" />
-    <Compile Include="Threading\Tasks\TaskExtensionsTests.cs" />
-    <Compile Include="ProjectSystem\Utilities\StringExtensionsTests .cs" />
-    <Compile Include="ProjectSystem\Utilities\TaskDelaySchedulerTests.cs" />
-    <Compile Include="Properties\AssemblyAttributes.cs" />
-    <Compile Include="ResolveDependenciesLocallyTestFramework.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{C7EC63F8-F96A-4A8F-B879-D572516746B4}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{469B50E9-FE67-459E-8AFA-44CBE523DBF6}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -23,26 +23,12 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DeployTestDependencies\DeployTestDependencies.csproj">
-      <Project>{37ba82e6-9abd-4aca-aa26-2dfd39a359a5}</Project>
-      <Name>DeployTestDependencies</Name>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj">
-      <Project>{23bcbc90-ed65-4ee3-8af1-dd7caefdbee9}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.TestServices</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj">
-      <Project>{c7ec63f8-f96a-4a8f-b879-d572516746b4}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS\Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj">
-      <Project>{1c5666ea-24a4-4ec2-b8fb-faedf6b14697}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.VS</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj">
-      <Project>{6c6a41ce-72c5-4d77-8208-d01693f9bc88}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS\Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Properties\AssemblyAttributes.cs">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -1,13 +1,7 @@
 ﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
-    <AssemblyName>Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFramework>net46</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <Nonshipping>true</Nonshipping>
@@ -15,6 +9,7 @@
     <OutDir>$(OutDir)Tests\</OutDir>
     <ProjectSystemLayer>VisualStudio</ProjectSystemLayer>
     <ProjectSystemProjectType>Test</ProjectSystemProjectType>
+    <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleToTest Include="Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests" />
@@ -34,127 +29,6 @@
     <Compile Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Properties\AssemblyAttributes.cs">
       <Link>Properties\AssemblyAttributes.cs</Link>
     </Compile>
-    <Compile Include="GlobalSuppressions.cs" />
-    <Compile Include="Mocks\DteFactory.cs" />
-    <Compile Include="Mocks\IActiveConfiguredProjectSubscriptionServiceFactory.cs" />
-    <Compile Include="Mocks\IDebugLaunchProviderFactory.cs" />
-    <Compile Include="Mocks\IDebugLaunchProviderMetadataViewFactory.cs" />
-    <Compile Include="Mocks\IDteServicesFactory.cs" />
-    <Compile Include="Mocks\ExportFactoryFactory.cs" />
-    <Compile Include="Mocks\INuGetPackagesDataProviderFactory.cs" />
-    <Compile Include="Mocks\IDependenciesChangeDiffFactory.cs" />
-    <Compile Include="Mocks\IVsHiearchyItemFactory.cs" />
-    <Compile Include="Mocks\IProjectFileEditorPresenterFactory.cs" />
-    <Compile Include="Mocks\IFrameOpenCloseListenerFactory.cs" />
-    <Compile Include="Mocks\IProjectXmlAccessorFactory.cs" />
-    <Compile Include="Mocks\IOutputGroupsFactory.cs" />
-    <Compile Include="Mocks\IProjectCapabilitiesScopeFactory.cs" />
-    <Compile Include="CollectionsExtensions.cs" />
-    <Compile Include="Mocks\DependenciesChangeFactory.cs" />
-    <Compile Include="Mocks\IGraphContextFactory.cs" />
-    <Compile Include="Mocks\IDependenciesGraphProjectContextProviderFactory.cs" />
-    <Compile Include="Mocks\IProjectDependenciesSubTreeProviderMock.cs" />
-    <Compile Include="Mocks\IJsonModel.cs" />
-    <Compile Include="Mocks\IDependencyNodeFactory.cs" />
-    <Compile Include="Mocks\IProjectCatalogSnapshotFactory.cs" />
-    <Compile Include="Mocks\IProjectFileModelWatcherFactory.cs" />
-    <Compile Include="Mocks\ITextBufferFactory.cs" />
-    <Compile Include="Mocks\ITextBufferManagerMock.cs" />
-    <Compile Include="Mocks\ITextBufferStateListenerFactory.cs" />
-    <Compile Include="Mocks\ITextDocumentFactory.cs" />
-    <Compile Include="Mocks\ITextDocumentFactoryServiceFactory.cs" />
-    <Compile Include="Mocks\IVsUpdateSolutionEventsFactory.cs" />
-    <Compile Include="Mocks\IVsSolutionBuildManager2Factory.cs" />
-    <Compile Include="Mocks\IVsEditorAdaptersFactoryServiceFactory.cs" />
-    <Compile Include="Mocks\IVsPersistDocDataFactory.cs" />
-    <Compile Include="Mocks\IVsProjectSpecialFilesFactory.cs" />
-    <Compile Include="Mocks\IVsSettingsManagerFactory.cs" />
-    <Compile Include="Mocks\IVsSettingsStoreTester.cs" />
-    <Compile Include="Mocks\IVsShellUtilitiesHelperFactory.cs" />
-    <Compile Include="Mocks\IVsUIShell7Factory.cs" />
-    <Compile Include="Mocks\IVsUnconfiguredProjectIntegrationServiceFactory.cs" />
-    <Compile Include="Mocks\ProjectConfigurationFactory.cs" />
-    <Compile Include="Mocks\IProjectSubscriptionUpdateFactory.cs" />
-    <Compile Include="Mocks\IProjectRuleSnapshotFactory.cs" />
-    <Compile Include="Mocks\IProjectChangeDiffFactory.cs" />
-    <Compile Include="Mocks\IProjectChangeDescriptionFactory.cs" />
-    <Compile Include="Mocks\IProjectValueDataSourceFactory.cs" />
-    <Compile Include="Mocks\DataFlowExtensionMethodWrapperMock.cs" />
-    <Compile Include="Mocks\IRoslynServicesFactory.cs" />
-    <Compile Include="Mocks\IServiceProviderFactory.cs" />
-    <Compile Include="Mocks\IServiceProviderMoq.cs" />
-    <Compile Include="Mocks\IVsSolutionFactory.cs" />
-    <Compile Include="Mocks\IVsFileChangeExFactory.cs" />
-    <Compile Include="Mocks\IVsStartupProjectsListServiceFactory.cs" />
-    <Compile Include="Mocks\ProjectItemFactory.cs" />
-    <Compile Include="Mocks\Reference3Factory.cs" />
-    <Compile Include="Mocks\RegistrationContextFactory.cs" />
-    <Compile Include="Mocks\IVsAddProjectItemDlgFactory.cs" />
-    <Compile Include="Mocks\SVsServiceProviderFactory.cs" />
-    <Compile Include="Mocks\IOptionsSettingsFactory.cs" />
-    <Compile Include="Mocks\ILanguageServiceHostFactory.cs" />
-    <Compile Include="Mocks\IUserNotificationServicesFactory.cs" />
-    <Compile Include="Mocks\IUnconfiguredProjectVsServicesFactory.cs" />
-    <Compile Include="Mocks\IVsLanguageServiceBuildErrorReporter2Factory.cs" />
-    <Compile Include="Mocks\IVsWindowFrameFactory.cs" />
-    <Compile Include="Mocks\IVsHierarchyFactory.cs" />
-    <Compile Include="Mocks\IVsProject_Factory.cs" />
-    <Compile Include="Mocks\ProjectFactory.cs" />
-    <Compile Include="Mocks\SolutionFactory.cs" />
-    <Compile Include="Mocks\VSProjectFactory.cs" />
-    <Compile Include="ProjectSystem\VS\Build\LanguageServiceErrorListProviderTests.cs" />
-    <Compile Include="ProjectSystem\VS\CreateFileFromTemplateServiceTests.cs" />
-    <Compile Include="ProjectSystem\VS\Debug\ConsoleDebugLaunchProviderTests.cs" />
-    <Compile Include="ProjectSystem\VS\Debug\DebugProfileEnumValuesGeneratorTests.cs" />
-    <Compile Include="ProjectSystem\VS\Debug\ProjectDebuggerProviderTests.cs" />
-    <Compile Include="ProjectSystem\VS\DebugTests\StartupProjectRegistrarTests.cs" />
-    <Compile Include="ProjectSystem\VS\Editor\ProjectFileEditorPresenterTests.cs" />
-    <Compile Include="ProjectSystem\VS\Editor\Listeners\FrameOpenCloseListenerTests.cs" />
-    <Compile Include="ProjectSystem\VS\Editor\Listeners\ProjectFileModelWatcherTests.cs" />
-    <Compile Include="ProjectSystem\VS\Editor\Listeners\TempFileBufferStateListenerTests.cs" />
-    <Compile Include="ProjectSystem\VS\Editor\TempFileTextBufferManagerTests.cs" />
-    <Compile Include="ProjectSystem\VS\Generators\GeneratorExtensionRegistrationAttributeTests.cs" />
-    <Compile Include="ProjectSystem\VS\Generators\SingleFileGeneratorFactoryAggregatorTests.cs" />
-    <Compile Include="ProjectSystem\VS\Generators\RemoteCodeGenerationRegistrationAttributeTests.cs" />
-    <Compile Include="ProjectSystem\VS\Input\Commands\AbstractGenerateNuGetPackageCommandTests.cs" />
-    <Compile Include="ProjectSystem\VS\Input\Commands\GenerateNuGetPackageProjectContextMenuCommandTests.cs" />
-    <Compile Include="ProjectSystem\VS\Input\Commands\GenerateNuGetPackageTopLevelBuildMenuCommandTests.cs" />
-    <Compile Include="ProjectSystem\VS\Input\Commands\EditProjectFileCommandTests.cs" />
-    <Compile Include="ProjectSystem\VS\Input\Commands\AbstractOpenProjectDesignerCommandTests.cs" />
-    <Compile Include="ProjectSystem\VS\Input\Commands\AbstractAddClassProjectCommandTests.cs" />
-    <Compile Include="ProjectSystem\VS\Input\Commands\AddClassProjectCSharpCommandTests.cs" />
-    <Compile Include="ProjectSystem\VS\Input\Commands\AddClassProjectVBCommandTests.cs" />
-    <Compile Include="ProjectSystem\VS\Input\Commands\OpenProjectDesignerCommandTests.cs" />
-    <Compile Include="ProjectSystem\VS\Input\Commands\OpenProjectDesignerOnDefaultActionCommandTests.cs" />
-    <Compile Include="ProjectSystem\VS\NuGet\ProjectRestoreInfoBuilderTests.cs" />
-    <Compile Include="ProjectSystem\VS\OptionsSettingsTests.cs" />
-    <Compile Include="ProjectSystem\VS\Properties\OutputTypeExValueProviderTests.cs" />
-    <Compile Include="ProjectSystem\VS\PropertyPages\BuildMacroInfoTests.cs" />
-    <Compile Include="ProjectSystem\VS\PropertyPages\DebugPageViewModelTests.cs" />
-    <Compile Include="ProjectSystem\VS\PropertyPages\PropertyPageControlTests.cs" />
-    <Compile Include="ProjectSystem\VS\PropertyPages\PropertyPageTests.cs" />
-    <Compile Include="ProjectSystem\VS\PropertyPages\TestPropertyProviders.cs" />
-    <Compile Include="ProjectSystem\VS\References\DesignTimeAssemblyResolutionTests.cs" />
-    <Compile Include="ProjectSystem\VS\References\ReferenceContextProviderTests.cs" />
-    <Compile Include="ProjectSystem\VS\Reload\ReloadableProjectTests.cs" />
-    <Compile Include="ProjectSystem\VS\Reload\ProjectReloadManagerTests.cs" />
-    <Compile Include="ProjectSystem\VS\ProjectLockFileWatcherTests.cs" />
-    <Compile Include="ProjectSystem\VS\Properties\ProjectDesignerPageMetadataTests.cs" />
-    <Compile Include="ProjectSystem\VS\Rename\SimpleRenamerTests.cs" />
-    <Compile Include="ProjectSystem\VS\SpecialFileProviders\VsProjectSpecialFilesManagerTests.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\DependenciesGraphProviderTests.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\DependenciesSubTreeProviderBaseTests.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\SdkDependenciesSubTreeProviderTests.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\ProjectDependenciesSubTreeProviderTests.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\NuGetDependenciesSubTreeProviderTests.cs" />
-    <Compile Include="ProjectSystem\VS\UI\MultiChoiceMsgBoxViewModelTests.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\DependencyNodeTests.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\DependencyNodeIdTests.cs" />
-    <Compile Include="ProjectSystem\VS\DteServicesTests.cs" />
-    <Compile Include="ProjectSystem\VS\UnconfiguredProjectVsServicesTests.cs" />
-    <Compile Include="ProjectSystem\VS\Properties\ProjectDesignerServiceTests.cs" />
-    <Compile Include="ProjectSystem\VS\Utilities\EnumMatchToBooleanConverterTests.cs" />
-    <Compile Include="Shell\HierarchyIdTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -9,7 +9,6 @@
     <OutDir>$(OutDir)Tests\</OutDir>
     <ProjectSystemLayer>VisualStudio</ProjectSystemLayer>
     <ProjectSystemProjectType>Test</ProjectSystemProjectType>
-    <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleToTest Include="Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{1C5666EA-24A4-4EC2-B8FB-FAEDF6B14697}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -236,14 +236,8 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Dependencies\VisualStudio\VisualStudio.csproj">
-      <Project>{8da861d8-0cce-4334-b6c0-01a846c881ec}</Project>
-      <Name>VisualStudio</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj">
-      <Project>{6c6a41ce-72c5-4d77-8208-d01693f9bc88}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Dependencies\VisualStudio\VisualStudio.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.SolutionRestoreManager.Interop" Version="4.0.0-rc-2024" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -1,13 +1,7 @@
 ﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
-    <AssemblyName>Microsoft.VisualStudio.ProjectSystem.Managed.VS</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFramework>net46</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
@@ -16,6 +10,7 @@
     <DeployExtension>false</DeployExtension>
     <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
     <ProjectSystemLayer>VisualStudio</ProjectSystemLayer>
+    <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.CSharp.VS" />
@@ -29,209 +24,35 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="GlobalSuppressions.cs" />
-    <Compile Include="Input\CommandGroup.cs" />
-    <Compile Include="Input\UIHierarchyWindowCommandId.cs" />
-    <Compile Include="Input\VisualStudioStandard2kCommandId.cs" />
-    <Compile Include="Input\VisualStudioStandard97CommandId.cs" />
-    <Compile Include="Packaging\DplOptOutRegistrationAttribute.cs" />
-    <Compile Include="ProjectSystem\VS\Editor\MSBuildXmlAccessor.cs" />
-    <Compile Include="ProjectSystem\VS\Editor\ProjectFileEditorPresenter.cs" />
-    <Compile Include="ProjectSystem\VS\Editor\IProjectFileEditorPresenter.cs" />
-    <Compile Include="ProjectSystem\VS\Editor\ITextBufferManager.cs" />
-    <Compile Include="ProjectSystem\VS\Editor\Listeners\FrameOpenCloseListener.cs" />
-    <Compile Include="ProjectSystem\VS\Editor\Listeners\IFrameOpenCloseListener.cs" />
-    <Compile Include="ProjectSystem\VS\Editor\Listeners\IProjectFileModelWatcher.cs" />
-    <Compile Include="ProjectSystem\VS\Editor\Listeners\ITextBufferStateListener.cs" />
-    <Compile Include="ProjectSystem\VS\Editor\Listeners\ProjectFileModelWatcher.cs" />
-    <Compile Include="ProjectSystem\VS\Editor\Listeners\TempFileBufferStateListener.cs" />
-    <Compile Include="ProjectSystem\VS\Editor\TempFileTextBufferManager.cs" />
-    <Compile Include="ProjectSystem\VS\EditAndContinue\EditAndContinueProvider.cs" />
-    <Compile Include="ProjectSystem\VS\ExportProjectNodeComServiceAttribute.cs" />
-    <Compile Include="ProjectSystem\VS\Input\Commands\GenerateNuGetPackageTopLevelBuildMenuCommand.cs" />
-    <Compile Include="ProjectSystem\VS\Input\Commands\GenerateNuGetPackageProjectContextMenuCommand.cs" />
-    <Compile Include="ProjectSystem\VS\Input\Commands\AbstractGenerateNuGetPackageCommand.cs" />
-    <Compile Include="ProjectSystem\VS\Properties\InterceptedProjectProperties\OutputTypeExValueProvider.cs" />
-    <Compile Include="ProjectSystem\VS\PropertyPages\BuildMacroInfo.cs" />
-    <Compile Include="ProjectSystem\VS\Generators\SingleFileGeneratorFactoryAggregator.cs" />
-    <Compile Include="ProjectSystem\VS\NuGet\ProjectProperties.cs" />
-    <Compile Include="ProjectSystem\VS\NuGet\ProjectProperty.cs" />
-    <Compile Include="ProjectSystem\VS\NuGet\VsItemList.cs" />
-    <Compile Include="ProjectSystem\VS\NuGet\ProjectRestoreInfo.cs" />
-    <Compile Include="ProjectSystem\VS\NuGet\ProjectRestoreInfoBuilder.cs" />
-    <Compile Include="ProjectSystem\VS\Debug\ConsoleDebugTargetsProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Debug\ErrorProfileDebugTargetsProvider.cs" />
-    <Compile Include="ProjectSystem\VS\LanguageServices\ConfiguredProjectHostObject.cs" />
-    <Compile Include="ProjectSystem\VS\LanguageServices\UnconfiguredProjectHostObject.cs" />
-    <Compile Include="ProjectSystem\VS\LanguageServices\AbstractHostObject.cs" />
-    <Compile Include="ProjectSystem\VS\LanguageServices\ProjectHostProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Generators\ClassRegistrationAttribute.cs" />
-    <Compile Include="ProjectSystem\VS\DteServices.cs" />
-    <Compile Include="ProjectSystem\VS\IDteServices.cs" />
-    <Compile Include="ProjectSystem\VS\LanguageServices\ProjectContextCodeModelProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Input\Commands\EditProjectFileCommand.cs" />
-    <Compile Include="ProjectSystem\VS\LanguageServices\VsContainedLanguageComponentsFactoryBase.cs" />
-    <Compile Include="ProjectSystem\VS\LanguageServices\IVsContainedLanguageComponentsFactory.cs" />
-    <Compile Include="Packaging\ManagedProjectSystemPackage.cs" />
-    <Compile Include="ProjectSystem\VS\Debug\DebugProfileDebugTargetGenerator.cs" />
-    <Compile Include="ProjectSystem\VS\Debug\DebugProfileEnumValuesGenerator.cs" />
-    <Compile Include="ProjectSystem\VS\Debug\IDebugProfileLaunchTargetsProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Debug\ProjectDebuggerProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Debug\StartupProjectRegistrar.cs" />
-    <Compile Include="ProjectSystem\VS\Generators\GeneratorExtensionRegistrationAttribute.cs" />
-    <Compile Include="ProjectSystem\VS\Generators\RemoteCodeGeneratorRegistrationAttribute.cs" />
-    <Compile Include="ProjectSystem\VS\Extensibility\ProjectExportProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Extensibility\IProjectExportProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Generators\SingleFileGenerators.cs" />
-    <Compile Include="ProjectSystem\VS\Input\Commands\AbstractAddClassProjectCommand.cs" />
-    <Compile Include="ProjectSystem\VS\Input\Commands\AddClassProjectCSharpCommand.cs" />
-    <Compile Include="ProjectSystem\VS\Input\Commands\AddClassProjectVBCommand.cs" />
-    <Compile Include="ProjectSystem\VS\PropertyPages\DebugPageControl.xaml.cs">
+    <Compile Update="ProjectSystem\VS\PropertyPages\DebugPageControl.xaml.cs">
       <DependentUpon>DebugPageControl.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\VS\PropertyPages\DebugPageViewModel.cs" />
-    <Compile Include="ProjectSystem\VS\PropertyPages\DebugPropertyPage.cs" />
-    <Compile Include="ProjectSystem\VS\PropertyPages\EnvironmentGridTemplateColumn.cs" />
-    <Compile Include="ProjectSystem\VS\PropertyPages\ProjectLaunchSettingsUIProvider.cs" />
-    <Compile Include="ProjectSystem\VS\PropertyPages\GetProfileNameDialog.xaml.cs">
+    <Compile Update="ProjectSystem\VS\PropertyPages\GetProfileNameDialog.xaml.cs">
       <DependentUpon>GetProfileNameDialog.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\VS\PropertyPages\ExecutableLaunchSettingsUIProvider.cs" />
-    <Compile Include="ProjectSystem\VS\PropertyPages\IPageMetadata.cs" />
-    <Compile Include="ProjectSystem\VS\PropertyPages\PropertyPage.cs">
+    <Compile Update="ProjectSystem\VS\PropertyPages\PropertyPage.cs">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="ProjectSystem\VS\PropertyPages\PropertyPage.Designer.cs">
+    <Compile Update="ProjectSystem\VS\PropertyPages\PropertyPage.Designer.cs">
       <DependentUpon>PropertyPage.cs</DependentUpon>
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="ProjectSystem\VS\PropertyPages\PropertyPageControl.cs" />
-    <Compile Include="ProjectSystem\VS\PropertyPages\PropertyPageElementHost.cs" />
-    <Compile Include="ProjectSystem\VS\PropertyPages\PropertyPageResources.Designer.cs">
+    <Compile Update="ProjectSystem\VS\PropertyPages\PropertyPageResources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>PropertyPageResources.resx</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\VS\PropertyPages\PropertyPageViewModel.cs" />
-    <Compile Include="ProjectSystem\VS\PropertyPages\WatermarkTextBox.cs" />
-    <Compile Include="ProjectSystem\VS\PropertyPages\WpfBasedPropertyPage.cs">
+    <Compile Update="ProjectSystem\VS\PropertyPages\WpfBasedPropertyPage.cs">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="ProjectSystem\VS\PropertyPages\WpfBasedPropertyPage.Designer.cs">
+    <Compile Update="ProjectSystem\VS\PropertyPages\WpfBasedPropertyPage.Designer.cs">
       <DependentUpon>WpfBasedPropertyPage.cs</DependentUpon>
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="ProjectSystem\VS\NuGet\NuGetRestorer.cs" />
-    <Compile Include="ProjectSystem\VS\References\AddFileContextProvider.cs" />
-    <Compile Include="ProjectSystem\VS\References\AssemblyReferenceContextProvider.cs" />
-    <Compile Include="ProjectSystem\VS\References\BaseReferenceContextProvider.cs" />
-    <Compile Include="ProjectSystem\VS\References\ComReferencesProviderContext.cs" />
-    <Compile Include="ProjectSystem\VS\References\DesignTimeAssemblyResolution.cs" />
-    <Compile Include="ProjectSystem\VS\References\DesignTimeAssemblyResolution.ResolvedReference.cs" />
-    <Compile Include="ProjectSystem\VS\References\ProjectReferencesProviderContext.cs" />
-    <Compile Include="ProjectSystem\VS\References\SharedProjectReferencesProviderContext.cs" />
-    <Compile Include="ProjectSystem\VS\References\WinRTReferencesProviderContext.cs" />
-    <Compile Include="ProjectSystem\VS\Reload\IProjectReloadManager.cs" />
-    <Compile Include="ProjectSystem\VS\Reload\ProjectReloadManager.cs" />
-    <Compile Include="ProjectSystem\VS\IOptionsSettings.cs" />
-    <Compile Include="ProjectSystem\VS\IPhysicalProjectTreeExtensions.cs" />
-    <Compile Include="ProjectSystem\VS\IProjectTreeExtensions.cs" />
-    <Compile Include="ProjectSystem\VS\IRoslynServices.cs" />
-    <Compile Include="ProjectSystem\VS\IUserNotificationServices.cs" />
-    <Compile Include="ProjectSystem\VS\OptionsSettings.cs" />
-    <Compile Include="ProjectSystem\VS\ProjectLockFileWatcher.cs" />
-    <Compile Include="ProjectSystem\VS\Properties\InterceptedProjectProperties\TargetFrameworkMonikerValueProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Properties\ProjectFileOrAssemblyInfoPropertiesProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Reload\IReloadableProject.cs" />
-    <Compile Include="ProjectSystem\VS\Reload\ReloadableProject.cs" />
-    <Compile Include="ProjectSystem\VS\Renamer.cs" />
-    <Compile Include="ProjectSystem\VS\Build\LanguageServiceErrorListProvider.ErrorListDetails.cs" />
-    <Compile Include="ProjectSystem\VS\FileRenameTracker.cs" />
-    <Compile Include="ProjectSystem\VS\Input\Commands\OpenProjectDesignerCommand.cs" />
-    <Compile Include="ProjectSystem\VS\Input\Commands\AbstractOpenProjectDesignerCommand.cs" />
-    <Compile Include="ProjectSystem\VS\Input\Commands\OpenProjectDesignerOnDefaultActionCommand.cs" />
-    <Compile Include="ProjectSystem\VS\Build\LanguageServiceErrorListProvider.cs" />
-    <Compile Include="ProjectSystem\VS\IServiceProviderExtensions.cs" />
-    <Compile Include="ProjectSystem\VS\Properties\ProjectDesignerPageMetadata.cs" />
-    <Compile Include="ProjectSystem\VS\IUnconfiguredProjectVsServices.cs" />
-    <Compile Include="ProjectSystem\VS\Rename\AbstractRenameStrategy.cs" />
-    <Compile Include="ProjectSystem\VS\Rename\IRenameStrategy.cs" />
-    <Compile Include="ProjectSystem\VS\Rename\SimpleRenameStrategy.cs" />
-    <Compile Include="ProjectSystem\VS\RoslynServices.cs" />
-    <Compile Include="ProjectSystem\VS\SpecialFilesProviders\VsProjectSpecialFilesManager.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\AnalyzerDependenciesSubTreeProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\AnalyzerDependencyNode.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\DependencyNodeResolvedStateComparer.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\IDependencyNodeExtensions.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\INuGetPackagesDataProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\PackageAnalyzerAssemblyDependencyNode.cs" />
-    <Compile Include="ProjectSystem\VS\UI\DialogServices.cs" />
-    <Compile Include="ProjectSystem\VS\UI\IDialogServices.cs" />
-    <Compile Include="ProjectSystem\VS\UI\IVsShellUtilitiesHelper.cs" />
-    <Compile Include="ProjectSystem\VS\UI\MultiChoiceMsgBox.Xaml.cs">
+    <Compile Update="ProjectSystem\VS\UI\MultiChoiceMsgBox.Xaml.cs">
       <DependentUpon>MultiChoiceMsgBox.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\VS\UI\MultiChoiceMsgBoxResult.cs" />
-    <Compile Include="ProjectSystem\VS\UI\MultiChoiceMsgBoxViewModel.cs" />
-    <Compile Include="ProjectSystem\VS\UI\RelayCommand.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\AssemblyDependenciesSubTreeProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\AssemblyDependencyNode.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\DependencyNodeId.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\PackageFrameworkAssembliesDependencyNode.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\PackageAssemblyDependencyNode.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\PackageUnknownDependencyNode.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\SdkDependencyNode.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\SdkDependenciesSubTreeProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\DependenciesProjectTreeProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\IEnumerableExtensions.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\PackageDependencyNode.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\ComDependenciesSubTreeProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\ComDependencyNode.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\SharedProjectDependencyNode.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\SubTreeRootDependencyNode.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\ProjectDependencyNode.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\DependencyNode.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\DependenciesChange.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\IDependenciesChangeDiff.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\IDependencyNode.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\ProjectDependenciesSubTreeProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\DependenciesSubTreeProviderBase.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\DependenciesGraphProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\DependenciesGraphProjectContextProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\IDependenciesGraphProjectContextProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\IDependenciesGraphProjectContext.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\NuGetDependenciesSubTreeProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\DependenciesGraphSchema.cs" />
-    <Compile Include="ProjectSystem\VS\Tree\Dependencies\IProjectDependenciesSubTreeProvider.cs" />
-    <Compile Include="ProjectSystem\VS\UserNotificationServices.cs" />
-    <Compile Include="ProjectSystem\VS\CreateFileFromTemplateService.cs" />
-    <Compile Include="ProjectSystem\VS\UnconfiguredProjectVsServices.cs" />
-    <Compile Include="ProjectSystem\VS\Properties\ProjectDesignerService.cs" />
-    <Compile Include="ProjectSystem\VS\Utilities\Converters.cs" />
-    <Compile Include="ProjectSystem\VS\Utilities\DelegateCommand.cs" />
-    <Compile Include="ProjectSystem\VS\Utilities\EnumMatchToBooleanConverter.cs" />
-    <Compile Include="ProjectSystem\VS\Utilities\FocusAttacher.cs" />
-    <Compile Include="ProjectSystem\VS\Editor\IProjectXmlAccessor.cs" />
-    <Compile Include="ProjectSystem\VS\Utilities\NameValuePair.cs" />
-    <Compile Include="ProjectSystem\VS\Utilities\ObservableList.cs" />
-    <Compile Include="ProjectSystem\VS\Utilities\ObservableListExtensions.cs" />
-    <Compile Include="ProjectSystem\VS\Utilities\ManagedPathHelper.cs" />
-    <Compile Include="ProjectSystem\VS\Utilities\UnitTestHelper.cs" />
-    <Compile Include="ProjectSystem\VS\Utilities\UIThreadHelper.cs" />
-    <Compile Include="ProjectSystem\VS\UI\VsShellUtilitiesHelper.cs" />
-    <Compile Include="ProjectSystem\VS\Utilities\WpfHelper.cs" />
-    <Compile Include="ProjectSystem\VS\NuGet\ReferenceItem.cs" />
-    <Compile Include="ProjectSystem\VS\NuGet\ReferenceItems.cs" />
-    <Compile Include="ProjectSystem\VS\NuGet\ReferenceProperties.cs" />
-    <Compile Include="ProjectSystem\VS\NuGet\ReferenceProperty.cs" />
-    <Compile Include="ProjectSystem\VS\NuGet\TargetFrameworkInfo.cs" />
-    <Compile Include="ProjectSystem\VS\NuGet\TargetFrameworks.cs" />
-    <Compile Include="Shell\HierarchyId.cs" />
-    <Compile Include="Shell\Interop\VsProjectExtensions.cs" />
-    <Compile Include="Shell\Interop\VsHierarchyExtensions.cs" />
-    <Compile Include="Shell\ServiceProviderToOleServiceProviderAdapter.cs" />
-    <Compile Include="Threading\Tasks\VsTaskScheduler.cs" />
-    <Compile Include="VSResources.Designer.cs">
+    <Compile Update="VSResources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>VSResources.resx</DependentUpon>
@@ -246,21 +67,21 @@
     <PackageReference Include="NuGet.VisualStudio" Version="4.0.0-rc-2048" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="ProjectSystem\VS\PropertyPages\PropertyPageResources.resx">
+    <EmbeddedResource Update="ProjectSystem\VS\PropertyPages\PropertyPageResources.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>PropertyPageResources.Designer.cs</LastGenOutput>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="ProjectSystem\VS\PropertyPages\PropertyPageResources.*.resx">
+    <EmbeddedResource Update="ProjectSystem\VS\PropertyPages\PropertyPageResources.*.resx">
       <DependentUpon>PropertyPageResources.resx</DependentUpon>
     </EmbeddedResource>
-    <EmbeddedResource Include="VSResources.resx">
+    <EmbeddedResource Update="VSResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>VSResources.Designer.cs</LastGenOutput>
       <SubType>Designer</SubType>
       <MergeWithCTO>true</MergeWithCTO>
     </EmbeddedResource>
-    <EmbeddedResource Include="VSResources.*.resx">
+    <EmbeddedResource Update="VSResources.*.resx">
       <DependentUpon>VSResources.resx</DependentUpon>
       <MergeWithCTO>true</MergeWithCTO>
     </EmbeddedResource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -10,7 +10,6 @@
     <DeployExtension>false</DeployExtension>
     <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
     <ProjectSystemLayer>VisualStudio</ProjectSystemLayer>
-    <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.CSharp.VS" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -103,6 +103,7 @@
     </Compile>
     <Compile Include="ProjectSystem\VS\PropertyPages\PropertyPage.Designer.cs">
       <DependentUpon>PropertyPage.cs</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="ProjectSystem\VS\PropertyPages\PropertyPageControl.cs" />
     <Compile Include="ProjectSystem\VS\PropertyPages\PropertyPageElementHost.cs" />
@@ -118,6 +119,7 @@
     </Compile>
     <Compile Include="ProjectSystem\VS\PropertyPages\WpfBasedPropertyPage.Designer.cs">
       <DependentUpon>WpfBasedPropertyPage.cs</DependentUpon>
+      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="ProjectSystem\VS\NuGet\NuGetRestorer.cs" />
     <Compile Include="ProjectSystem\VS\References\AddFileContextProvider.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -1,17 +1,12 @@
 ﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
-    <AssemblyName>Microsoft.VisualStudio.ProjectSystem.Managed</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFramework>net46</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
     <ProjectSystemLayer>HostAgnostic</ProjectSystemLayer>
+    <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS" />
@@ -31,243 +26,107 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Extensions\SemaphoreSlimExtensions.cs" />
-    <Compile Include="Extensions\ProjectConfigurationExtensions.cs" />
-    <Compile Include="ProjectSystem\Build\BuildProperty.cs" />
-    <Compile Include="CommonConstants.cs" />
-    <Compile Include="ProjectSystem\Build\TurnOffUseHostCompilerIfAvailableBuildPropertiesProvider.cs" />
-    <Compile Include="ProjectSystem\Build\CommandLineDesignTimeBuildPropertiesProvider.cs" />
-    <Compile Include="ProjectSystem\Build\GeneratePackageOnBuildDesignTimeBuildPropertyProvider.cs" />
-    <Compile Include="ProjectSystem\Build\GeneratePackageOnBuildPropertyProvider.cs" />
-    <Compile Include="ProjectSystem\Build\TargetFrameworkGlobalBuildPropertyProvider.cs" />
-    <Compile Include="ProjectSystem\ContractNames.cs" />
-    <Compile Include="GlobalSuppressions.cs" />
-    <Compile Include="ProjectSystem\Build\PublishableProjectConfigProvider.cs" />
-    <Compile Include="ProjectSystem\Debug\IDebugTokenReplacer.cs" />
-    <Compile Include="ProjectSystem\Debug\DebugTokenReplacer.cs" />
-    <Compile Include="ProjectSystem\Debug\IJsonSection.cs" />
-    <Compile Include="ProjectSystem\Debug\IWritableLaunchProfile.cs" />
-    <Compile Include="ProjectSystem\Debug\IWritableLaunchSettings.cs" />
-    <Compile Include="ProjectSystem\Debug\ILaunchSettingsUIProvider.cs" />
-    <Compile Include="ProjectSystem\Debug\ILaunchSettingsSerializationProvider.cs" />
-    <Compile Include="ProjectSystem\Debug\WritableLaunchSettings.cs" />
-    <Compile Include="ProjectSystem\Debug\WritableLaunchProfile.cs" />
-    <Compile Include="ProjectSystem\Debug\LaunchProfileData.cs" />
-    <Compile Include="ProjectSystem\Debug\LaunchProfile.cs" />
-    <Compile Include="ProjectSystem\Debug\ILaunchProfile.cs" />
-    <Compile Include="ProjectSystem\Debug\ILaunchSettings.cs" />
-    <Compile Include="ProjectSystem\Debug\ILaunchSettingsProvider.cs" />
-    <Compile Include="ProjectSystem\Debug\LaunchSettings.cs" />
-    <Compile Include="ProjectSystem\Debug\LaunchSettingsData.cs" />
-    <Compile Include="ProjectSystem\Debug\LaunchSettingsProvider.cs" />
-    <Compile Include="ProjectSystem\IPhysicalProjectTreeStorage.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\IConfiguredProjectHostObject.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\ConfiguredProjectReadyToBuild.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\IUnconfiguredProjectHostObject.cs" />
-    <Compile Include="ProjectSystem\DefaultCapabilitiesProvider.cs" />
-    <Compile Include="ProjectSystem\ActiveConfiguredProjectsProvider.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\CommandLineParserService.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\Handlers\AbstractLanguageServiceRuleHandler.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\Handlers\CommandLineItemHandler.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\Handlers\MetadataReferenceItemHandler.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\Handlers\AdditionalFilesItemHandler.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\Handlers\AnalyzerItemHandler.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\Handlers\ProjectPropertiesItemHandler.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\Handlers\SourceItemHandler.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\ICommandLineParserService.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\ILanguageServiceHost.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\AggregateWorkspaceProjectContext.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\IProjectHostProvider.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\IProjectContextProvider.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\ILanguageServiceRuleHandler.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\ILanguageServiceCommandLineHandler.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\ProjectTreeServiceExtensions.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\RuleHandlerType.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\LanguageServiceHost.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\UnconfiguredProjectContextProvider.cs" />
-    <Compile Include="ProjectSystem\PhysicalProjectTreeStorage.cs" />
-    <Compile Include="ProjectSystem\DataflowUtilities.cs" />
-    <Compile Include="ProjectSystem\ProjectTreeProviderExtensions.cs" />
-    <Compile Include="ProjectSystem\Properties\DelegatedProjectPropertiesProviderBase.cs" />
-    <Compile Include="ProjectSystem\Properties\DelegatedProjectPropertiesBase.cs" />
-    <Compile Include="ProjectSystem\Properties\ImplicitProjectPropertiesProvider.cs" />
-    <Compile Include="ProjectSystem\Properties\ImplicitProjectPropertiesStore.cs" />
-    <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\PackagePropertyPage\AssemblyVersionValueProvider.cs" />
-    <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\PackagePropertyPage\BaseVersionValueProvider.cs" />
-    <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\PackagePropertyPage\FileVersionValueProvider.cs" />
-    <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\ApplicationManifestValueProvider.cs" />
-    <Compile Include="ProjectSystem\Properties\RuleExtensions.cs" />
-    <Compile Include="ProjectSystem\Properties\RuleDataSourceTypes.cs" />
-    <Compile Include="ProjectSystem\Properties\AssemblyAttributeProperties\SourceAssemblyAttributePropertyValueProvider.cs" />
-    <Compile Include="ProjectSystem\References\AlwaysAllowValidProjectReferenceChecker.cs" />
-    <Compile Include="ProjectSystem\Reload\ProjectReloadInterceptor.cs" />
-    <Compile Include="ProjectSystem\Reload\IProjectReloadInterceptor.cs" />
-    <Compile Include="ProjectSystem\Reload\ProjectReloadResult.cs" />
-    <Compile Include="ProjectSystem\Rules\AnalyzerReference.xaml.cs">
+    <Compile Update="ProjectSystem\Rules\AnalyzerReference.xaml.cs">
       <DependentUpon>AnalyzerReference.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\AdditionalFiles.cs">
+    <Compile Update="ProjectSystem\Rules\AdditionalFiles.cs">
       <DependentUpon>AdditionalFiles.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\ProjectDebugger.xaml.cs">
+    <Compile Update="ProjectSystem\Rules\ProjectDebugger.xaml.cs">
       <DependentUpon>ProjectDebugger.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\ResolvedAnalyzerReference.xaml.cs">
+    <Compile Update="ProjectSystem\Rules\ResolvedAnalyzerReference.xaml.cs">
       <DependentUpon>ResolvedAnalyzerReference.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\ResolvedPackageReference.cs">
+    <Compile Update="ProjectSystem\Rules\ResolvedPackageReference.cs">
       <DependentUpon>ResolvedPackageReference.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\ResolvedSdkReference.cs">
+    <Compile Update="ProjectSystem\Rules\ResolvedSdkReference.cs">
       <DependentUpon>ResolvedSdkReference.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\SdkReference.xaml.cs">
+    <Compile Update="ProjectSystem\Rules\SdkReference.xaml.cs">
       <DependentUpon>SdkReference.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\PackageReference.cs">
+    <Compile Update="ProjectSystem\Rules\PackageReference.cs">
       <DependentUpon>PackageReference.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\ExportInterceptingPropertyValueProviderAttribute.cs" />
-    <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\IInterceptingPropertyValueProviderMetadata.cs" />
-    <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\InterceptedProjectPropertiesProviderBase.cs" />
-    <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\InterceptingPropertyValueProviderBase.cs" />
-    <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\IInterceptingPropertyValueProvider.cs" />
-    <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\InterceptedProjectProperties.cs" />
-    <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\ProjectFileInterceptedProjectPropertiesProvider.cs" />
-    <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\SigningPropertyPage\AssemblyOriginatorKeyFileValueProvider.cs" />
-    <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\UserFileInterceptedProjectPropertiesProvider.cs" />
-    <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\UserFileWithXamlDefaultsInterceptedProjectPropertiesProvider.cs" />
-    <Compile Include="ProjectSystem\Properties\InterceptedProjectProperties\TargetFrameworkValueProvider.cs" />
-    <Compile Include="ProjectSystem\Properties\OutputTypeEnumProvider.cs" />
-    <Compile Include="ProjectSystem\Properties\AssemblyAttributeProperties\AbstractProjectFileOrAssemblyInfoPropertiesProvider.cs" />
-    <Compile Include="ProjectSystem\Properties\AssemblyAttributeProperties\AssemblyInfoProperties.cs" />
-    <Compile Include="IEnumerableExtensions.cs" />
-    <Compile Include="ProjectSystem\Rules\CompilerCommandLineArgs.cs">
+    <Compile Update="ProjectSystem\Rules\CompilerCommandLineArgs.cs">
       <DependentUpon>CompilerCommandLineArgs.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Configurations\TargetFrameworkProjectConfigurationDimensionProvider.cs" />
-    <Compile Include="Collections\DictionaryEqualityComparer.cs" />
-    <Compile Include="ProjectSystem\SpecialFileProviders\AppDesignerFolderSpecialFileProvider.cs" />
-    <Compile Include="ProjectSystem\SpecialFileProviders\ISpecialFilesManager.cs" />
-    <Compile Include="ProjectSystem\Utilities\EnvironmentHelper.cs" />
-    <Compile Include="ProjectSystem\Utilities\DataFlowExtensions\DataFlowExtensionMethodCaller.cs" />
-    <Compile Include="ProjectSystem\Utilities\DataFlowExtensions\DataFlowExtensionMethodWrapper.cs" />
-    <Compile Include="ProjectSystem\Utilities\DataFlowExtensions\IDataFlowExtensionWrapper.cs" />
-    <Compile Include="IO\Win32FileSystem.cs" />
-    <Compile Include="ProjectSystem\Utilities\IEnvironmentHelper.cs" />
-    <Compile Include="IO\IFileSystem.cs" />
-    <Compile Include="ProjectSystem\Imaging\IProjectImageProvider.cs" />
-    <Compile Include="ProjectSystem\Imaging\ProjectImageKey.cs" />
-    <Compile Include="ProjectSystem\Imaging\ProjectImageProviderAggregator.cs" />
-    <Compile Include="ProjectSystem\IPhysicalProjectTree.cs" />
-    <Compile Include="ProjectSystem\PhysicalProjectTree.cs" />
-    <Compile Include="ProjectSystem\ProjectCapabilitiesService.cs" />
-    <Compile Include="ProjectSystem\IProjectCapabilitiesService.cs" />
-    <Compile Include="ProjectSystem\ProjectRootImageProjectTreePropertiesProvider.cs" />
-    <Compile Include="ProjectSystem\Input\GetCommandStatusResult.cs" />
-    <Compile Include="ProjectSystem\Input\AbstractSingleNodeProjectCommand.cs" />
-    <Compile Include="ProjectSystem\Input\AbstractProjectCommand.cs" />
-    <Compile Include="ProjectSystem\Input\ProjectCommandAttribute.cs" />
-    <Compile Include="ProjectSystem\Properties\IProjectDesignerService.cs" />
-    <Compile Include="ProjectSystem\IUnconfiguredProjectCommonServices.cs" />
-    <Compile Include="ProjectSystem\ProjectCapability.cs" />
-    <Compile Include="ProjectSystem\AppDesignerFolderProjectTreePropertiesProvider.cs" />
-    <Compile Include="ProjectSystem\ProjectTreeFlagsExtensions.cs" />
-    <Compile Include="ProjectSystem\AbstractSpecialFolderProjectTreePropertiesProvider.cs" />
-    <Compile Include="ProjectSystem\Properties\ProjectRuleSnapshotExtensions.cs" />
-    <Compile Include="ProjectSystem\Rules\AppDesigner.xaml.cs">
+    <Compile Update="ProjectSystem\Rules\AppDesigner.xaml.cs">
       <DependentUpon>AppDesigner.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\CSharp.cs">
+    <Compile Update="ProjectSystem\Rules\CSharp.cs">
       <DependentUpon>CSharp.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\AssemblyReference.cs">
+    <Compile Update="ProjectSystem\Rules\AssemblyReference.cs">
       <DependentUpon>AssemblyReference.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\COMReference.cs">
+    <Compile Update="ProjectSystem\Rules\COMReference.cs">
       <DependentUpon>COMReference.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\ConfigurationGeneralFile.cs">
+    <Compile Update="ProjectSystem\Rules\ConfigurationGeneralFile.cs">
       <DependentUpon>ConfigurationGeneralFile.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\Content.cs">
+    <Compile Update="ProjectSystem\Rules\Content.cs">
       <DependentUpon>Content.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\DebuggerGeneral.cs">
+    <Compile Update="ProjectSystem\Rules\DebuggerGeneral.cs">
       <DependentUpon>DebuggerGeneral.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\DotNetCliToolReference.cs">
+    <Compile Update="ProjectSystem\Rules\DotNetCliToolReference.cs">
       <DependentUpon>DotNetCliToolReference.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\EmbeddedResource.cs">
+    <Compile Update="ProjectSystem\Rules\EmbeddedResource.cs">
       <DependentUpon>EmbeddedResource.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\Folder.cs">
+    <Compile Update="ProjectSystem\Rules\Folder.cs">
       <DependentUpon>Folder.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\SourceControl.cs">
+    <Compile Update="ProjectSystem\Rules\SourceControl.cs">
       <DependentUpon>SourceControl.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\SpecialFolder.cs">
+    <Compile Update="ProjectSystem\Rules\SpecialFolder.cs">
       <DependentUpon>SpecialFolder.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\SubProject.cs">
+    <Compile Update="ProjectSystem\Rules\SubProject.cs">
       <DependentUpon>SubProject.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\ConfigurationGeneral.xaml.cs">
+    <Compile Update="ProjectSystem\Rules\ConfigurationGeneral.xaml.cs">
       <DependentUpon>ConfigurationGeneral.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\ProjectProperties.cs" />
-    <Compile Include="ProjectSystem\Rules\ProjectReference.cs">
+    <Compile Update="ProjectSystem\Rules\ProjectReference.cs">
       <DependentUpon>ProjectReference.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\ResolvedAssemblyReference.cs">
+    <Compile Update="ProjectSystem\Rules\ResolvedAssemblyReference.cs">
       <DependentUpon>ResolvedAssemblyReference.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\ResolvedCOMReference.cs">
+    <Compile Update="ProjectSystem\Rules\ResolvedCOMReference.cs">
       <DependentUpon>ResolvedCOMReference.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\ResolvedProjectReference.cs">
+    <Compile Update="ProjectSystem\Rules\ResolvedProjectReference.cs">
       <DependentUpon>ResolvedProjectReference.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\GeneralBrowseObject.cs">
+    <Compile Update="ProjectSystem\Rules\GeneralBrowseObject.cs">
       <DependentUpon>GeneralBrowseObject.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\ConfiguredBrowseObject.cs">
+    <Compile Update="ProjectSystem\Rules\ConfiguredBrowseObject.cs">
       <DependentUpon>GeneralConfiguredBrowseObject.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\None.cs">
+    <Compile Update="ProjectSystem\Rules\None.cs">
       <DependentUpon>None.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\NuGetRestore.cs">
+    <Compile Update="ProjectSystem\Rules\NuGetRestore.cs">
       <DependentUpon>NuGetRestore.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\Rules\VisualBasic.cs">
+    <Compile Update="ProjectSystem\Rules\VisualBasic.cs">
       <DependentUpon>VisualBasic.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ProjectSystem\SpecialFileProviders\AbstractSpecialFileProvider.cs" />
-    <Compile Include="ProjectSystem\SpecialFileProviders\AppConfigFileSpecialFileProvider.cs" />
-    <Compile Include="ProjectSystem\ICreateFileFromTemplateService.cs" />
-    <Compile Include="ProjectSystem\SpecialFileProviders\ResourcesFileSpecialFileProvider.cs" />
-    <Compile Include="ProjectSystem\SpecialFileProviders\SettingsFileSpecialFileProvider.cs" />
-    <Compile Include="ProjectSystem\UnconfiguredProjectCommonServices.cs" />
-    <Compile Include="ProjectSystem\Utilities\ITaskDelayScheduler.cs" />
-    <Compile Include="ProjectSystem\Utilities\SimpleFileWatcher.cs" />
-    <Compile Include="ProjectSystem\Utilities\StringExtensions.cs" />
-    <Compile Include="ProjectSystem\Utilities\TaskDelayScheduler.cs" />
-    <Compile Include="ProjectSystem\Utilities\ProjectErrorUtilities.cs" />
-    <Compile Include="ProjectSystem\Utilities\ResourceUtilities.cs" />
-    <Compile Include="ProjectSystem\Utilities\TraceUtilities.cs" />
-    <Compile Include="Threading\Tasks\TaskExtensions.cs" />
-    <Compile Include="Resources.Designer.cs">
+    <Compile Update="Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
-    <Compile Include="StringComparers.cs" />
-    <Compile Include="Threading\Tasks\ITaskScheduler.cs" />
-    <Compile Include="Threading\Tasks\TaskResult.cs" />
-    <Compile Include="Threading\Tasks\TaskSchedulerPriority.cs" />
   </ItemGroup>
   <ItemGroup>
     <XamlPropertyRule Include="ProjectSystem\Rules\CSharp.xaml">
@@ -408,12 +267,12 @@
     </XamlPropertyRule>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Resources.resx">
+    <EmbeddedResource Update="Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="Resources.*.resx">
+    <EmbeddedResource Update="Resources.*.resx">
       <DependentUpon>Resources.resx</DependentUpon>
     </EmbeddedResource>
   </ItemGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -6,7 +6,6 @@
     <SignAssembly>true</SignAssembly>
     <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
     <ProjectSystemLayer>HostAgnostic</ProjectSystemLayer>
-    <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{6C6A41CE-72C5-4D77-8208-D01693F9BC88}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests.csproj
@@ -22,26 +22,12 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DeployTestDependencies\DeployTestDependencies.csproj">
-      <Project>{37ba82e6-9abd-4aca-aa26-2dfd39a359a5}</Project>
-      <Name>DeployTestDependencies</Name>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj">
-      <Project>{23bcbc90-ed65-4ee3-8af1-dd7caefdbee9}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.TestServices</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj">
-      <Project>{c7ec63f8-f96a-4a8f-b879-d572516746b4}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj">
-      <Project>{6c6a41ce-72c5-4d77-8208-d01693f9bc88}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.VisualBasic\Microsoft.VisualStudio.ProjectSystem.VisualBasic.csproj">
-      <Project>{04aa393a-48c2-424d-985c-77385a962019}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.VisualBasic</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.VisualBasic\Microsoft.VisualStudio.ProjectSystem.VisualBasic.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Properties\AssemblyAttributes.cs">

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests.csproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests.csproj
@@ -9,7 +9,6 @@
     <OutDir>$(OutDir)Tests\</OutDir>
     <ProjectSystemLayer>HostAgnostic</ProjectSystemLayer>
     <ProjectSystemProjectType>Test</ProjectSystemProjectType>
-    <EnableDefaultItems>true</EnableDefaultItems>    
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleToTest Include="Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests.csproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{FE8D7869-3ABA-45D3-8058-E60C9F1267BF}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests.csproj
@@ -1,13 +1,7 @@
 ﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
-    <AssemblyName>Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFramework>net46</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <Nonshipping>true</Nonshipping>
@@ -15,6 +9,7 @@
     <OutDir>$(OutDir)Tests\</OutDir>
     <ProjectSystemLayer>HostAgnostic</ProjectSystemLayer>
     <ProjectSystemProjectType>Test</ProjectSystemProjectType>
+    <EnableDefaultItems>true</EnableDefaultItems>    
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleToTest Include="Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests.csproj
@@ -21,34 +21,14 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DeployTestDependencies\DeployTestDependencies.csproj">
-      <Project>{37ba82e6-9abd-4aca-aa26-2dfd39a359a5}</Project>
-      <Name>DeployTestDependencies</Name>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj">
-      <Project>{23bcbc90-ed65-4ee3-8af1-dd7caefdbee9}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.TestServices</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj">
-      <Project>{c7ec63f8-f96a-4a8f-b879-d572516746b4}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS\Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj">
-      <Project>{1c5666ea-24a4-4ec2-b8fb-faedf6b14697}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.VS</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj">
-      <Project>{6c6a41ce-72c5-4d77-8208-d01693f9bc88}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS\Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.csproj">
-      <Project>{15dcb34c-b628-49b8-b472-bba65a0ab6a5}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.VisualBasic\Microsoft.VisualStudio.ProjectSystem.VisualBasic.csproj">
-      <Project>{04aa393a-48c2-424d-985c-77385a962019}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.VisualBasic</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS\Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS\Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.VisualBasic\Microsoft.VisualStudio.ProjectSystem.VisualBasic.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Properties\AssemblyAttributes.cs">

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests.csproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{2F58FC7F-85D9-427A-84F0-A6AA741E5BBA}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests.csproj
@@ -1,13 +1,7 @@
 ﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
-    <AssemblyName>Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFramework>net46</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <Nonshipping>true</Nonshipping>
@@ -15,6 +9,7 @@
     <OutDir>$(OutDir)Tests\</OutDir>
     <ProjectSystemLayer>VisualStudio</ProjectSystemLayer>
     <ProjectSystemProjectType>Test</ProjectSystemProjectType>
+    <EnableDefaultItems>true</EnableDefaultItems>    
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleToMoq Include="DynamicProxyGenAssembly2" />
@@ -34,12 +29,6 @@
     <Compile Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Properties\AssemblyAttributes.cs">
       <Link>Properties\AssemblyAttributes.cs</Link>
     </Compile>
-    <Compile Include="Packaging\VisualBasicProjectSystemPackageTests.cs" />
-    <Compile Include="ProjectSystem\VS\Imaging\VisualBasicProjectImageProviderTests.cs" />
-    <Compile Include="ProjectSystem\VS\Properties\VisualBasicProjectDesignerPageProviderTests.cs" />
-    <Compile Include="ProjectSystem\VS\LanguageServices\VisualBasicCodeDomProviderTests.cs" />
-    <Compile Include="ProjectSystem\VS\VisualBasicProjectCompatibilityProviderTests.cs" />
-    <Compile Include="ProjectSystem\VS\VisualBasicProjectGuidProviderTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests.csproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests.csproj
@@ -9,7 +9,6 @@
     <OutDir>$(OutDir)Tests\</OutDir>
     <ProjectSystemLayer>VisualStudio</ProjectSystemLayer>
     <ProjectSystemProjectType>Test</ProjectSystemProjectType>
-    <EnableDefaultItems>true</EnableDefaultItems>    
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleToMoq Include="DynamicProxyGenAssembly2" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.csproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{15DCB34C-B628-49B8-B472-BBA65A0AB6A5}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.csproj
@@ -11,7 +11,6 @@
     <SignAssembly>true</SignAssembly>
     <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
     <ProjectSystemLayer>VisualStudio</ProjectSystemLayer>
-    <EnableDefaultItems>true</EnableDefaultItems>    
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleToTest Include="Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.csproj
@@ -1,13 +1,7 @@
 ﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
-    <AssemblyName>Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFramework>net46</TargetFramework>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <ImportVSSDKTargets>true</ImportVSSDKTargets>
@@ -17,6 +11,7 @@
     <SignAssembly>true</SignAssembly>
     <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
     <ProjectSystemLayer>VisualStudio</ProjectSystemLayer>
+    <EnableDefaultItems>true</EnableDefaultItems>    
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleToTest Include="Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests" />
@@ -37,21 +32,12 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="GlobalSuppressions.cs" />
-    <Compile Include="ProjectSystem\VS\LanguageServices\VisualBasicVsContainedLanguageComponentsFactory.cs" />
-    <Compile Include="ProjectSystem\VS\VisualBasicProjectCompatibilityProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Imaging\VisualBasicProjectImageProvider.cs" />
-    <Compile Include="ProjectSystem\VS\Properties\VisualBasicProjectDesignerPage.cs" />
-    <Compile Include="ProjectSystem\VS\Properties\VisualBasicProjectDesignerPageProvider.cs" />
     <Compile Include="ProjectSystem\VS\LanguageServices\VisualBasicCodeDomProvider.cs">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="ProjectSystem\VS\VisualBasicProjectGuidProvider.cs" />
-    <Compile Include="Packaging\VisualBasicProjectSystemPackage.cs" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="VSPackage.resx" />
-    <EmbeddedResource Include="VSPackage.*.resx">
+    <EmbeddedResource Update="VSPackage.*.resx">
       <DependentUpon>VSPackage.resx</DependentUpon>
     </EmbeddedResource>
   </ItemGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.csproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.csproj
@@ -32,7 +32,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ProjectSystem\VS\LanguageServices\VisualBasicCodeDomProvider.cs">
+    <Compile Update="ProjectSystem\VS\LanguageServices\VisualBasicCodeDomProvider.cs">
       <SubType>Component</SubType>
     </Compile>
   </ItemGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.csproj
@@ -27,18 +27,12 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS\Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj">
-      <Project>{1c5666ea-24a4-4ec2-b8fb-faedf6b14697}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed.VS</Name>
       <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj">
-      <Project>{6c6a41ce-72c5-4d77-8208-d01693f9bc88}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed</Name>
       <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.VisualBasic\Microsoft.VisualStudio.ProjectSystem.VisualBasic.csproj">
-      <Project>{04aa393a-48c2-424d-985c-77385a962019}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.VisualBasic</Name>
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic/Microsoft.VisualStudio.ProjectSystem.VisualBasic.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic/Microsoft.VisualStudio.ProjectSystem.VisualBasic.csproj
@@ -27,10 +27,7 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj">
-      <Project>{6c6a41ce-72c5-4d77-8208-d01693f9bc88}</Project>
-      <Name>Microsoft.VisualStudio.ProjectSystem.Managed</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="GlobalSuppressions.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic/Microsoft.VisualStudio.ProjectSystem.VisualBasic.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic/Microsoft.VisualStudio.ProjectSystem.VisualBasic.csproj
@@ -1,13 +1,7 @@
 ﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
-    <AssemblyName>Microsoft.VisualStudio.ProjectSystem.VisualBasic</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFramework>net46</TargetFramework>
     <ImportVSSDKTargets>false</ImportVSSDKTargets>
     <CreateVsixContainer>false</CreateVsixContainer>
@@ -16,6 +10,7 @@
     <SignAssembly>true</SignAssembly>
     <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
     <ProjectSystemLayer>HostAgnostic</ProjectSystemLayer>
+    <EnableDefaultItems>true</EnableDefaultItems>    
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS" />
@@ -28,11 +23,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="GlobalSuppressions.cs" />
-    <Compile Include="ProjectSystem\LanguageServices\VisualBasicCommandLineParserProvider.cs" />
-    <Compile Include="ProjectSystem\SpecialFileProviders\BasicAssemblyInfoSpecialFileProvider.cs" />
   </ItemGroup>
   <Import Project="..\..\build\Targets\VSL.Imports.targets" />
   <ItemDefinitionGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic/Microsoft.VisualStudio.ProjectSystem.VisualBasic.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic/Microsoft.VisualStudio.ProjectSystem.VisualBasic.csproj
@@ -1,10 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{04AA393A-48C2-424D-985C-77385A962019}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic/Microsoft.VisualStudio.ProjectSystem.VisualBasic.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic/Microsoft.VisualStudio.ProjectSystem.VisualBasic.csproj
@@ -1,4 +1,5 @@
-﻿<Project>
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic/Microsoft.VisualStudio.ProjectSystem.VisualBasic.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic/Microsoft.VisualStudio.ProjectSystem.VisualBasic.csproj
@@ -10,7 +10,6 @@
     <SignAssembly>true</SignAssembly>
     <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
     <ProjectSystemLayer>HostAgnostic</ProjectSystemLayer>
-    <EnableDefaultItems>true</EnableDefaultItems>    
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS" />

--- a/src/ProjectSystemDogfoodSetup/ProjectSystemDogfoodSetup.csproj
+++ b/src/ProjectSystemDogfoodSetup/ProjectSystemDogfoodSetup.csproj
@@ -34,12 +34,8 @@
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
     </ProjectReference>
-    <ProjectReference Include="..\ProjectSystemSetup\ProjectSystemSetup.csproj">
-      <Name>ProjectSystemSetup</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\VisualStudioEditorsSetup\VisualStudioEditorsSetup.csproj">
-      <Name>VisualStudioEditorsSetup</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\ProjectSystemSetup\ProjectSystemSetup.csproj" />
+    <ProjectReference Include="..\VisualStudioEditorsSetup\VisualStudioEditorsSetup.csproj" />
   </ItemGroup>
   <Import Project="..\..\build\Targets\VSL.Imports.targets" />
 </Project>

--- a/src/ProjectSystemDogfoodSetup/ProjectSystemDogfoodSetup.csproj
+++ b/src/ProjectSystemDogfoodSetup/ProjectSystemDogfoodSetup.csproj
@@ -21,7 +21,6 @@
     <ProjectSystemLayer>VisualStudio</ProjectSystemLayer>
     <UseCodebase>true</UseCodebase>
     <Nonshipping>true</Nonshipping>
-    <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Dogfood.pkgdef">

--- a/src/ProjectSystemDogfoodSetup/ProjectSystemDogfoodSetup.csproj
+++ b/src/ProjectSystemDogfoodSetup/ProjectSystemDogfoodSetup.csproj
@@ -2,12 +2,8 @@
 <Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
-    <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
-    <AssemblyName>ProjectSystemDogfoodSetup</AssemblyName>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
@@ -25,21 +21,8 @@
     <ProjectSystemLayer>VisualStudio</ProjectSystemLayer>
     <UseCodebase>true</UseCodebase>
     <Nonshipping>true</Nonshipping>
+    <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- Debugging Settings (usually stored in .user project stored in project file to be available to everyone -->
-    <StartAction>Program</StartAction>
-    <StartProgram>$(DevEnvDir)devenv.exe</StartProgram>
-    <StartArguments>/rootsuffix RoslynDev /log</StartArguments>
-    <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>
-  </PropertyGroup>
-  <ItemGroup>
-    <None Include="source.extension.vsixmanifest" />
-  </ItemGroup>
   <ItemGroup>
     <Content Include="Dogfood.pkgdef">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -58,10 +41,6 @@
     <ProjectReference Include="..\VisualStudioEditorsSetup\VisualStudioEditorsSetup.csproj">
       <Name>VisualStudioEditorsSetup</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="VisualStudio\Packaging\DogfoodProjectSystemPackage.DebuggerTraceListener.cs" />
-    <Compile Include="VisualStudio\Packaging\DogfoodProjectSystemPackage.cs" />
   </ItemGroup>
   <Import Project="..\..\build\Targets\VSL.Imports.targets" />
 </Project>

--- a/src/ProjectSystemDogfoodSetup/ProjectSystemDogfoodSetup.csproj
+++ b/src/ProjectSystemDogfoodSetup/ProjectSystemDogfoodSetup.csproj
@@ -48,17 +48,14 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj">
-      <Project>{23BCBC90-ED65-4EE3-8AF1-DD7CAEFDBEE9}</Project>
       <Name>Microsoft.VisualStudio.ProjectSystem.Managed.TestServices</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
     </ProjectReference>
     <ProjectReference Include="..\ProjectSystemSetup\ProjectSystemSetup.csproj">
-      <Project>{9fbd7ef2-9449-486d-9fdd-fa56160aa8bb}</Project>
       <Name>ProjectSystemSetup</Name>
     </ProjectReference>
     <ProjectReference Include="..\VisualStudioEditorsSetup\VisualStudioEditorsSetup.csproj">
-      <Project>{49705330-a4f5-47ea-bb10-3b783ce91aea}</Project>
       <Name>VisualStudioEditorsSetup</Name>
     </ProjectReference>
   </ItemGroup>

--- a/src/ProjectSystemDogfoodSetup/ProjectSystemDogfoodSetup.csproj
+++ b/src/ProjectSystemDogfoodSetup/ProjectSystemDogfoodSetup.csproj
@@ -1,13 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <ProjectGuid>{F9522F27-B9AC-4D6F-8F54-6A8BD4D33574}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <AssemblyName>ProjectSystemDogfoodSetup</AssemblyName>

--- a/src/ProjectSystemDogfoodSetup/Properties/launchSettings.json
+++ b/src/ProjectSystemDogfoodSetup/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "ProjectSystemDogfoodSetup": {
       "commandName": "Executable",
-      "executablePath": "devenv.exe",
-      "commandLineArgs": "/rootsuffix RoslynDev"
+      "executablePath": "$(DevEnvDir)devenv.exe",
+      "commandLineArgs": "/rootsuffix RoslynDev /log"
     }
   }
 }

--- a/src/ProjectSystemSetup/ProjectSystemSetup.csproj
+++ b/src/ProjectSystemSetup/ProjectSystemSetup.csproj
@@ -1,13 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <ProjectGuid>{9FBD7EF2-9449-486D-9FDD-FA56160AA8BB}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <AssemblyName>ProjectSystem</AssemblyName>
@@ -42,7 +39,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp.VS\Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj">
-      <Project>{765ef6eb-9f36-4d68-8c3d-9e11cd49e0bc}</Project>
       <Name>Microsoft.VisualStudio.ProjectSystem.CSharp.VS</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroupWithFinalOutputPath%3bPkgdefProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
@@ -50,7 +46,6 @@
       <Private>True</Private>
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp\Microsoft.VisualStudio.ProjectSystem.CSharp.csproj">
-      <Project>{7d150b7b-ce02-4cd4-8ec9-6a7c18727a36}</Project>
       <Name>Microsoft.VisualStudio.ProjectSystem.CSharp</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bSatelliteDllsProjectOutputGroupWithFinalOutputPath%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
@@ -58,7 +53,6 @@
       <Private>True</Private>
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS\Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj">
-      <Project>{1c5666ea-24a4-4ec2-b8fb-faedf6b14697}</Project>
       <Name>Microsoft.VisualStudio.ProjectSystem.Managed.VS</Name>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bSatelliteDllsProjectOutputGroupWithFinalOutputPath%3bBuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bPkgdefProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
@@ -66,7 +60,6 @@
       <Private>True</Private>
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj">
-      <Project>{6c6a41ce-72c5-4d77-8208-d01693f9bc88}</Project>
       <Name>Microsoft.VisualStudio.ProjectSystem.Managed</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bSatelliteDllsProjectOutputGroupWithFinalOutputPath%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
@@ -74,7 +67,6 @@
       <Private>True</Private>
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS\Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.csproj">
-      <Project>{15dcb34c-b628-49b8-b472-bba65a0ab6a5}</Project>
       <Name>Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS</Name>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroupWithFinalOutputPath%3bPkgdefProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
@@ -82,7 +74,6 @@
       <Private>True</Private>
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.VisualBasic\Microsoft.VisualStudio.ProjectSystem.VisualBasic.csproj">
-      <Project>{04aa393a-48c2-424d-985c-77385a962019}</Project>
       <Name>Microsoft.VisualStudio.ProjectSystem.VisualBasic</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bSatelliteDllsProjectOutputGroupWithFinalOutputPath%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>

--- a/src/ProjectSystemSetup/ProjectSystemSetup.csproj
+++ b/src/ProjectSystemSetup/ProjectSystemSetup.csproj
@@ -2,10 +2,7 @@
 <Project>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
-    <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <AssemblyName>ProjectSystem</AssemblyName>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
@@ -25,17 +22,7 @@
     <ProjectSystemLayer>VisualStudio</ProjectSystemLayer>
     <ProducingSignedVsix>true</ProducingSignedVsix>
     <IsProductComponent>true</IsProductComponent>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- Debugging Settings (usually stored in .user project stored in project file to be available to everyone -->
-    <StartAction>Program</StartAction>
-    <StartProgram>$(DevEnvDir)devenv.exe</StartProgram>
-    <StartArguments>/rootsuffix RoslynDev /log</StartArguments>
-    <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>
+    <EnableDefaultItems>true</EnableDefaultItems>    
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp.VS\Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj">
@@ -87,13 +74,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="source.extension.vsixmanifest" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="..\Common\ProvideBindingRedirectionAttribute.cs">
       <Link>ProvideBindingRedirectionAttribute.cs</Link>
     </Compile>
-    <Compile Include="AssemblyRedirects.cs" />
   </ItemGroup>
   <Import Project="..\..\build\Targets\VSL.Imports.targets" />
 </Project>

--- a/src/ProjectSystemSetup/ProjectSystemSetup.csproj
+++ b/src/ProjectSystemSetup/ProjectSystemSetup.csproj
@@ -22,7 +22,6 @@
     <ProjectSystemLayer>VisualStudio</ProjectSystemLayer>
     <ProducingSignedVsix>true</ProducingSignedVsix>
     <IsProductComponent>true</IsProductComponent>
-    <EnableDefaultItems>true</EnableDefaultItems>    
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp.VS\Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj">

--- a/src/ProjectSystemSetup/Properties/launchSettings.json
+++ b/src/ProjectSystemSetup/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "ProjectSystemSetup": {
       "commandName": "Executable",
-      "executablePath": "devenv.exe",
-      "commandLineArgs": "/rootsuffix RoslynDev"
+      "executablePath": "$(DevEnvDir)devenv.exe",
+      "commandLineArgs": "/rootsuffix RoslynDev /log"
     }
   }
 }

--- a/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
+++ b/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
@@ -29,7 +29,6 @@
     <NgenPriority>3</NgenPriority>
     <ExtensionInstallationRoot>CommonExtensions</ExtensionInstallationRoot>
     <ExtensionInstallationFolder>Microsoft\VisualStudio\Editors</ExtensionInstallationFolder>
-    <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.AppDesigner\Microsoft.VisualStudio.AppDesigner.vbproj">

--- a/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
+++ b/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
@@ -1,5 +1,5 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Project DefaultTargets="Build">
+<Project>
   <PropertyGroup>
     <UseVisualStudioVersion>true</UseVisualStudioVersion>
   </PropertyGroup>
@@ -40,7 +40,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.AppDesigner\Microsoft.VisualStudio.AppDesigner.vbproj">
-      <Project>{19725d6f-4690-412b-934a-fc48d752b802}</Project>
       <Name>Microsoft.VisualStudio.AppDesigner</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroupWithFinalOutputPath%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
@@ -50,7 +49,6 @@
       <NgenPriority>3</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.VisualStudio.Editors\Microsoft.VisualStudio.Editors.vbproj">
-      <Project>{CD6E5D00-7B0B-442D-9F5D-EAEC1A71838A}</Project>
       <Name>Microsoft.VisualStudio.Editors</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroupWithFinalOutputPath%3bPkgdefProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>

--- a/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
+++ b/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
@@ -1,6 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project DefaultTargets="Build">
   <PropertyGroup>
     <UseVisualStudioVersion>true</UseVisualStudioVersion>
   </PropertyGroup>
@@ -9,8 +8,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <ProjectGuid>{49705330-A4F5-47EA-BB10-3B783CE91AEA}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <AssemblyName>VisualStudioEditorsSetup</AssemblyName>

--- a/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
+++ b/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
@@ -5,12 +5,8 @@
   </PropertyGroup>
   <Import Project="..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
-    <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
-    <AssemblyName>VisualStudioEditorsSetup</AssemblyName>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
@@ -33,10 +29,7 @@
     <NgenPriority>3</NgenPriority>
     <ExtensionInstallationRoot>CommonExtensions</ExtensionInstallationRoot>
     <ExtensionInstallationFolder>Microsoft\VisualStudio\Editors</ExtensionInstallationFolder>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.AppDesigner\Microsoft.VisualStudio.AppDesigner.vbproj">
@@ -59,15 +52,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AssemblyRedirects.cs" />
     <Compile Include="..\Common\ProvideBindingRedirectionAttribute.cs">
       <Link>ProvideBindingRedirectionAttribute.cs</Link>
     </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="source.extension.vsixmanifest">
-      <SubType>Designer</SubType>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
Removing xmlns, toolsversion, projectguids.
Removing properties that are defaulted by the SDK,
Removing items that are brought in by default globs in the SDK.

Wrote a tool to diff a given project against the defaults brought in by the SDK and produce a report of properties and items that are different from the defaults - https://github.com/srivatsn/MSBuildSdkDiffer to make sure that there are no semantic differences.