### PR TITLE
Fix icon for shared projects in nested hierarchy

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ProjectDependenciesSubTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/ProjectDependenciesSubTreeProvider.cs
@@ -64,7 +64,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
         private List<ImageMoniker> _nodeIcons = new List<ImageMoniker>
         {
-            KnownMonikers.Application
+            KnownMonikers.Application,
+            KnownMonikers.SharedProject
         };
 
         public override IEnumerable<ImageMoniker> Icons


### PR DESCRIPTION
Fixes: #1623

Before:

![image](https://cloud.githubusercontent.com/assets/1103906/23349744/74cc0318-fd09-11e6-8d47-042229608a6a.png)

After:

![image](https://cloud.githubusercontent.com/assets/1103906/23349764/94d58e9a-fd09-11e6-9c41-88db474a79fb.png)

The warning icon is being tracked here: https://github.com/dotnet/roslyn-project-system/issues/1627
