### PR TITLE
Handle Robocopy success code

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -84,7 +84,10 @@ for %%T IN (Restore %MSBuildBuildTarget%, BuildModernVsixPackages) do (
 
 REM Run copy as a final step after all the product components are built
 if /I "%CopyOutputArtifacts%" == "true" (
-  call %ROOT%build\Scripts\CopyOutput.cmd || goto :BuildFailed
+  call %ROOT%build\Scripts\CopyOutput.cmd
+
+  REM Robocopy has a return code 0 - 7 on success
+  if %ERRORLEVEL% gtr 7 goto BuildFailed
 )
 
 echo.


### PR DESCRIPTION
Robocopy has a success return ranging from 0-7 which build.cmd was not handling. Fixing the script.

@dotnet/project-system for review