### PR TITLE
Build the tree and modern VSIX together and a few other things

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -64,8 +64,14 @@ for %%T IN (Restore %MSBuildBuildTarget%, BuildModernVsixPackages) do (
     set ConsoleLoggerVerbosity=quiet
     echo   Restoring packages for ProjectSystem
   )
+
+  set BuildCommand=msbuild /nologo /warnaserror /nodeReuse:%NodeReuse% /consoleloggerparameters:Verbosity=!ConsoleLoggerVerbosity! /fileLogger /fileloggerparameters:LogFile="!LogFile!";verbosity=%FileLoggerVerbosity% /t:"%%T" /p:Configuration="%BuildConfiguration%" /p:RunTests="%RunTests%" /p:DeployVsixExtension="%DeployVsixExtension%" "%Root%build\build.proj" %MSBuildAdditionalArguments%
+  if "%FileLoggerVerbosity%" == "diagnostic" (
+    echo !BuildCommand!
+  )
   
-  msbuild /nologo /warnaserror /nodeReuse:%NodeReuse% /consoleloggerparameters:Verbosity=!ConsoleLoggerVerbosity! /fileLogger /fileloggerparameters:LogFile="!LogFile!";verbosity=%FileLoggerVerbosity% /t:"%%T" /p:Configuration="%BuildConfiguration%" /p:RunTests="%RunTests%" /p:DeployVsixExtension="%DeployVsixExtension%" "%Root%build\build.proj" %MSBuildAdditionalArguments%
+  !BuildCommand!
+
   if ERRORLEVEL 1 (
     echo.
     call :PrintColor Red "Build failed, for full log see !LogFile!."

--- a/build.cmd
+++ b/build.cmd
@@ -10,6 +10,8 @@ set DeveloperCommandPrompt=%VS150COMNTOOLS%\VsDevCmd.bat
 set MSBuildAdditionalArguments=/m
 set RunTests=true
 set DeployVsixExtension=true
+REM Turn on MSBuild async logging to speed up builds
+set MSBUILDLOGASYNC=1 
 
 :ParseArguments
 if "%1" == "" goto :DoneParsing

--- a/build.cmd
+++ b/build.cmd
@@ -4,7 +4,7 @@ setlocal enabledelayedexpansion
 set BatchFile=%0
 set Root=%~dp0
 set BuildConfiguration=Debug
-set MSBuildTarget=Build
+set MSBuildBuildTarget=Build
 set NodeReuse=true
 set DeveloperCommandPrompt=%VS150COMNTOOLS%\VsDevCmd.bat
 set MSBuildAdditionalArguments=/m
@@ -17,8 +17,8 @@ set MSBUILDLOGASYNC=1
 :ParseArguments
 if "%1" == "" goto :DoneParsing
 if /I "%1" == "/?" call :Usage && exit /b 1
-if /I "%1" == "/build" set MSBuildTarget=Build&&shift&& goto :ParseArguments
-if /I "%1" == "/rebuild" set MSBuildTarget=Rebuild&&shift&& goto :ParseArguments
+if /I "%1" == "/build" set MSBuildBuildTarget=Build&&shift&& goto :ParseArguments
+if /I "%1" == "/rebuild" set MSBuildBuildTarget=Rebuild&&shift&& goto :ParseArguments
 if /I "%1" == "/debug" set BuildConfiguration=Debug&&shift&& goto :ParseArguments
 if /I "%1" == "/release" set BuildConfiguration=Release&&shift&& goto :ParseArguments
 if /I "%1" == "/skiptests" set RunTests=false&&shift&& goto :ParseArguments
@@ -53,7 +53,7 @@ if not exist "%BinariesDirectory%" mkdir "%BinariesDirectory%" || goto :BuildFai
 REM We need to build the VSIX and Modern VSIX packages in a different MSBuild process because
 REM MicroBuild when building the modern VSIX packages has a dependency on a dll with the same 
 REM version but different contents.
-for %%T IN (%MSBuildTarget%, BuildModernVsixPackages) do (
+for %%T IN (%MSBuildBuildTarget%, BuildModernVsixPackages) do (
   
   set LogFile=%BinariesDirectory%%%T.log
   set LogFiles=!LogFiles!!LogFile! 

--- a/build.cmd
+++ b/build.cmd
@@ -62,7 +62,7 @@ for %%T IN (Restore %MSBuildBuildTarget%, BuildModernVsixPackages) do (
   
   if "%%T" == "Restore" (
     set ConsoleLoggerVerbosity=quiet
-    echo   Restoring packages for ProjectSystem
+    echo   Restoring packages for ProjectSystem (this may take some time^)
   )
 
   set BuildCommand=msbuild /nologo /warnaserror /nodeReuse:%NodeReuse% /consoleloggerparameters:Verbosity=!ConsoleLoggerVerbosity! /fileLogger /fileloggerparameters:LogFile="!LogFile!";verbosity=%FileLoggerVerbosity% /t:"%%T" /p:Configuration="%BuildConfiguration%" /p:RunTests="%RunTests%" /p:DeployVsixExtension="%DeployVsixExtension%" "%Root%build\build.proj" %MSBuildAdditionalArguments%

--- a/build.cmd
+++ b/build.cmd
@@ -10,6 +10,7 @@ set DeveloperCommandPrompt=%VS150COMNTOOLS%\VsDevCmd.bat
 set MSBuildAdditionalArguments=/m
 set RunTests=true
 set DeployVsixExtension=true
+set ConsoleLoggerVerbosity=minimal
 set FileLoggerVerbosity=detailed
 REM Turn on MSBuild async logging to speed up builds
 set MSBUILDLOGASYNC=1 
@@ -57,9 +58,14 @@ REM version but different contents than the legacy VSIX projects.
 for %%T IN (Restore %MSBuildBuildTarget%, BuildModernVsixPackages) do (
   
   set LogFile=%BinariesDirectory%%%T.log
-  set LogFiles=!LogFiles!!LogFile! 
+  set LogFiles=!LogFiles!!LogFile!
   
-  msbuild /nologo /warnaserror /nodeReuse:%NodeReuse% /consoleloggerparameters:Verbosity=minimal /fileLogger /fileloggerparameters:LogFile="!LogFile!";verbosity=%FileLoggerVerbosity% /t:"%%T" /p:Configuration="%BuildConfiguration%" /p:RunTests="%RunTests%" /p:DeployVsixExtension="%DeployVsixExtension%" "%Root%build\build.proj" %MSBuildAdditionalArguments%
+  if "%%T" == "Restore" (
+    set ConsoleLoggerVerbosity=quiet
+    echo   Restoring packages for ProjectSystem
+  )
+  
+  msbuild /nologo /warnaserror /nodeReuse:%NodeReuse% /consoleloggerparameters:Verbosity=!ConsoleLoggerVerbosity! /fileLogger /fileloggerparameters:LogFile="!LogFile!";verbosity=%FileLoggerVerbosity% /t:"%%T" /p:Configuration="%BuildConfiguration%" /p:RunTests="%RunTests%" /p:DeployVsixExtension="%DeployVsixExtension%" "%Root%build\build.proj" %MSBuildAdditionalArguments%
   if ERRORLEVEL 1 (
     echo.
     call :PrintColor Red "Build failed, for full log see !LogFile!."

--- a/build.cmd
+++ b/build.cmd
@@ -50,10 +50,11 @@ if "%VisualStudioVersion%" == "" (
 set BinariesDirectory=%Root%bin\%BuildConfiguration%\
 if not exist "%BinariesDirectory%" mkdir "%BinariesDirectory%" || goto :BuildFailed
 
-REM We need to build the VSIX and Modern VSIX packages in a different MSBuild process because
-REM MicroBuild when building the modern VSIX packages has a dependency on a dll with the same 
-REM version but different contents.
-for %%T IN (%MSBuildBuildTarget%, BuildModernVsixPackages) do (
+REM We build Restore, Build and BuildModernVsixPackages in different MSBuild processes.
+REM Restore because we want to control the verbosity due to https://github.com/NuGet/Home/issues/4695.
+REM BuildModernVsixPackages because under MicroBuild, it has a dependency on a dll with the same 
+REM version but different contents than the legacy VSIX projects.
+for %%T IN (Restore %MSBuildBuildTarget%, BuildModernVsixPackages) do (
   
   set LogFile=%BinariesDirectory%%%T.log
   set LogFiles=!LogFiles!!LogFile! 

--- a/build.cmd
+++ b/build.cmd
@@ -83,7 +83,7 @@ echo     /no-node-reuse           Prevents MSBuild from reusing existing MSBuild
 echo                              useful for avoiding unexpected behavior on build machines
 echo     /no-multi-proc           No multi-proc build, useful for diagnosing build logs
 echo     /no-deploy-extension     Does not deploy the VSIX extension when building the solution
-echo     /skiptests               Don't run unit tests
+echo     /skiptests               Does not run unit tests
 goto :eof
 
 :BuildFailed

--- a/build.cmd
+++ b/build.cmd
@@ -58,7 +58,7 @@ REM version but different contents than the legacy VSIX projects.
 for %%T IN (Restore %MSBuildBuildTarget%, BuildModernVsixPackages) do (
   
   set LogFile=%BinariesDirectory%%%T.log
-  set LogFiles=!LogFiles!!LogFile!
+  set LogFiles=!LogFiles!!LogFile! 
   
   if "%%T" == "Restore" (
     set ConsoleLoggerVerbosity=quiet

--- a/build.cmd
+++ b/build.cmd
@@ -74,9 +74,11 @@ echo   Build targets:
 echo     /build                   Perform a build (default)
 echo     /rebuild                 Perform a clean, then build
 echo.
-echo   Build options:
+echo   Configurations:
 echo     /debug                   Perform debug build (default)
 echo     /release                 Perform release build
+echo.
+echo   Build options:
 echo     /no-node-reuse           Prevents MSBuild from reusing existing MSBuild instances,
 echo                              useful for avoiding unexpected behavior on build machines
 echo     /no-multi-proc           No multi-proc build, useful for diagnosing build logs

--- a/build.cmd
+++ b/build.cmd
@@ -10,7 +10,6 @@ set DeveloperCommandPrompt=%VS150COMNTOOLS%\VsDevCmd.bat
 set MSBuildAdditionalArguments=/m
 set RunTests=true
 set DeployVsixExtension=true
-set ConsoleLoggerVerbosity=minimal
 set FileLoggerVerbosity=detailed
 REM Turn on MSBuild async logging to speed up builds
 set MSBUILDLOGASYNC=1 
@@ -63,6 +62,8 @@ for %%T IN (Restore %MSBuildBuildTarget%, BuildModernVsixPackages) do (
   if "%%T" == "Restore" (
     set ConsoleLoggerVerbosity=quiet
     echo   Restoring packages for ProjectSystem (this may take some time^)
+  ) else (
+    set ConsoleLoggerVerbosity=minimal
   )
 
   set BuildCommand=msbuild /nologo /warnaserror /nodeReuse:%NodeReuse% /consoleloggerparameters:Verbosity=!ConsoleLoggerVerbosity! /fileLogger /fileloggerparameters:LogFile="!LogFile!";verbosity=%FileLoggerVerbosity% /t:"%%T" /p:Configuration="%BuildConfiguration%" /p:RunTests="%RunTests%" /p:DeployVsixExtension="%DeployVsixExtension%" "%Root%build\build.proj" %MSBuildAdditionalArguments%

--- a/build.cmd
+++ b/build.cmd
@@ -14,9 +14,10 @@ set DeployVsixExtension=true
 :ParseArguments
 if "%1" == "" goto :DoneParsing
 if /I "%1" == "/?" call :Usage && exit /b 1
+if /I "%1" == "/build" set MSBuildTarget=Build&&shift&& goto :ParseArguments
+if /I "%1" == "/rebuild" set MSBuildTarget=Rebuild&&shift&& goto :ParseArguments
 if /I "%1" == "/debug" set BuildConfiguration=Debug&&shift&& goto :ParseArguments
 if /I "%1" == "/release" set BuildConfiguration=Release&&shift&& goto :ParseArguments
-if /I "%1" == "/rebuild" set MSBuildTarget=Rebuild&&shift&& goto :ParseArguments
 if /I "%1" == "/skiptests" set RunTests=false&&shift&& goto :ParseArguments
 if /I "%1" == "/no-deploy-extension" set DeployVsixExtension=false&&shift&& goto :ParseArguments
 if /I "%1" == "/no-node-reuse" set NodeReuse=false&&shift&& goto :ParseArguments
@@ -67,11 +68,11 @@ call :PrintColor Green "Build completed successfully, for full logs see %LogFile
 exit /b 0
 
 :Usage
-echo Usage: %BatchFile% [/rebuild^|/restore^|/modernvsixonly] [/debug^|/release] [/no-node-reuse] [/no-multi-proc] [/skiptests] [/no-deploy-extension]
+echo Usage: %BatchFile% [/build^|/rebuild] [/debug^|/release] [/no-node-reuse] [/no-multi-proc] [/skiptests] [/no-deploy-extension]
 echo.
 echo   Build targets:
+echo     /build                   Perform a build (default)
 echo     /rebuild                 Perform a clean, then build
-echo     /skiptests               Don't run unit tests
 echo.
 echo   Build options:
 echo     /debug                   Perform debug build (default)
@@ -80,6 +81,7 @@ echo     /no-node-reuse           Prevents MSBuild from reusing existing MSBuild
 echo                              useful for avoiding unexpected behavior on build machines
 echo     /no-multi-proc           No multi-proc build, useful for diagnosing build logs
 echo     /no-deploy-extension     Does not deploy the VSIX extension when building the solution
+echo     /skiptests               Don't run unit tests
 goto :eof
 
 :BuildFailed

--- a/build.cmd
+++ b/build.cmd
@@ -17,8 +17,6 @@ if /I "%1" == "/?" call :Usage && exit /b 1
 if /I "%1" == "/debug" set BuildConfiguration=Debug&&shift&& goto :ParseArguments
 if /I "%1" == "/release" set BuildConfiguration=Release&&shift&& goto :ParseArguments
 if /I "%1" == "/rebuild" set MSBuildTarget=Rebuild&&shift&& goto :ParseArguments
-if /I "%1" == "/restore" set MSBuildTarget=RestorePackages&&shift&& goto :ParseArguments
-if /I "%1" == "/modernvsixonly" set MSBuildTarget=BuildModernVsixPackages&&shift&& goto :ParseArguments
 if /I "%1" == "/skiptests" set RunTests=false&&shift&& goto :ParseArguments
 if /I "%1" == "/no-deploy-extension" set DeployVsixExtension=false&&shift&& goto :ParseArguments
 if /I "%1" == "/no-node-reuse" set NodeReuse=false&&shift&& goto :ParseArguments
@@ -46,18 +44,26 @@ if "%VisualStudioVersion%" == "" (
 )
 
 set BinariesDirectory=%Root%bin\%BuildConfiguration%\
-set LogFile=%BinariesDirectory%Build.log
 if not exist "%BinariesDirectory%" mkdir "%BinariesDirectory%" || goto :BuildFailed
 
-msbuild /nologo /warnaserror /nodeReuse:%NodeReuse% /consoleloggerparameters:Verbosity=minimal /fileLogger /fileloggerparameters:LogFile="%LogFile%";verbosity=diagnostic /t:"%MSBuildTarget%" /p:Configuration="%BuildConfiguration%" /p:RunTests="%RunTests%" /p:DeployVsixExtension="%DeployVsixExtension%" "%Root%build\build.proj" %MSBuildAdditionalArguments%
-if ERRORLEVEL 1 (
+REM We need to build the VSIX and Modern VSIX packages in a different MSBuild process because
+REM MicroBuild when building the modern VSIX packages has a dependency on a dll with the same 
+REM version but different contents.
+for %%T IN (%MSBuildTarget%, BuildModernVsixPackages) do (
+  
+  set LogFile=%BinariesDirectory%%%T.log
+  set LogFiles=!LogFiles!!LogFile! 
+  
+  msbuild /nologo /warnaserror /nodeReuse:%NodeReuse% /consoleloggerparameters:Verbosity=minimal /fileLogger /fileloggerparameters:LogFile="!LogFile!";verbosity=diagnostic /t:"%%T" /p:Configuration="%BuildConfiguration%" /p:RunTests="%RunTests%" /p:DeployVsixExtension="%DeployVsixExtension%" "%Root%build\build.proj" %MSBuildAdditionalArguments%
+  if ERRORLEVEL 1 (
     echo.
-    call :PrintColor Red "Build failed, for full log see %LogFile%."
+    call :PrintColor Red "Build failed, for full log see !LogFile!."
     exit /b 1
+  )
 )
 
 echo.
-call :PrintColor Green "Build completed successfully, for full log see %LogFile%"
+call :PrintColor Green "Build completed successfully, for full logs see %LogFiles%"
 exit /b 0
 
 :Usage
@@ -65,8 +71,6 @@ echo Usage: %BatchFile% [/rebuild^|/restore^|/modernvsixonly] [/debug^|/release]
 echo.
 echo   Build targets:
 echo     /rebuild                 Perform a clean, then build
-echo     /restore                 Only restore NuGet packages
-echo     /modernvsixonly          Only build modern vsman VSIXes
 echo     /skiptests               Don't run unit tests
 echo.
 echo   Build options:

--- a/build/build.proj
+++ b/build/build.proj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <SolutionFile Include="$(RepositoryRootDirectory)src\ProjectSystem.sln" />
-    <NuGetProjectFile Include="$(RepositoryRootDirectory)src\Nuget\Nuget.proj" />
+    <NuGetProjectFile Include="$(RepositoryRootDirectory)src\NuGet\NuGet.proj" />
     <VsManProjectFile Include="$(RepositoryRootDirectory)src\VsixV3\EditorsPackage\Microsoft.VisualStudio.Editors.vsmanproj" />
     <VsManProjectFile Include="$(RepositoryRootDirectory)src\VsixV3\ProjectSystemPackage\Microsoft.VisualStudio.ProjectSystem.Managed.vsmanproj" />
   </ItemGroup>

--- a/build/build.proj
+++ b/build/build.proj
@@ -1,7 +1,4 @@
-<Project
-  xmlns="http://schemas.microsoft.com/developer/msbuild/2003"
-  DefaultTargets="Build"
-  ToolsVersion="14.0">
+<Project DefaultTargets="Build">
 
   <PropertyGroup>
     <RepositoryRootDirectory>$(MSBuildThisFileDirectory)..\</RepositoryRootDirectory>

--- a/build/build.proj
+++ b/build/build.proj
@@ -59,6 +59,8 @@
 
     <Target Name="BuildNuGetPackages">
 
+      <Message Text="Building NuGet packages [$(Configuration)]" Importance="high" />
+      
       <MSBuild BuildInParallel="true"
                Projects="@(NuGetProjectFile)"
                Targets="Build"
@@ -67,7 +69,9 @@
     </Target>
   
     <Target Name="RebuildNuGetPackages">
-  
+
+      <Message Text="Rebuilding NuGet packages [$(Configuration)]" Importance="high" />
+      
       <MSBuild BuildInParallel="true"
                Projects="@(NuGetProjectFile)"
                Targets="Rebuild"
@@ -77,6 +81,8 @@
 
   <Target Name="BuildModernVsixPackages">
 
+    <Message Text="Rebuilding Modern VSIX Packages [$(Configuration)]" Importance="high" />
+    
     <MSBuild Projects="@(VsManProjectFile)"
              Targets="Rebuild"
              

--- a/build/build.proj
+++ b/build/build.proj
@@ -24,7 +24,7 @@
     <VsManProjectFile Include="$(RepositoryRootDirectory)src\VsixV3\ProjectSystemPackage\Microsoft.VisualStudio.ProjectSystem.Managed.vsmanproj" />
   </ItemGroup>
 
-  <Target Name="RestorePackages">
+  <Target Name="Restore">
 
     <Message Text="Restoring packages for %(SolutionFile.Filename)" Importance="high" />
 
@@ -111,7 +111,7 @@
 
   </Target>
  
-  <Target Name="Build" DependsOnTargets="RestorePackages;BuildSolution;BuildNuGetPackages;Test" />
-  <Target Name="Rebuild" DependsOnTargets="RestorePackages;RebuildSolution;RebuildNuGetPackages;Test" />
+  <Target Name="Build" DependsOnTargets="BuildSolution;BuildNuGetPackages;Test" />
+  <Target Name="Rebuild" DependsOnTargets="RebuildSolution;RebuildNuGetPackages;Test" />
 
 </Project>

--- a/build/build.proj
+++ b/build/build.proj
@@ -26,7 +26,7 @@
 
   <Target Name="Restore">
 
-    <Message Text="Restoring packages for %(SolutionFile.Filename)" Importance="high" />
+    <Message Text="Restoring packages for %(SolutionFile.Filename) (this may take some time)" Importance="high" />
 
     <MSBuild BuildInParallel="true"
              Projects="@(SolutionFile)"

--- a/build/build.proj
+++ b/build/build.proj
@@ -57,27 +57,27 @@
              />
   </Target>
 
-    <Target Name="BuildNuGetPackages">
+  <Target Name="BuildNuGetPackages">
 
-      <Message Text="Building NuGet packages [$(Configuration)]" Importance="high" />
+    <Message Text="Building NuGet packages [$(Configuration)]" Importance="high" />
       
-      <MSBuild BuildInParallel="true"
-               Projects="@(NuGetProjectFile)"
-               Targets="Build"
-               Properties="$(CommonMSBuildGlobalProperties)"
-               />
-    </Target>
+    <MSBuild BuildInParallel="true"
+              Projects="@(NuGetProjectFile)"
+              Targets="Build"
+              Properties="$(CommonMSBuildGlobalProperties)"
+              />
+  </Target>
   
-    <Target Name="RebuildNuGetPackages">
+  <Target Name="RebuildNuGetPackages">
 
-      <Message Text="Rebuilding NuGet packages [$(Configuration)]" Importance="high" />
+    <Message Text="Rebuilding NuGet packages [$(Configuration)]" Importance="high" />
       
-      <MSBuild BuildInParallel="true"
-               Projects="@(NuGetProjectFile)"
-               Targets="Rebuild"
-               Properties="$(CommonMSBuildGlobalProperties)"
-               />
-    </Target>
+    <MSBuild BuildInParallel="true"
+              Projects="@(NuGetProjectFile)"
+              Targets="Rebuild"
+              Properties="$(CommonMSBuildGlobalProperties)"
+              />
+  </Target>
 
   <Target Name="BuildModernVsixPackages">
 
@@ -85,8 +85,8 @@
     
     <MSBuild Projects="@(VsManProjectFile)"
              Targets="Rebuild"
-             
              />
+
   </Target>
 
   <Target Name="Test" Condition="'$(RunTests)' == 'true'">
@@ -103,6 +103,7 @@
           LogStandardErrorAsError="true"
           IgnoreExitCode="true"
           >
+
       <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
     </Exec>
 

--- a/src/NuGet/NuGet.proj
+++ b/src/NuGet/NuGet.proj
@@ -49,7 +49,7 @@
    <Target Name="Rebuild" DependsOnTargets="Clean;Build" />
 
    <Target Name="LogOutput">
-     <Message Importance="High" Text="%(NuSpec.Identity) -> %(NuSpec.NuPkgOutput)'" />
+     <Message Importance="High" Text="%(NuSpec.Identity) -> %(NuSpec.NuPkgOutput)" />
    </Target>
 
  </Project>


### PR DESCRIPTION
- Remove unneeded attributes
- Log a few more things
- Build.cmd now builds the tree and modern VSIX together
- Add /build switch for "implicit" build
- Seperate config from build options			
- Don't -> Does not			
- Remove trailing ' from log output
- Nuget -> NuGet to match file on disk			
- Fix spacing in build.proj