### PR TITLE
Add C# 7.1/Latest versions to project system

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/AdvBuildSettingsPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AdvBuildSettingsPropPage.resx
@@ -753,4 +753,10 @@
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase, Microsoft.VisualStudio.AppDesigner, Version=42.42.42.42, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="CSharpLanguageVerison.Default" xml:space="preserve">
+    <value>C# latest major version (default)</value>
+  </data>
+  <data name="CSharpLanguageVerison.Latest" xml:space="preserve">
+    <value>C# latest minor version (latest)</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CSharpLanguageVersion.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CSharpLanguageVersion.vb
@@ -7,7 +7,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     ''' </summary>
     Friend Class CSharpLanguageVersion
 
+        Private Shared ReadOnly _resources As ComponentModel.ComponentResourceManager = New ComponentModel.ComponentResourceManager(GetType(AdvBuildSettingsPropPage))
+
         Private Const s_languageVersion_Default As String = "default"
+        Private Const s_languageVersion_Latest As String = "latest"
         Private Const s_languageVersion_ISO1 As String = "ISO-1"
         Private Const s_languageVersion_ISO2 As String = "ISO-2"
         Private Const s_languageVersion_3 As String = "3"
@@ -20,6 +23,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private Const s_languageVersion_DisplayNameFor6 As String = "C# 6.0"
         Private Const s_languageVersion_7 As String = "7"
         Private Const s_languageVersion_DisplayNameFor7 As String = "C# 7.0"
+        Private Const s_languageVersion_7_1 As String = "7.1"
+        Private Const s_languageVersion_DisplayNameFor7_1 As String = "C# 7.1"
 
         ''' <summary>
         ''' Stores the property value corresponding to the language version
@@ -62,7 +67,17 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         Public Shared ReadOnly Property [Default]() As CSharpLanguageVersion
             Get
-                Static value As New CSharpLanguageVersion(s_languageVersion_Default, s_languageVersion_Default)
+                Static value As New CSharpLanguageVersion(s_languageVersion_Default, _resources.GetString("CSharpLanguageVerison.Default"))
+                Return value
+            End Get
+        End Property
+
+        ''' <summary>
+        ''' Return the 'latest' language version object
+        ''' </summary>
+        Public Shared ReadOnly Property Latest() As CSharpLanguageVersion
+            Get
+                Static value As New CSharpLanguageVersion(s_languageVersion_Latest, _resources.GetString("CSharpLanguageVerison.Latest"))
                 Return value
             End Get
         End Property
@@ -133,6 +148,16 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Public Shared ReadOnly Property Version7() As CSharpLanguageVersion
             Get
                 Static value As New CSharpLanguageVersion(s_languageVersion_7, s_languageVersion_DisplayNameFor7)
+                Return value
+            End Get
+        End Property
+
+        ''' <summary>
+        ''' Return the C# 7.1 language version object
+        ''' </summary>
+        Public Shared ReadOnly Property Version7_1() As CSharpLanguageVersion
+            Get
+                Static value As New CSharpLanguageVersion(s_languageVersion_7_1, s_languageVersion_DisplayNameFor7_1)
                 Return value
             End Get
         End Property

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CSharpLanguageVersionUtilities.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CSharpLanguageVersionUtilities.vb
@@ -16,13 +16,15 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
             Return New CSharpLanguageVersion() {
                 CSharpLanguageVersion.Default,
+                CSharpLanguageVersion.Latest,
                 CSharpLanguageVersion.ISO1,
                 CSharpLanguageVersion.ISO2,
                 CSharpLanguageVersion.Version3,
                 CSharpLanguageVersion.Version4,
                 CSharpLanguageVersion.Version5,
                 CSharpLanguageVersion.Version6,
-                CSharpLanguageVersion.Version7}
+                CSharpLanguageVersion.Version7,
+                CSharpLanguageVersion.Version7_1}
 
         End Function
 


### PR DESCRIPTION
cc @davkean @jcouv @VSadov @jaredpar 

This adds 7.1 language version, and a "Latest" option. More details in https://github.com/dotnet/roslyn/issues/17173

![image](https://cloud.githubusercontent.com/assets/15987992/23975914/3aeaac90-09a1-11e7-88e7-cc0ef42a70f2.png)

A few notes, please let me know if I missed something.
1. Noticed this area is not covered by any tests.
2. The strings are not localized as well (default item).
3. This version is intended for VS 15.3. Is `master` the correct branch to use?