### PR TITLE
Release Roslyn Project System and Nugets which are Release versioned

### DIFF
--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -63,10 +63,10 @@
   <PropertyGroup>
     <VSSemanticVersion>15.0</VSSemanticVersion>
 
-    <RoslynNuGetPreReleaseVersion>$(RoslynSemanticVersion)-rc</RoslynNuGetPreReleaseVersion>
-    <RoslynNuGetPerBuildPreReleaseVersion Condition="'$(BuildNumberFiveDigitDateStamp)' != '' AND '$(BuildNumberBuildOfTheDayPadded)' != ''">$(RoslynNuGetPreReleaseVersion)-$(BuildNumberFiveDigitDateStamp.Trim())-$(BuildNumberBuildOfTheDayPadded.Trim())</RoslynNuGetPerBuildPreReleaseVersion>
-    <RoslynNuGetPerBuildPreReleaseVersion Condition="'$(RoslynNuGetPerBuildPreReleaseVersion)' == ''">1.0.0-rc</RoslynNuGetPerBuildPreReleaseVersion>
-    <VSNuGetPerBuildReleaseVersion Condition="'$(BuildNumberFiveDigitDateStamp)' != '' AND '$(BuildNumberBuildOfTheDayPadded)' != ''">$(VSSemanticVersion)-$(BuildNumberFiveDigitDateStamp.Trim())-$(BuildNumberBuildOfTheDayPadded.Trim())</VSNuGetPerBuildReleaseVersion>
+    <RoslynNuGetReleaseVersion>$(RoslynSemanticVersion.Substring(0, $(RoslynSemanticVersion.LastIndexOf('.'))))</RoslynNuGetReleaseVersion>
+    <RoslynNuGetPerBuildReleaseVersion Condition="'$(BuildNumberFiveDigitDateStamp)' != '' AND '$(BuildNumberBuildOfTheDayPadded)' != ''">$(RoslynNuGetReleaseVersion).$(BuildNumberFiveDigitDateStamp.Trim())$(BuildNumberBuildOfTheDayPadded.Trim())</RoslynNuGetPerBuildReleaseVersion>
+    <RoslynNuGetPerBuildReleaseVersion Condition="'$(RoslynNuGetPerBuildReleaseVersion)' == ''">1.0.0</RoslynNuGetPerBuildReleaseVersion>
+    <VSNuGetPerBuildReleaseVersion Condition="'$(BuildNumberFiveDigitDateStamp)' != '' AND '$(BuildNumberBuildOfTheDayPadded)' != ''">$(VSSemanticVersion).$(BuildNumberFiveDigitDateStamp.Trim())$(BuildNumberBuildOfTheDayPadded.Trim())</VSNuGetPerBuildReleaseVersion>
     <VSNuGetPerBuildReleaseVersion Condition="'$(VSNuGetPerBuildReleaseVersion)' == ''">1.0.0</VSNuGetPerBuildReleaseVersion>
   </PropertyGroup>
   

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -61,14 +61,13 @@
 
   <!-- NuGet version -->
   <PropertyGroup>
-    <VSSemanticVersion>15.0.1</VSSemanticVersion>
+    <VSSemanticVersion>15.0</VSSemanticVersion>
 
     <RoslynNuGetPreReleaseVersion>$(RoslynSemanticVersion)-rc</RoslynNuGetPreReleaseVersion>
     <RoslynNuGetPerBuildPreReleaseVersion Condition="'$(BuildNumberFiveDigitDateStamp)' != '' AND '$(BuildNumberBuildOfTheDayPadded)' != ''">$(RoslynNuGetPreReleaseVersion)-$(BuildNumberFiveDigitDateStamp.Trim())-$(BuildNumberBuildOfTheDayPadded.Trim())</RoslynNuGetPerBuildPreReleaseVersion>
     <RoslynNuGetPerBuildPreReleaseVersion Condition="'$(RoslynNuGetPerBuildPreReleaseVersion)' == ''">1.0.0-rc</RoslynNuGetPerBuildPreReleaseVersion>
-    <VSNuGetPreReleaseVersion>$(VSSemanticVersion)-rc</VSNuGetPreReleaseVersion>
-    <VSNuGetPerBuildPreReleaseVersion Condition="'$(BuildNumberFiveDigitDateStamp)' != '' AND '$(BuildNumberBuildOfTheDayPadded)' != ''">$(VSNuGetPreReleaseVersion)-$(BuildNumberFiveDigitDateStamp.Trim())-$(BuildNumberBuildOfTheDayPadded.Trim())</VSNuGetPerBuildPreReleaseVersion>
-    <VSNuGetPerBuildPreReleaseVersion Condition="'$(VSNuGetPerBuildPreReleaseVersion)' == ''">1.0.0-rc</VSNuGetPerBuildPreReleaseVersion>
+    <VSNuGetPerBuildReleaseVersion Condition="'$(BuildNumberFiveDigitDateStamp)' != '' AND '$(BuildNumberBuildOfTheDayPadded)' != ''">$(VSSemanticVersion)-$(BuildNumberFiveDigitDateStamp.Trim())-$(BuildNumberBuildOfTheDayPadded.Trim())</VSNuGetPerBuildReleaseVersion>
+    <VSNuGetPerBuildReleaseVersion Condition="'$(VSNuGetPerBuildReleaseVersion)' == ''">1.0.0</VSNuGetPerBuildReleaseVersion>
   </PropertyGroup>
   
 </Project>

--- a/src/Dependencies/CPS/project.json
+++ b/src/Dependencies/CPS/project.json
@@ -2,7 +2,7 @@
   "supports": {},
   "dependencies": {
     "Microsoft.VisualStudio.ProjectSystem.SDK": {
-      "version": "15.0.661-pre-g3d0c752f96",
+      "version": "15.0.737",
       "suppressParent": "none"
     }
   },

--- a/src/Dependencies/VisualStudio/project.json
+++ b/src/Dependencies/VisualStudio/project.json
@@ -23,8 +23,8 @@
 
     "Microsoft.VisualStudio.Editor": "15.0.25726-Preview5",
     "Microsoft.VisualStudio.ImageCatalog": "15.0.25726-Preview5",
-    "Microsoft.VisualStudio.Shell.Design": "15.0.25726-Preview5",
-    "Microsoft.VisualStudio.Shell.15.0": "15.0.25726-Preview5",
+    "Microsoft.VisualStudio.Shell.Design": "15.0.26201",
+    "Microsoft.VisualStudio.Shell.15.0": "15.0.26201",
     "RoslynDependencies.Microsoft.VisualStudio.GraphModel": "15.0.25807",
     "Microsoft.VisualStudio.Telemetry": {
       "version": "15.0.691-master31907920",

--- a/src/NuGet/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.nuspec
@@ -10,6 +10,9 @@
     <version>15.0.0</version> <!-- This value will be overriden by the Nuget pack call. Having this value to satisfy the schema. -->
     <authors>dotnet</authors>
     <projectUrl>https://github.com/dotnet/roslyn-project-system/</projectUrl>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=529444</licenseUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
       <dependency id="Microsoft.VisualStudio.ManagedInterfaces" version="8.0.50727" />
       <dependency id="Microsoft.VisualStudio.TextManager.Interop.10.0" version="10.0.30319" />

--- a/src/NuGet/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.nuspec
@@ -7,15 +7,15 @@
       This package implements the AppDesigner, which is the designer host used for project property pages among other things in Visual Studio
     </description>
     <language>en-US</language>
-    <version>15.0.0-alpha</version> <!-- This value will be overriden by the Nuget pack call. Having this value to satisfy the schema. -->
+    <version>15.0.0</version> <!-- This value will be overriden by the Nuget pack call. Having this value to satisfy the schema. -->
     <authors>dotnet</authors>
     <projectUrl>https://github.com/dotnet/roslyn-project-system/</projectUrl>
     <dependencies>
       <dependency id="Microsoft.VisualStudio.ManagedInterfaces" version="8.0.50727" />
       <dependency id="Microsoft.VisualStudio.TextManager.Interop.10.0" version="10.0.30319" />
       <dependency id="Microsoft.VisualStudio.TextManager.Interop.12.0" version="12.0.30110" />
-      <dependency id="Microsoft.VisualStudio.Shell.15.0" version="15.0.25726-Dev15Preview" />
-      <dependency id="Microsoft.VisualStudio.Shell.Design" version="15.0.25726-Dev15Preview" />
+      <dependency id="Microsoft.VisualStudio.Shell.15.0" version="15.0.26201" />
+      <dependency id="Microsoft.VisualStudio.Shell.Design" version="15.0.26201" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.10.0" version="10.0.30319" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.11.0" version="11.0.61030" />
     </dependencies>

--- a/src/NuGet/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.nuspec
@@ -10,6 +10,9 @@
     <version>15.0.0</version> <!-- This value will be overriden by the Nuget pack call. Having this value to satisfy the schema. -->
     <authors>dotnet</authors>
     <projectUrl>https://github.com/dotnet/roslyn-project-system/</projectUrl>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=529444</licenseUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
       <dependency id="Microsoft.VisualStudio.AppDesigner" version="$version$" />
       <dependency id="Microsoft.VisualStudio.Shell.15.0" version="15.0.26201" />

--- a/src/NuGet/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.nuspec
@@ -7,12 +7,12 @@
       Implementation of some designers and project property page editors in VisualStudio.
     </description>
     <language>en-US</language>
-    <version>15.0.0-alpha</version> <!-- This value will be overriden by the Nuget pack call. Having this value to satisfy the schema. -->
+    <version>15.0.0</version> <!-- This value will be overriden by the Nuget pack call. Having this value to satisfy the schema. -->
     <authors>dotnet</authors>
     <projectUrl>https://github.com/dotnet/roslyn-project-system/</projectUrl>
     <dependencies>
       <dependency id="Microsoft.VisualStudio.AppDesigner" version="$version$" />
-      <dependency id="Microsoft.VisualStudio.Shell.15.0" version="15.0.25726-Dev15Preview" />
+      <dependency id="Microsoft.VisualStudio.Shell.15.0" version="15.0.26201" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.10.0" version="10.0.30319" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.11.0" version="11.0.61030" />
     </dependencies>

--- a/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.nuspec
@@ -7,14 +7,17 @@
       Microsoft VisualStudio ProjectSystem for Managed Languages Project hosts that interact with VisualStudio interfaces.
     </description>
     <language>en-US</language>
-    <version>2.0.0-alpha</version> <!-- This value will be overriden by the Nuget pack call. Having this value to satisfy the schema. -->
+    <version>2.0.0</version> <!-- This value will be overriden by the Nuget pack call. Having this value to satisfy the schema. -->
     <authors>dotnet</authors>
     <projectUrl>https://github.com/dotnet/roslyn-project-system/</projectUrl>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=529445</licenseUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
       <dependency id="System.Collections.Immutable" version="1.1.36" />
       <dependency id="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" version="14.1.24720" />
       <dependency id="Microsoft.VisualStudio.ProjectSystem.Managed" version="$version$" />
-      <dependency id="Microsoft.VisualStudio.ProjectSystem.SDK" version="15.0.661-pre-g3d0c752f96" />
+      <dependency id="Microsoft.VisualStudio.ProjectSystem.SDK" version="15.0.737" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.10.0" version="10.0.30319" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.11.0" version="11.0.61030" />
       <dependency id="Microsoft.VisualStudio.TextManager.Interop.10.0" version="10.0.30319" />

--- a/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.nuspec
@@ -7,12 +7,15 @@
       Microsoft VisualStudio ProjectSystem for Managed languages Projects
     </description>
     <language>en-US</language>
-    <version>2.0.0-alpha</version> <!-- This value will be overriden by the Nuget pack call. Having this value to satisfy the schema. -->
+    <version>2.0.0</version> <!-- This value will be overriden by the Nuget pack call. Having this value to satisfy the schema. -->
     <authors>dotnet</authors>
     <projectUrl>https://github.com/dotnet/roslyn-project-system/</projectUrl>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=529445</licenseUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
       <dependency id="System.Collections.Immutable" version="1.1.36" />
-      <dependency id="Microsoft.VisualStudio.ProjectSystem.SDK" version="15.0.661-pre-g3d0c752f96" />
+      <dependency id="Microsoft.VisualStudio.ProjectSystem.SDK" version="15.0.737" />
     </dependencies>
   </metadata>
   <files>

--- a/src/NuGet/NuGet.proj
+++ b/src/NuGet/NuGet.proj
@@ -19,12 +19,12 @@
        <NuGetArguments>-Version "$(VSNuGetPerBuildReleaseVersion)"</NuGetArguments>
      </NuSpec>
      <NuSpec Include="Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.nuspec">
-       <NuPkgOutput>$(NuGetOutDir)%(FileName).$(RoslynNuGetPerBuildPreReleaseVersion).nupkg</NuPkgOutput>
-       <NuGetArguments>-Version "$(RoslynNuGetPerBuildPreReleaseVersion)"</NuGetArguments>
+       <NuPkgOutput>$(NuGetOutDir)%(FileName).$(RoslynNuGetPerBuildReleaseVersion).nupkg</NuPkgOutput>
+       <NuGetArguments>-Version "$(RoslynNuGetPerBuildReleaseVersion)"</NuGetArguments>
      </NuSpec>
       <NuSpec Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS\Microsoft.VisualStudio.ProjectSystem.Managed.VS.nuspec">
-       <NuPkgOutput>$(NuGetOutDir)%(FileName).$(RoslynNuGetPerBuildPreReleaseVersion).nupkg</NuPkgOutput>
-       <NuGetArguments>-Version "$(RoslynNuGetPerBuildPreReleaseVersion)"</NuGetArguments>
+       <NuPkgOutput>$(NuGetOutDir)%(FileName).$(RoslynNuGetPerBuildReleaseVersion).nupkg</NuPkgOutput>
+       <NuGetArguments>-Version "$(RoslynNuGetPerBuildReleaseVersion)"</NuGetArguments>
      </NuSpec>
 
      <!-- Make note, without actually knowing what's included in the NuSpec, 

--- a/src/NuGet/NuGet.proj
+++ b/src/NuGet/NuGet.proj
@@ -11,12 +11,12 @@
 
    <ItemGroup>
      <NuSpec Include="Microsoft.VisualStudio.Editors\Microsoft.VisualStudio.Editors.nuspec">
-       <NuPkgOutput>$(NuGetOutDir)%(FileName).$(VSNuGetPerBuildPreReleaseVersion).nupkg</NuPkgOutput>
-       <NuGetArguments>-Version "$(VSNuGetPerBuildPreReleaseVersion)"</NuGetArguments>
+       <NuPkgOutput>$(NuGetOutDir)%(FileName).$(VSNuGetPerBuildReleaseVersion).nupkg</NuPkgOutput>
+       <NuGetArguments>-Version "$(VSNuGetPerBuildReleaseVersion)"</NuGetArguments>
      </NuSpec>
      <NuSpec Include="Microsoft.VisualStudio.AppDesigner\Microsoft.VisualStudio.AppDesigner.nuspec">
-       <NuPkgOutput>$(NuGetOutDir)%(FileName).$(VSNuGetPerBuildPreReleaseVersion).nupkg</NuPkgOutput>
-       <NuGetArguments>-Version "$(VSNuGetPerBuildPreReleaseVersion)"</NuGetArguments>
+       <NuPkgOutput>$(NuGetOutDir)%(FileName).$(VSNuGetPerBuildReleaseVersion).nupkg</NuPkgOutput>
+       <NuGetArguments>-Version "$(VSNuGetPerBuildReleaseVersion)"</NuGetArguments>
      </NuSpec>
      <NuSpec Include="Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.nuspec">
        <NuPkgOutput>$(NuGetOutDir)%(FileName).$(RoslynNuGetPerBuildPreReleaseVersion).nupkg</NuPkgOutput>


### PR DESCRIPTION
**Customer scenario**

Nugets that we produce today are built using the Pre-release version of some of the dependencies. This change will remove those Pre-release version dependencies and hence will enable us to release release-versioned Nuget packages for Roslyn Project system. The binaries that get built and packaged into the Nuget will be available to insert into VS

**Bugs this fixes:**

[388822](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/388822)

**Workarounds, if any**

No. All VS nugets are non-pre release so it makes sense to release non-pre release nugets for Project system as well

**Risk**

There has not been much code churn with the dependencies and we are taking a dependency over VS release quality package. So we hope the risk is minimal. We will do manual validation in addition to this.

**Performance impact**

none

**Is this a regression from a previous update?**

No

**Root cause analysis:**

CPS just released their Nuget with non-pre-release version. Without their package, this work is not possible

**How was the bug found?**

We have been tracking this for sometime now.

Tagging @natidea @srivatsn @davkean @dotnet/project-system for review