### PR TITLE
Remove ManagedLang Capability

### DIFF
--- a/src/Targets/Microsoft.Managed.DesignTime.targets
+++ b/src/Targets/Microsoft.Managed.DesignTime.targets
@@ -51,7 +51,6 @@
 
   <!-- Project Capabilities -->
   <ItemGroup Condition="'$(DefineCommonManagedCapabilities)' == 'true'">
-    <ProjectCapability Include="ManagedLang"/> <!-- Temporary: See https://github.com/dotnet/roslyn-project-system/issues/47 -->
     <ProjectCapability Include="UseFileGlobs"/>
 
     <!-- DependenciesTree capability lights up a Dependencies tree node and it's sub node providers-->


### PR DESCRIPTION
All the Managed Components have been moved from CPS to Roslyn PS. So we no longer need this capability

Fixes #47 

@dotnet/project-system for review