### PR TITLE
Use in-box compiler to fix incremental build

### DIFF
--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -16,8 +16,6 @@
     <BaseNuGetRuntimeIdentifier Condition="'$(OS)' == 'Windows_NT'">win7</BaseNuGetRuntimeIdentifier>
   </PropertyGroup>
 
-  <Import Project="$(NuGetPackageRoot)\Microsoft.Net.Compilers\2.0.0-rc2-61102-09\build\Microsoft.Net.Compilers.props" Condition="Exists('$(NuGetPackageRoot)\Microsoft.Net.Compilers\2.0.0-rc2-61102-09\build\Microsoft.Net.Compilers.props')" />
-
   <!-- Import the global NuGet packages -->
   <PropertyGroup>
     <RoslynDiagnosticsNugetPackageVersion>1.2.0-beta2</RoslynDiagnosticsNugetPackageVersion>

--- a/src/Dependencies/Toolset/Toolset.csproj
+++ b/src/Dependencies/Toolset/Toolset.csproj
@@ -12,9 +12,8 @@
     <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
     <PackageReference Include="MicroBuild.Core.Sentinel" Version="1.0.0" />
     <PackageReference Include="MicroBuild.Plugins.SwixBuild" Version="1.0.101" ExcludeAssets="Build" />
-    <PackageReference Include="Microsoft.Net.Compilers"  Version="2.0.0-rc2-61102-09" ExcludeAssets="Build" />
     <PackageReference Include="Microsoft.Net.RoslynDiagnostics" Version="1.2.0-beta2" ExcludeAssets="Build" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version ="15.0.26124-RC3" ExcludeAssets="Build" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.0.26124-RC3" ExcludeAssets="Build" />
   </ItemGroup>
   <Import Project="..\..\..\build\Targets\ProducesNoOutput.Imports.targets" />
 </Project>


### PR DESCRIPTION
Incremental build is broken due to some bad interplay with the package version of the compiler and the compile cache introduced for SDK projects, see: https://github.com/Microsoft/msbuild/issues/1757

This removes usage of the package version of the compiler which was only needed while the language was changing - now that we should be on RC4+, we can use the inbox version.

This reduced `build /release /no-multi-proc` from ~3:30 minutes to ~1:59 minutes on my box.