### PR TITLE
Prevent user disabled package sources

### DIFF
--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -13,4 +13,8 @@
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 
+  <!-- Don't let user disabled sources in VS prevent us from restoring -->
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
 </configuration>


### PR DESCRIPTION
VS settings on my box were preventing us from restoring because I'd disabled a source in VS which broke our repo. Prevent that, like we prevent VS registered sources from breaking us.