### PR TITLE
Use RunningInMicroBuild instead of OfficialBuild

### DIFF
--- a/build/Targets/GenerateAssemblyInfo.targets
+++ b/build/Targets/GenerateAssemblyInfo.targets
@@ -1,6 +1,6 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Choose>
-    <When Condition="'$(OfficialBuild)' != 'true'">
+    <When Condition="'$(RunningInMicroBuild)' != 'true'">
       <!-- On non-official builds we don't burn in a git sha.  In large part because it 
            hurts our determinism efforts as binaries which should be the same between
            builds will not (due to developers building against different HEAD 


### PR DESCRIPTION
When the build is run in Microbuild, we use the property RunningInMicroBuild and not OfficialBuild.

@natidea Today, the official binary has the product version as Developer build. Should we take this for 15.1?
 
![image](https://cloud.githubusercontent.com/assets/10550513/23804266/2c193808-056e-11e7-95a6-2449812c1eb4.png)


@dotnet/project-system for review