### PR TITLE
Upgrade RuntimeInformation from 4.0 -> 4.3

### DIFF
--- a/src/DeployTestDependencies/DeployTestDependencies.csproj
+++ b/src/DeployTestDependencies/DeployTestDependencies.csproj
@@ -60,7 +60,7 @@
   <ItemGroup>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.1.0" />
     <PackageReference Include="xunit.runner.console" Version="2.1.0" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Readme.txt" />


### PR DESCRIPTION
This is to prevent a downgrade error when running on a machine with https://github.com/dotnet/sdk/pull/893.

Filed https://github.com/NuGet/Home/issues/4703 to track the large number of warnings/errors this case caused.