### PR TITLE
Jenkins groovy file changes:

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -86,11 +86,12 @@ pushd %WORKSPACE%\\roslyn-internal
 git submodule init
 git submodule sync
 git submodule update --init --recursive
+init.cmd
 """)
 
             // Build the SDK and install .NET Core Templates.
             batchFile("""
-echo *** Build the SDK  ***
+echo *** Build the SDK and install .NET Core Templates  ***
 SET VS150COMNTOOLS=%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\Enterprise\\Common7\\Tools\\
 SET DeveloperCommandPrompt=%VS150COMNTOOLS%\\VsMSBuildCmd.bat
 
@@ -103,6 +104,28 @@ SET VSSDKInstall=%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\Enterprise\
 pushd %WORKSPACE%\\sdk
 echo *** Build SDK
 call build.cmd -Configuration release -SkipTests || goto :BuildFailed "SDK"
+
+SET VSIXExpInstallerExe=%USERPROFILE%\\.nuget\\packages\\roslyntools.microsoft.vsixexpinstaller\\0.2.4-beta\\tools\\VsixExpInstaller.exe
+
+SET VSIXTarget=%WORKSPACE%\\sdk\\bin\\Release\\Microsoft.VisualStudio.ProjectSystem.CSharp.NetStandard.Templates.vsix
+echo *** Install %VSIXTarget%
+%VSIXExpInstallerExe% /rootsuffix:RoslynDev %VSIXTarget%
+if not "%ERRORLEVEL%"=="0" echo ERROR: %VSIXTarget% did not install successfully
+
+SET VSIXTarget=%WORKSPACE%\\sdk\\bin\\Release\\Microsoft.VisualStudio.ProjectSystem.CSharp.Templates.vsix
+echo *** Install %VSIXTarget%
+%VSIXExpInstallerExe% /rootsuffix:RoslynDev %VSIXTarget%
+if not "%ERRORLEVEL%"=="0" echo ERROR: %VSIXTarget% did not install successfully
+
+SET VSIXTarget=%WORKSPACE%\\sdk\\bin\\Release\\Microsoft.VisualStudio.ProjectSystem.VisualBasic.NetStandard.Templates.vsix
+echo *** Install %VSIXTarget%
+%VSIXExpInstallerExe% /rootsuffix:RoslynDev %VSIXTarget%
+if not "%ERRORLEVEL%"=="0" echo ERROR: %VSIXTarget% did not install successfully
+
+SET VSIXTarget=%WORKSPACE%\\sdk\\bin\\Release\\Microsoft.VisualStudio.ProjectSystem.VisualBasic.Templates.vsix
+echo *** Install %VSIXTarget%
+%VSIXExpInstallerExe% /rootsuffix:RoslynDev %VSIXTarget%
+if not "%ERRORLEVEL%"=="0" echo ERROR: %VSIXTarget% did not install successfully
 
 exit /b 0
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -90,7 +90,7 @@ git submodule update --init --recursive
 
             // Build the SDK and install .NET Core Templates.
             batchFile("""
-echo *** Build the SDK and install .NET Core Templates  ***
+echo *** Build the SDK  ***
 SET VS150COMNTOOLS=%ProgramFiles(x86)%\\Microsoft Visual Studio\\2017\\Enterprise\\Common7\\Tools\\
 SET DeveloperCommandPrompt=%VS150COMNTOOLS%\\VsMSBuildCmd.bat
 
@@ -122,8 +122,6 @@ pushd %WORKSPACE%\\roslyn-internal
 set TEMP=%WORKSPACE%\\roslyn-internal\\Open\\Binaries\\Temp
 mkdir %TEMP%
 set TMP=%TEMP%
-
-set EchoOn=true
 
 BuildAndTest.cmd -build:true -clean:false -deployExtensions:true -trackFileAccess:false -officialBuild:false -realSignBuild:false -parallel:true -release:true -delaySignBuild:true -samples:false -unit:false -eta:false -vs:true -cibuild:true -x64:false -netcoretestrun
 """)


### PR DESCRIPTION
1. moving the Roslyn-Internal pointer forward to consume the latest changes; adding 2 VSI tests & a fix to Raul's codemarker stuff
2. temporary workaround for the microbuild.plugins.swixbuild cache build error in Roslyn-Project-System