### PR TITLE
Fix subscription hookup in LanguageServiceHost.OnProjectFactoryComple…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -85,17 +85,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             using (_tasksService.LoadedProject())
             {
                 var watchedEvaluationRules = GetWatchedRules(RuleHandlerType.Evaluation);
-                var watchedDesignTimeBuildRules = GetWatchedRules(RuleHandlerType.DesignTimeBuild);
-
-                _designTimeBuildSubscriptionLinks.Add(_activeConfiguredProjectSubscriptionService.JointRuleSource.SourceBlock.LinkTo(
-                  new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(e => OnProjectChangedAsync(e, RuleHandlerType.DesignTimeBuild)),
-                  ruleNames: watchedDesignTimeBuildRules.Union(watchedEvaluationRules), suppressVersionOnlyUpdates: true));
 
                 _evaluationSubscriptionLinks.Add(_activeConfiguredProjectSubscriptionService.ProjectRuleSource.SourceBlock.LinkTo(
-                    new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(e => OnProjectChangedAsync(e, RuleHandlerType.Evaluation)),
+                    new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(e => InitializeAsync(e, RuleHandlerType.Evaluation)),
                     ruleNames: watchedEvaluationRules, suppressVersionOnlyUpdates: true));
-
-                _projectConfigurationsWithSubscriptions.Add(_commonServices.ActiveConfiguredProject.ProjectConfiguration);
             }
 
             return Task.CompletedTask;
@@ -115,14 +108,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             return InitializeAsync(cancellationToken);
         }
 
-        private async Task OnProjectChangedAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e, RuleHandlerType handlerType)
+        private async Task InitializeAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e, RuleHandlerType handlerType)
         {
             if (IsDisposing || IsDisposed)
                 return;
 
             await InitializeAsync().ConfigureAwait(false);
-
-            await OnProjectChangedCoreAsync(e, handlerType).ConfigureAwait(false);
         }
 
         private async Task OnProjectChangedCoreAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e, RuleHandlerType handlerType)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -82,20 +82,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         [AppliesTo(ProjectCapability.CSharpOrVisualBasicLanguageService)]
         private Task OnProjectFactoryCompletedAsync()
         {
-            using (_tasksService.LoadedProject())
-            {
-                var watchedEvaluationRules = GetWatchedRules(RuleHandlerType.Evaluation);
-
-                _evaluationSubscriptionLinks.Add(_activeConfiguredProjectSubscriptionService.ProjectRuleSource.SourceBlock.LinkTo(
-                    new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(e => InitializeAsync(e, RuleHandlerType.Evaluation)),
-                    ruleNames: watchedEvaluationRules, suppressVersionOnlyUpdates: true));
-            }
-
-            return Task.CompletedTask;
+            return InitializeAsync();
         }
 
         protected async override Task InitializeCoreAsync(CancellationToken cancellationToken)
         {
+            if (IsDisposing || IsDisposed)
+                return;
+
             // Don't initialize if we're unloading
             _tasksService.UnloadCancellationToken.ThrowIfCancellationRequested();
 
@@ -106,14 +100,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         Task ILanguageServiceHost.InitializeAsync(CancellationToken cancellationToken)
         {
             return InitializeAsync(cancellationToken);
-        }
-
-        private async Task InitializeAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e, RuleHandlerType handlerType)
-        {
-            if (IsDisposing || IsDisposed)
-                return;
-
-            await InitializeAsync().ConfigureAwait(false);
         }
 
         private async Task OnProjectChangedCoreAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e, RuleHandlerType handlerType)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -104,6 +104,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         private async Task OnProjectChangedCoreAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e, RuleHandlerType handlerType)
         {
+            if (IsDisposing || IsDisposed)
+                return;
+
             await _tasksService.LoadedProjectAsync(async () =>
             {
                 await HandleAsync(e, handlerType).ConfigureAwait(false);


### PR DESCRIPTION
…tedAsync

Do not hookup subscription to design time builds in OnProjectFactoryCompletedAsync, and only invoke InitializeAsync for evaluation subscription hooked up in this method. This way, we will only process project change subscription updates  after LanguageServiceHost has been initialized, and we have a valid active project configuration, not just the NoVariablesDefault fallback configuration.

Fixes #1666