### PR TITLE
Pass empty as add item template GUID instead of project GUID in AbstractAddClassProjectCommand

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractAddClassProjectCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractAddClassProjectCommandTests.cs
@@ -114,13 +114,8 @@ Root (flags: {ProjectRoot})
         [Fact]
         public async Task GetCommandStatusAsync_FolderAsNodes_ReturnsHandled()
         {
-
-            var projectProperties = ProjectPropertiesFactory.Create(UnconfiguredProjectFactory.Create(), new[] {
-                    new PropertyPageData { Category = ConfigurationGeneral.SchemaName, PropertyName = ConfigurationGeneral.ProjectGuidProperty, Value = Guid.NewGuid().ToString() }
-                });
-
             var command = CreateInstance(provider: IProjectTreeProviderFactory.Create(""), dlg:
-                IVsAddProjectItemDlgFactory.Create(0), properties: () => projectProperties);
+                IVsAddProjectItemDlgFactory.Create(0));
 
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot})
@@ -139,12 +134,8 @@ Root (flags: {ProjectRoot})
         [Fact]
         public async Task TryHandleCommandAsync_FolderAsNodes_ReturnsTrue()
         {
-            var projectProperties = ProjectPropertiesFactory.Create(UnconfiguredProjectFactory.Create(), new[] {
-                    new PropertyPageData { Category = ConfigurationGeneral.SchemaName, PropertyName = ConfigurationGeneral.ProjectGuidProperty, Value = Guid.NewGuid().ToString() }
-                });
-
             var command = CreateInstance(provider: IProjectTreeProviderFactory.Create(""), dlg:
-                IVsAddProjectItemDlgFactory.Create(0), properties: () => projectProperties);
+                IVsAddProjectItemDlgFactory.Create(0));
 
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot})
@@ -181,7 +172,7 @@ Root (flags: {ProjectRoot})
                     new PropertyPageData { Category = ConfigurationGeneral.SchemaName, PropertyName = ConfigurationGeneral.ProjectGuidProperty, Value = g.ToString() }
                 });
 
-            var command = CreateInstance(provider: IProjectTreeProviderFactory.Create(folder), dlg: dlg, properties: () => projectProperties);
+            var command = CreateInstance(provider: IProjectTreeProviderFactory.Create(folder), dlg: dlg);
 
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot})
@@ -205,7 +196,7 @@ Root (flags: {ProjectRoot})
                 });
 
             var command = CreateInstance(provider: IProjectTreeProviderFactory.Create(""), dlg:
-                IVsAddProjectItemDlgFactory.Create(VSConstants.OLE_E_PROMPTSAVECANCELLED), properties: () => projectProperties);
+                IVsAddProjectItemDlgFactory.Create(VSConstants.OLE_E_PROMPTSAVECANCELLED));
 
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot})
@@ -224,10 +215,10 @@ Root (flags: {ProjectRoot})
 
         internal abstract string DirName { get; }
 
-        internal AbstractAddClassProjectCommand CreateInstance(IPhysicalProjectTree projectTree = null, IUnconfiguredProjectVsServices projectVsServices = null, Shell.SVsServiceProvider serviceProvider = null, IProjectTreeProvider provider = null, IVsAddProjectItemDlg dlg = null, Func<ProjectProperties> properties = null)
+        internal AbstractAddClassProjectCommand CreateInstance(IPhysicalProjectTree projectTree = null, IUnconfiguredProjectVsServices projectVsServices = null, Shell.SVsServiceProvider serviceProvider = null, IProjectTreeProvider provider = null, IVsAddProjectItemDlg dlg = null)
         {
             projectTree = projectTree ?? IPhysicalProjectTreeFactory.Create(provider);
-            projectVsServices = projectVsServices ?? IUnconfiguredProjectVsServicesFactory.Implement(projectProperties: properties);
+            projectVsServices = projectVsServices ?? IUnconfiguredProjectVsServicesFactory.Implement(threadingServiceCreator: () => IProjectThreadingServiceFactory.Create());
             serviceProvider = serviceProvider ?? SVsServiceProviderFactory.Create(dlg);
 
             return CreateInstance(projectTree, projectVsServices, serviceProvider);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractAddClassProjectCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractAddClassProjectCommand.cs
@@ -46,10 +46,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
                 return false;
             }
 
-            ConfigurationGeneral projectProperties =
-                            await _projectVsServices.ActiveConfiguredProjectProperties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(false);
-            Guid guid = new Guid((string)await projectProperties.ProjectGuid.GetValueAsync().ConfigureAwait(false));
-
             __VSADDITEMFLAGS uiFlags = __VSADDITEMFLAGS.VSADDITEM_AddNewItems | __VSADDITEMFLAGS.VSADDITEM_SuggestTemplateName | __VSADDITEMFLAGS.VSADDITEM_AllowHiddenTreeView;
 
             string strBrowseLocations = _projectTree.TreeProvider.GetAddNewItemDirectory(node);
@@ -59,7 +55,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 
             IVsAddProjectItemDlg addItemDialog = _serviceProvider.GetService<IVsAddProjectItemDlg, SVsAddProjectItemDlg>();
             Assumes.Present(addItemDialog);
-            HResult res = addItemDialog.AddProjectItemDlg(node.GetHierarchyId(), ref guid, _projectVsServices.VsProject, (uint)uiFlags,
+
+            Guid addItemTemplateGuid = Guid.Empty;  // Let the dialog ask the hierarchy itself
+            HResult res = addItemDialog.AddProjectItemDlg(node.GetHierarchyId(), ref addItemTemplateGuid, _projectVsServices.VsProject, (uint)uiFlags,
                 DirName, VSResources.ClassTemplateName, ref strBrowseLocations, ref strFilter, out int iDontShowAgain);
 
             // Return true here regardless of whether or not the user clicked OK or they clicked Cancel. This ensures that some other


### PR DESCRIPTION
- Pass empty as add item template GUID instead of project

AddItemDialog isn't expecting the project GUID - it's expecting the Add Item Template GUID. We pass empty here - as it ends up asking the hierarchy for it, see CAddProjectItemDlg::AddProjectItemDlgTitledEx.