### PR TITLE
Fix issue preventing externals changes to launchsettings.json to appe…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -603,6 +603,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                     LaunchProfiles.Add(profile);
                 }
 
+                // When loading new profiles we need to clear the launch type. This is so the external changes cause the current 
+                // active provider to be refreshed
+                _selectedLaunchType = null;
                 NotifyProfileCollectionChanged();
 
                 // If we have a selection, we want to leave it as is

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchSettings.cs
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             }
             
             // Check the global settings
-            return DictionaryEqualityComparer<string, object>.Instance.Equals(launchSettings.GlobalSettings.ToImmutableDictionary(), settingsToCompare.GlobalSettings.ToImmutableDictionary());
+            return !DictionaryEqualityComparer<string, object>.Instance.Equals(launchSettings.GlobalSettings.ToImmutableDictionary(), settingsToCompare.GlobalSettings.ToImmutableDictionary());
         }
 
     }


### PR DESCRIPTION
Fix for issue https://github.com/dotnet/roslyn-project-system/issues/1638

Two bugs
The comparison to see if settings are different was missing a not.

When new settings are detected in the page it needs to clear the selected launch type to force a reload into the providers control

@srivatsn 