### PR TITLE
Run _CheckForInvalidConfigurationAndPlatform in design-time builds

### DIFF
--- a/src/Targets/Microsoft.CSharp.DesignTime.targets
+++ b/src/Targets/Microsoft.CSharp.DesignTime.targets
@@ -35,7 +35,7 @@
     <!-- Returns Csc command-line arguments for the language service -->
     <Target Name="CompileDesignTime"
             Returns="@(_CompilerCommandLineArgs)"
-            DependsOnTargets="_CheckCompileDesignTimePrerequisite;Compile"
+            DependsOnTargets="_CheckForInvalidConfigurationAndPlatform;_CheckCompileDesignTimePrerequisite;Compile"
             Condition="'$(IsCrossTargetingBuild)' != 'true'"
           >
 

--- a/src/Targets/Microsoft.VisualBasic.DesignTime.targets
+++ b/src/Targets/Microsoft.VisualBasic.DesignTime.targets
@@ -35,7 +35,7 @@
     <!-- Returns Vbc command-line arguments for the language service -->
     <Target Name="CompileDesignTime"
             Returns="@(_CompilerCommandLineArgs)"
-            DependsOnTargets="_CheckCompileDesignTimePrerequisite;Compile"
+            DependsOnTargets="_CheckForInvalidConfigurationAndPlatform;_CheckCompileDesignTimePrerequisite;Compile"
             Condition="'$(IsCrossTargetingBuild)' != 'true'"
           >
 


### PR DESCRIPTION
Should fix the VS side of dotnet/sdk#798

The targets which currently get run as part of `_CheckForInvalidConfigurationAndPlatform` are:

- _CheckForUnsupportedTargetFramework
- CheckForDuplicateItems
- _CheckForInvalidConfigurationAndPlatform
- CheckForImplicitPackageReferenceOverrides