### PR TITLE
Import IProjectServiceAccessor directly instead of GetService indirection

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IServiceProviderExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IServiceProviderExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.VisualStudio.ComponentModelHost;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
@@ -23,28 +22,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         public static ServiceType GetService<ServiceType>(this IServiceProvider sp) where ServiceType : class
         {
             return sp.GetService<ServiceType, ServiceType>();
-        }
-
-        /// <summary>
-        /// Returns IProjectService a global scope component that provdes data accross all CPS projects
-        /// </summary>
-        /// <param name="sp"></param>
-        /// <returns></returns>
-        public static IProjectService GetProjectService(this IServiceProvider sp)
-        {
-            var componentModel = sp.GetService(typeof(SComponentModel)) as IComponentModel;
-            if (componentModel == null)
-            {
-                return null;
-            }
-
-            var projectServiceAccessor = componentModel.GetService<IProjectServiceAccessor>();
-            if (projectServiceAccessor == null)
-            {
-                return null;
-            }
-
-            return projectServiceAccessor.GetProjectService();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesGraphProjectContextProvider.cs
@@ -5,7 +5,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.ProjectSystem.VS.Extensibility;
-using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
@@ -19,15 +18,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     {
         [ImportingConstructor]
         public DependenciesGraphProjectContextProvider(IProjectExportProvider projectExportProvider, 
-                                                       SVsServiceProvider serviceProvider)
+                                                       IProjectServiceAccessor projectServiceAccessor)
         {
-            ServiceProvider = serviceProvider;
+            ProjectServiceAccessor = projectServiceAccessor;
             ProjectExportProvider = projectExportProvider;
         }
 
         private IProjectExportProvider ProjectExportProvider { get; }
 
-        private SVsServiceProvider ServiceProvider { get; }
+        private IProjectServiceAccessor ProjectServiceAccessor { get; }
 
         private ConcurrentDictionary<string, IDependenciesGraphProjectContext> ProjectContexts { get; }
                             = new ConcurrentDictionary<string, IDependenciesGraphProjectContext>
@@ -101,18 +100,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
         public IEnumerable<IDependenciesGraphProjectContext> GetProjectContexts()
         {
-            var projectService = ServiceProvider.GetProjectService();
-            if (projectService == null)
-            {
-                return null;
-            }
+            var projectService = ProjectServiceAccessor.GetProjectService();
 
-            return GetProjectContextsInternal(projectService);
-        }
-
-        internal IEnumerable<IDependenciesGraphProjectContext> GetProjectContextsInternal(
-                    IProjectService projectService)
-        {
             var projects = projectService.LoadedUnconfiguredProjects;
             foreach (var project in projects)
             {


### PR DESCRIPTION
- Import IProjectServiceAccessor directly instead of GetService indirection

We're a MEF component, we can just import it directly instead of asking through IComponentModel.