### PR TITLE
Scale Build property page using Font

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.Designer.vb
@@ -364,6 +364,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             'BuildPropPage
             '
             resources.ApplyResources(Me, "$this")
+            Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
             Me.Controls.Add(Me.overarchingTableLayoutPanel)
             Me.Name = "BuildPropPage"
             Me.overarchingTableLayoutPanel.ResumeLayout(False)

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.resx
@@ -1368,6 +1368,9 @@
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
   <data name="$this.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
@@ -6,7 +6,6 @@ Imports System.ComponentModel
 Imports System.IO
 Imports System.Windows.Forms
 Imports Microsoft.VisualStudio.Editors.Common
-Imports Microsoft.VisualStudio.PlatformUI
 Imports Microsoft.VisualStudio.Shell.Interop
 Imports VSLangProj80
 Imports VSLangProj110
@@ -39,12 +38,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             'This call is required by the Windows Form Designer.
             InitializeComponent()
 
-            'Scale horizontally
-            cboPlatformTarget.Width = DpiHelper.LogicalToDeviceUnitsX(cboPlatformTarget.Width)
-            overarchingTableLayoutPanel.Width = DpiHelper.LogicalToDeviceUnitsX(overarchingTableLayoutPanel.Width)
-
             'Add any initialization after the InitializeComponent() call
             AddChangeHandlers()
+
+            'Opt out of page scaling since we're using AutoScaleMode
+            PageRequiresScaling = False
         End Sub
 
 


### PR DESCRIPTION
Scale Build property page using Font

The Build property page was using .NET 1.0-era DPI scaling. This had two issues:

1) Under DPIs less than 96 DPI, this was downscaling the page.
2) Under DPIs greater than 96 DPI, this wasn't scaling the TableLayout columns, resulting in squashed columns.

Opt into the .NET 2.0-era Font scaling similar to the rest of WinForms dialogs and pages around Visual Studio, this results in more accurate scaling across all DPIs, and used by other pages such as the Application page.

Also removed the manual DpiHelper scaling - this was compensating for the lack of scaling of the columns and actually causing it to be too wide on high DPIs resulting in a horizontal scroll bar.

Fixes: #820 #1374

Before at 200% on a 96 DPI machine:
![image](https://cloud.githubusercontent.com/assets/1103906/24130993/13755f9a-0e40-11e7-87b2-260abedda0a6.png)

After at 200% on a 96 DPI machine:
![image](https://cloud.githubusercontent.com/assets/1103906/24130984/02114c6e-0e40-11e7-8e2c-6e46c0ca42dd.png)
