### PR TITLE
Add BuildTools package reference

### DIFF
--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -115,6 +115,7 @@
           <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.Diagnostics.PerformanceProvider.dll</HintPath>
         </Reference>
 
+        <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.0.26124-rc3" />
         <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" Version="1.1.4322" />
         <PackageReference Include="Microsoft.VisualStudio.ManagedInterfaces" Version="8.0.50727" />
         <PackageReference Include="Microsoft.VisualStudio.WCFReference.Interop" Version="9.0.30729" />

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -109,12 +109,6 @@
     </Otherwise>
   </Choose>
 
-  <PropertyGroup>
-    <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.26124-RC3</VisualStudioBuildToolsNuGetPackagePath>
-  </PropertyGroup>
-  <Import Project="$(VisualStudioBuildToolsNuGetPackagePath)\build\Microsoft.VsSDK.BuildTools.props"
-          Condition="'$(OS)' == 'Windows_NT' And Exists('$(VisualStudioBuildToolsNuGetPackagePath)\build\Microsoft.VsSDK.BuildTools.props')" />
-
   <!-- Build reliability -->
   <PropertyGroup>
     <OverwriteReadOnlyFiles Condition="'$(OverwriteReadOnlyFiles)' == ''">true</OverwriteReadOnlyFiles>

--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -392,7 +392,6 @@
 
        ==================================================================================== -->
 
-  <Import Project="$(VisualStudioBuildToolsNuGetPackagePath)\build\Microsoft.VsSDK.BuildTools.targets" Condition="'$(ImportVSSDKTargets)' == 'true' And Exists('$(VisualStudioBuildToolsNuGetPackagePath)\build\Microsoft.VsSDK.BuildTools.targets')" />  
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(ImportVSSDKTargets)' == 'true' And Exists('$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets')" /> 
 
   <!-- The VSSDK immplements some targets which are run during design time builds per convention. 


### PR DESCRIPTION
This was removed in the dependency removal, and caused Jenkins to stop deploying VSIX.