### PR TITLE
Clear the dirty flag on UnconfiguredProject before saving the edited …

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Editor/TempFileTextBufferManagerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Editor/TempFileTextBufferManagerTests.cs
@@ -315,7 +315,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
             Assert.Equal("<Project />", fileSystem.ReadAllText(tempProjectPath));
 
             await textBufferManager.SaveAsync();
-            Mock.Get(msbuildAccessor).Verify(m => m.SaveProjectXmlAsync("<Project></Project>"));
+            Mock.Get(msbuildAccessor).Verify(m => m.ClearProjectDirtyFlagAsync(), Times.Once);
+            Mock.Get(msbuildAccessor).Verify(m => m.SaveProjectXmlAsync("<Project></Project>"), Times.Once);
         }
 
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Editor/TempFileTextBufferManagerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Editor/TempFileTextBufferManagerTests.cs
@@ -315,7 +315,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
             Assert.Equal("<Project />", fileSystem.ReadAllText(tempProjectPath));
 
             await textBufferManager.SaveAsync();
-            Mock.Get(msbuildAccessor).Verify(m => m.ClearProjectDirtyFlagAsync(), Times.Once);
             Mock.Get(msbuildAccessor).Verify(m => m.SaveProjectXmlAsync("<Project></Project>"), Times.Once);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/IProjectXmlAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/IProjectXmlAccessor.cs
@@ -18,10 +18,5 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         /// Saves the given xml to the project file.
         /// </summary>
         Task SaveProjectXmlAsync(string toSave);
-
-        /// <summary>
-        /// Clears the dirty flag on the UnconfiguredProject.
-        /// </summary>
-        Task ClearProjectDirtyFlagAsync();
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/IProjectXmlAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/IProjectXmlAccessor.cs
@@ -18,5 +18,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         /// Saves the given xml to the project file.
         /// </summary>
         Task SaveProjectXmlAsync(string toSave);
+
+        /// <summary>
+        /// Clears the dirty flag on the UnconfiguredProject.
+        /// </summary>
+        Task ClearProjectDirtyFlagAsync();
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/MSBuildXmlAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/MSBuildXmlAccessor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.IO;
 
@@ -43,6 +44,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
                 await access.CheckoutAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
                 var encoding = await _unconfiguredProject.GetFileEncodingAsync().ConfigureAwait(false);
                 _fileSystem.WriteAllText(_unconfiguredProject.FullPath, toSave, encoding);
+            }
+        }
+
+        public async Task ClearProjectDirtyFlagAsync()
+        {
+            using (var access = await _projectLockService.WriteLockAsync())
+            {
+                await access.CheckoutAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
+                var projectRoot = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
+                var stringWriter = new StringWriter();
+                projectRoot.Save(stringWriter);
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/MSBuildXmlAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/MSBuildXmlAccessor.cs
@@ -46,6 +46,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
                 // the project is dirty and fail the reload, and discard the changes.
                 var projectRoot = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
                 var stringWriter = new StringWriter();
+
+                // Calling save on the ProjectRootElement clears the dirty flag. However, we don't care about the result, to just
+                // throw it into a stringwriter and discard.
                 projectRoot.Save(stringWriter);
                 var encoding = await _unconfiguredProject.GetFileEncodingAsync().ConfigureAwait(false);
                 _fileSystem.WriteAllText(_unconfiguredProject.FullPath, toSave, encoding);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/MSBuildXmlAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/MSBuildXmlAccessor.cs
@@ -42,19 +42,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
             using (var access = await _projectLockService.WriteLockAsync())
             {
                 await access.CheckoutAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
-                var encoding = await _unconfiguredProject.GetFileEncodingAsync().ConfigureAwait(false);
-                _fileSystem.WriteAllText(_unconfiguredProject.FullPath, toSave, encoding);
-            }
-        }
-
-        public async Task ClearProjectDirtyFlagAsync()
-        {
-            using (var access = await _projectLockService.WriteLockAsync())
-            {
-                await access.CheckoutAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
+                // We must clear the project dirty flag first. If it's dirty in memory, the ProjectReloadManager will detect that
+                // the project is dirty and fail the reload, and discard the changes.
                 var projectRoot = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
                 var stringWriter = new StringWriter();
                 projectRoot.Save(stringWriter);
+                var encoding = await _unconfiguredProject.GetFileEncodingAsync().ConfigureAwait(false);
+                _fileSystem.WriteAllText(_unconfiguredProject.FullPath, toSave, encoding);
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/TempFileTextBufferManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/TempFileTextBufferManager.cs
@@ -148,11 +148,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
 
         public async Task SaveAsync()
         {
-            // We must clear the project dirty flag first. If it's dirty in memory, the ProjectReloadManager will detect that
-            // the project is dirty and fail the reload, and discard the changes.
-            var clearFlagTask = _projectXmlAccessor.ClearProjectDirtyFlagAsync();
             var toWrite = await ReadBufferXmlAsync().ConfigureAwait(false);
-            await clearFlagTask.ConfigureAwait(false);
             await _projectXmlAccessor.SaveProjectXmlAsync(toWrite).ConfigureAwait(false);
             lock (_savedXmlLock)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/TempFileTextBufferManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/TempFileTextBufferManager.cs
@@ -150,9 +150,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         {
             // We must clear the project dirty flag first. If it's dirty in memory, the ProjectReloadManager will detect that
             // the project is dirty and fail the reload, and discard the changes.
-            var saveTask = _projectXmlAccessor.ClearProjectDirtyFlagAsync();
+            var clearFlagTask = _projectXmlAccessor.ClearProjectDirtyFlagAsync();
             var toWrite = await ReadBufferXmlAsync().ConfigureAwait(false);
-            await saveTask.ConfigureAwait(false);
+            await clearFlagTask.ConfigureAwait(false);
             await _projectXmlAccessor.SaveProjectXmlAsync(toWrite).ConfigureAwait(false);
             lock (_savedXmlLock)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/TempFileTextBufferManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Editor/TempFileTextBufferManager.cs
@@ -148,9 +148,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
 
         public async Task SaveAsync()
         {
+            // We must clear the project dirty flag first. If it's dirty in memory, the ProjectReloadManager will detect that
+            // the project is dirty and fail the reload, and discard the changes.
+            var saveTask = _projectXmlAccessor.ClearProjectDirtyFlagAsync();
             var toWrite = await ReadBufferXmlAsync().ConfigureAwait(false);
+            await saveTask.ConfigureAwait(false);
             await _projectXmlAccessor.SaveProjectXmlAsync(toWrite).ConfigureAwait(false);
-            lock(_savedXmlLock)
+            lock (_savedXmlLock)
             {
                 _lastSavedXml = toWrite;
             }


### PR DESCRIPTION
…project file to prevent reload failure. Fixes #1663. Tagging @dotnet/project-system @davkean for review.