### PR TITLE
Ignore line ending differences

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/ProjectSystem/ProjectTreeParserTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/ProjectSystem/ProjectTreeParserTests.cs
@@ -406,7 +406,7 @@ Root
 
             string result = writer.WriteToString();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, result, ignoreLineEndingDifferences: true);
         }
 
         private void AssertThrows(string input, ProjectTreeFormatError error)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -308,7 +308,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             Assert.Equal(moqFS.LastFileWriteTime(provider.LaunchSettingsFile), provider.LastSettingsFileSyncTimeTest);
 
             // Check disk contents
-            Assert.Equal(JsonStringWithWebSettings, moqFS.ReadAllText(provider.LaunchSettingsFile));
+            Assert.Equal(JsonStringWithWebSettings, moqFS.ReadAllText(provider.LaunchSettingsFile), ignoreLineEndingDifferences:true);
         }
 
         [Fact]
@@ -427,7 +427,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             await provider.UpdateAndSaveSettingsAsync(testSettings.Object).ConfigureAwait(true);
 
             // Check disk contents
-            Assert.Equal(JsonStringWithWebSettings, moqFS.ReadAllText(provider.LaunchSettingsFile));
+            Assert.Equal(JsonStringWithWebSettings, moqFS.ReadAllText(provider.LaunchSettingsFile), ignoreLineEndingDifferences:true);
 
             // Check snapshot
             Assert.Equal(2, provider.CurrentSnapshot.Profiles.Count);


### PR DESCRIPTION
Fixes: #1765

These tests hard-code strings with new embedded new lines. Ignore these differences so that clone with Git set to use \n doesn't cause them to fail.