### PR TITLE
Add package references to MicroBuild

### DIFF
--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -76,6 +76,11 @@
         <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.0-preview-000516-03" />
         <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.1.0-preview-000516-03" />
         <PackageReference Include="Microsoft.Build.Engine" Version="15.1.0-preview-000516-03" />
+
+        <!-- MicroBuild -->
+        <PackageReference Include="MicroBuild.Core.Sentinel" Version="1.0.0" />
+        <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
+        <PackageReference Include="MicroBuild.Plugins.SwixBuild" Version="1.0.101" ExcludeAssets="Build" />
       </ItemGroup>
     </When>
   </Choose>

--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -1,17 +1,6 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 
-
-  <PropertyGroup>
-    <MicroBuildPackageDirectory>$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildVersion)\</MicroBuildPackageDirectory>
-  </PropertyGroup>
-
-  <!-- During Restore the props/targets won't be present-->
-  <ImportGroup Condition="'$(NonShipping)' != 'true' AND Exists('$(MicroBuildPackageDirectory)')">
-    <Import Project="$(MicroBuildPackageDirectory)\build\MicroBuild.Core.props" />
-    <Import Project="$(MicroBuildPackageDirectory)\build\MicroBuild.Core.targets" />
-  </ImportGroup>
-
   <!-- With UseCommonOutputDirectory turned on, any copy-local projects/references break
        csproj's up-to-date check because they aren't copied to the output directory. 
        Turn it off. 

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <RoslynSemanticVersion Condition="'$(RoslynSemanticVersion)' == '' AND '$(UseVisualStudioVersion)' == 'true'">15.0.1</RoslynSemanticVersion>
     <RoslynSemanticVersion Condition="'$(RoslynSemanticVersion)' == ''">2.0.1</RoslynSemanticVersion>
-    <MicroBuildVersion>0.2.0</MicroBuildVersion>
     <BuildNumber Condition="'$(BuildNumber)' == ''">$(BUILD_BUILDNUMBER)</BuildNumber>
 
     <!-- Split the build parts out from the BuildNumber which is given to us by MicroBuild in the format of yyyymmdd.nn


### PR DESCRIPTION
These were accidentely removed when we removed the dependency projects and prevented us from restoring these packages on clean machines.