### PR TITLE
Scale Debug property page using Font

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.Designer.vb
@@ -241,6 +241,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             'DebugPropPage
             '
             resources.ApplyResources(Me, "$this")
+            Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
             Me.Controls.Add(Me.overarchingTableLayoutPanel)
             Me.Name = "DebugPropPage"
             Me.overarchingTableLayoutPanel.ResumeLayout(False)

--- a/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.resx
@@ -984,6 +984,12 @@
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="$this.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
   </data>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.vb
@@ -19,6 +19,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
             'Add any initialization after the InitializeComponent() call
             AddChangeHandlers()
+
+            'Opt out of page scaling since we're using AutoScaleMode
+            PageRequiresScaling = False
         End Sub
 
 


### PR DESCRIPTION
Scale Debug property page using Font

**Customer scenario**

Opening the Debug property page on machines with a DPI less than 96 makes the page unusable.
Opening the Debug property page on machines with a DPI greater than 96 makes the middle column of the page squashed and too small.

**Bugs this fixes:**

Fixes: #427

**Workarounds, if any**

None

**Risk**

Low but if done incorrectly could result in making >96 DPI unusable. The page is unusable under 96 DPI, so there's very little risk of making that worse.

**Performance impact**

None.

**Is this a regression from a previous update?**

We made the dialog worse in VS 2017 on machines under 96 DPI when we changed the layout slightly.

**Root cause analysis:**

The Debug property page was using .NET 1.0-era DPI scaling. This had two issues:

1) Under DPIs less than 96 DPI, this was downscaling the page.
2) Under DPIs greater than 96 DPI, this wasn't scaling the TableLayout columns, resulting in squashed columns. These columns aren't scaled because this control didn't exist in .NET 1.0.

Opt into the .NET 2.0-era Font scaling similar to the rest of WinForms dialogs and pages around Visual Studio, this results in more accurate scaling across all DPIs, and used by other pages such as the Application page.

**How was the bug found?**

Many reports via VSFeedback, GitHub and emails.

**Before: (192 DPI machine):**
![image](https://cloud.githubusercontent.com/assets/1103906/24130913/98135438-0e3f-11e7-8fd9-ca0c27c01bed.png)

**After (192 DPI machine):**
![image](https://cloud.githubusercontent.com/assets/1103906/24130901/7e2b9f26-0e3f-11e7-8ce0-478484e37f93.png)

**Before (92 DPI machine):**
![image](https://cloud.githubusercontent.com/assets/1103906/24176455/2bff7748-0ef0-11e7-80ad-9b91411d7689.png)

**After(92 DPI machine):**
![image](https://cloud.githubusercontent.com/assets/1103906/24176477/49623bae-0ef0-11e7-9b20-499a2ff16782.png)

