### PR TITLE
Remove unneeded global properties [dev15.1.x]

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -11,9 +11,6 @@
          by NuGet.exe, so don't be tempted to change the name.-->
     <NUGET_PACKAGES Condition="'$(NUGET_PACKAGES)' == ''">$(UserProfile)\.nuget\packages</NUGET_PACKAGES>
 
-    <CommonMSBuildGlobalProperties>
-      Configuration=$(Configuration);
-    </CommonMSBuildGlobalProperties>
   </PropertyGroup>
 
   <ItemGroup>
@@ -42,7 +39,6 @@
     <MSBuild BuildInParallel="true"
              Projects="@(SolutionFile)"
              Targets="Build"
-             Properties="$(CommonMSBuildGlobalProperties)"
              />
   </Target>
 
@@ -53,27 +49,28 @@
     <MSBuild BuildInParallel="true"
              Projects="@(SolutionFile)"
              Targets="Rebuild"
-             Properties="$(CommonMSBuildGlobalProperties)"
              />
   </Target>
 
     <Target Name="BuildNuGetPackages">
 
-      <MSBuild BuildInParallel="true"
-               Projects="@(NuGetProjectFile)"
-               Targets="Build"
-               Properties="$(CommonMSBuildGlobalProperties)"
-               />
-    </Target>
+    <Message Text="Building NuGet packages [$(Configuration)]" Importance="high" />
+      
+    <MSBuild BuildInParallel="true"
+              Projects="@(NuGetProjectFile)"
+              Targets="Build"
+              />
+  </Target>
   
-    <Target Name="RebuildNuGetPackages">
-  
-      <MSBuild BuildInParallel="true"
-               Projects="@(NuGetProjectFile)"
-               Targets="Rebuild"
-               Properties="$(CommonMSBuildGlobalProperties)"
-               />
-    </Target>
+  <Target Name="RebuildNuGetPackages">
+
+    <Message Text="Rebuilding NuGet packages [$(Configuration)]" Importance="high" />
+      
+    <MSBuild BuildInParallel="true"
+              Projects="@(NuGetProjectFile)"
+              Targets="Rebuild"
+              />
+  </Target>
 
   <Target Name="BuildModernVsixPackages">
 

--- a/build/build.proj
+++ b/build/build.proj
@@ -14,10 +14,6 @@
     <CommonMSBuildGlobalProperties>
       Configuration=$(Configuration);
     </CommonMSBuildGlobalProperties>
-    <CommonMSBuildGlobalProperties Condition="'$(RunningInMicroBuild)' == 'true'">
-      $(CommonMSBuildGlobalProperties)
-      DeployExtension=false;
-    </CommonMSBuildGlobalProperties>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- 	Stop explictly setting DeployExtension=false for MicroBuild 
- 	Stop passing properties to inner builds

See commits for more details