### PR TITLE
Move the Nuget Version value from hard coded value to a variable

### DIFF
--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -126,7 +126,7 @@
         <PackageReference Include="Microsoft.VisualStudio.WCFReference.Interop" Version="9.0.30729" />
         <PackageReference Include="Microsoft.VisualStudio.Data.Core" Version="9.0.21022" />
         <PackageReference Include="Microsoft.VisualStudio.Data.Services" Version="9.0.21022" />
-        <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.10.0" Version="10.0.30319" />
+        <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.10.0" Version="$(MicrosoftVisualStudioTextManagerInterop10Version)" />
         <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.10.0" Version="$(MicrosoftVisualStudioShellInterop10Version)" />
         <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.11.0" Version="$(MicrosoftVisualStudioShellInterop11Version)" />
         <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.0" Version="12.0.30110" />

--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -65,7 +65,7 @@
         <Reference Include="System.Xaml" />
 
         <!-- NuGet Dependencies -->
-        <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
+        <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
         <PackageReference Include="System.Reflection.Metadata" Version="1.4.1-beta-24430-01" />
         <PackageReference Include="System.ValueTuple" Version="4.3.0" />
         <PackageReference Include="Microsoft.Composition" Version="1.0.27" />

--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -127,7 +127,7 @@
         <PackageReference Include="Microsoft.VisualStudio.Data.Core" Version="9.0.21022" />
         <PackageReference Include="Microsoft.VisualStudio.Data.Services" Version="9.0.21022" />
         <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.10.0" Version="10.0.30319" />
-        <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.10.0" Version="10.0.30319" />
+        <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.10.0" Version="$(MicrosoftVisualStudioShellInterop10Version)" />
         <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.11.0" Version="11.0.61030" />
         <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.0" Version="12.0.30110" />
         <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime" Version="12.1.30328" />

--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -128,7 +128,7 @@
         <PackageReference Include="Microsoft.VisualStudio.Data.Services" Version="9.0.21022" />
         <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.10.0" Version="10.0.30319" />
         <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.10.0" Version="$(MicrosoftVisualStudioShellInterop10Version)" />
-        <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.11.0" Version="11.0.61030" />
+        <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.11.0" Version="$(MicrosoftVisualStudioShellInterop11Version)" />
         <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.0" Version="12.0.30110" />
         <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime" Version="12.1.30328" />
         <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.1.DesignTime" Version="12.1.30328" />

--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -89,7 +89,7 @@
     <When Condition="'$(IncludeCPSReferences)' == 'true'">
       <ItemGroup>
 
-        <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="15.0.5-pre-g4382fbdb8f" PrivateAssets="None" />
+        <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="15.3.5-pre-g4382fbdb8f" PrivateAssets="None" />
 
       </ItemGroup>
     </When>

--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -89,7 +89,7 @@
     <When Condition="'$(IncludeCPSReferences)' == 'true'">
       <ItemGroup>
 
-        <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="15.0.737" PrivateAssets="None" />
+        <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="15.0.5-pre-g4382fbdb8f" PrivateAssets="None" />
 
       </ItemGroup>
     </When>

--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -136,7 +136,7 @@
         <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="14.1.2" />
         <PackageReference Include="Microsoft.VisualStudio.Editor" Version="15.0.25726-Preview5" />
         <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="15.0.25726-Preview5" />
-        <PackageReference Include="Microsoft.VisualStudio.Shell.Design" Version="15.0.26201" />
+        <PackageReference Include="Microsoft.VisualStudio.Shell.Design" Version="$(MicrosoftVisualStudioShellDesign)" />
         <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell15Version)" />
         <PackageReference Include="RoslynDependencies.Microsoft.VisualStudio.GraphModel" Version="15.0.25807" />
         <PackageReference Include="Microsoft.VisualStudio.Telemetry" Version="15.0.691-master31907920" ExcludeAssets="Build" />

--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -122,7 +122,7 @@
 
         <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.0.26124-rc3" />
         <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" Version="1.1.4322" />
-        <PackageReference Include="Microsoft.VisualStudio.ManagedInterfaces" Version="8.0.50727" />
+        <PackageReference Include="Microsoft.VisualStudio.ManagedInterfaces" Version="$(MicrosoftVisualStudioManagedInterfaces)" />
         <PackageReference Include="Microsoft.VisualStudio.WCFReference.Interop" Version="9.0.30729" />
         <PackageReference Include="Microsoft.VisualStudio.Data.Core" Version="9.0.21022" />
         <PackageReference Include="Microsoft.VisualStudio.Data.Services" Version="9.0.21022" />

--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -137,7 +137,7 @@
         <PackageReference Include="Microsoft.VisualStudio.Editor" Version="15.0.25726-Preview5" />
         <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="15.0.25726-Preview5" />
         <PackageReference Include="Microsoft.VisualStudio.Shell.Design" Version="15.0.26201" />
-        <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.0.26201" />
+        <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell15Version)" />
         <PackageReference Include="RoslynDependencies.Microsoft.VisualStudio.GraphModel" Version="15.0.25807" />
         <PackageReference Include="Microsoft.VisualStudio.Telemetry" Version="15.0.691-master31907920" ExcludeAssets="Build" />
 

--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -89,7 +89,7 @@
     <When Condition="'$(IncludeCPSReferences)' == 'true'">
       <ItemGroup>
 
-        <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="15.3.5-pre-g4382fbdb8f" PrivateAssets="None" />
+        <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="$(ProjectSystemSDKVersion)" PrivateAssets="None" />
 
       </ItemGroup>
     </When>

--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -129,7 +129,7 @@
         <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.10.0" Version="$(MicrosoftVisualStudioTextManagerInterop10Version)" />
         <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.10.0" Version="$(MicrosoftVisualStudioShellInterop10Version)" />
         <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.11.0" Version="$(MicrosoftVisualStudioShellInterop11Version)" />
-        <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.0" Version="12.0.30110" />
+        <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.0" Version="$(MicrosoftVisualStudioTextManagerInterop12Version)" />
         <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime" Version="12.1.30328" />
         <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.1.DesignTime" Version="12.1.30328" />
         <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime" Version="14.1.24720" />

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -25,6 +25,7 @@
     <MicrosoftVisualStudioTextManagerInterop10Version>10.0.30319</MicrosoftVisualStudioTextManagerInterop10Version>
     <MicrosoftVisualStudioTextManagerInterop12Version>12.0.30110</MicrosoftVisualStudioTextManagerInterop12Version>
     <MicrosoftVisualStudioShell15Version>15.0.26201</MicrosoftVisualStudioShell15Version>
+    <MicrosoftVisualStudioShellDesign>15.0.26201</MicrosoftVisualStudioShellDesign>
   </PropertyGroup>
 
   <Choose>

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -24,6 +24,7 @@
     <MicrosoftVisualStudioShellInterop11Version>11.0.61030</MicrosoftVisualStudioShellInterop11Version>
     <MicrosoftVisualStudioTextManagerInterop10Version>10.0.30319</MicrosoftVisualStudioTextManagerInterop10Version>
     <MicrosoftVisualStudioTextManagerInterop12Version>12.0.30110</MicrosoftVisualStudioTextManagerInterop12Version>
+    <MicrosoftVisualStudioShell15Version>15.0.26201</MicrosoftVisualStudioShell15Version>
   </PropertyGroup>
 
   <Choose>

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -19,6 +19,7 @@
 
   <PropertyGroup>
     <ProjectSystemSDKVersion>15.3.5-pre-g4382fbdb8f</ProjectSystemSDKVersion>
+    <SystemCollectionsImmutableVersion>1.3.1</SystemCollectionsImmutableVersion>
   </PropertyGroup>
 
   <Choose>

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -20,6 +20,7 @@
   <PropertyGroup>
     <ProjectSystemSDKVersion>15.3.5-pre-g4382fbdb8f</ProjectSystemSDKVersion>
     <SystemCollectionsImmutableVersion>1.3.1</SystemCollectionsImmutableVersion>
+    <MicrosoftVisualStudioShellInterop10Version>10.0.30319</MicrosoftVisualStudioShellInterop10Version>
   </PropertyGroup>
 
   <Choose>

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -61,13 +61,13 @@
 
   <!-- NuGet version -->
   <PropertyGroup>
-    <VSSemanticVersion>15.0</VSSemanticVersion>
+    <VSSemanticVersion>15.3</VSSemanticVersion>
 
     <RoslynNuGetReleaseVersion>$(RoslynSemanticVersion.Substring(0, $(RoslynSemanticVersion.LastIndexOf('.'))))</RoslynNuGetReleaseVersion>
-    <RoslynNuGetPerBuildReleaseVersion Condition="'$(BuildNumberFiveDigitDateStamp)' != '' AND '$(BuildNumberBuildOfTheDayPadded)' != ''">$(RoslynNuGetReleaseVersion).$(BuildNumberFiveDigitDateStamp.Trim())$(BuildNumberBuildOfTheDayPadded.Trim())</RoslynNuGetPerBuildReleaseVersion>
-    <RoslynNuGetPerBuildReleaseVersion Condition="'$(RoslynNuGetPerBuildReleaseVersion)' == ''">1.0.0</RoslynNuGetPerBuildReleaseVersion>
-    <VSNuGetPerBuildReleaseVersion Condition="'$(BuildNumberFiveDigitDateStamp)' != '' AND '$(BuildNumberBuildOfTheDayPadded)' != ''">$(VSSemanticVersion).$(BuildNumberFiveDigitDateStamp.Trim())$(BuildNumberBuildOfTheDayPadded.Trim())</VSNuGetPerBuildReleaseVersion>
-    <VSNuGetPerBuildReleaseVersion Condition="'$(VSNuGetPerBuildReleaseVersion)' == ''">1.0.0</VSNuGetPerBuildReleaseVersion>
+    <RoslynNuGetPerBuildVersion Condition="'$(BuildNumberFiveDigitDateStamp)' != '' AND '$(BuildNumberBuildOfTheDayPadded)' != ''">$(RoslynNuGetReleaseVersion).rc-$(BuildNumberFiveDigitDateStamp.Trim())$(BuildNumberBuildOfTheDayPadded.Trim())</RoslynNuGetPerBuildVersion>
+    <RoslynNuGetPerBuildVersion Condition="'$(RoslynNuGetPerBuildVersion)' == ''">1.0.0-rc</RoslynNuGetPerBuildVersion>
+    <VSNuGetPerBuildVersion Condition="'$(BuildNumberFiveDigitDateStamp)' != '' AND '$(BuildNumberBuildOfTheDayPadded)' != ''">$(VSSemanticVersion).rc-$(BuildNumberFiveDigitDateStamp.Trim())$(BuildNumberBuildOfTheDayPadded.Trim())</VSNuGetPerBuildVersion>
+    <VSNuGetPerBuildVersion Condition="'$(VSNuGetPerBuildVersion)' == ''">1.0.0-rc</VSNuGetPerBuildVersion>
   </PropertyGroup>
   
 </Project>

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -22,6 +22,7 @@
     <SystemCollectionsImmutableVersion>1.3.1</SystemCollectionsImmutableVersion>
     <MicrosoftVisualStudioShellInterop10Version>10.0.30319</MicrosoftVisualStudioShellInterop10Version>
     <MicrosoftVisualStudioShellInterop11Version>11.0.61030</MicrosoftVisualStudioShellInterop11Version>
+    <MicrosoftVisualStudioTextManagerInterop10Version>10.0.30319</MicrosoftVisualStudioTextManagerInterop10Version>
   </PropertyGroup>
 
   <Choose>

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -23,6 +23,7 @@
     <MicrosoftVisualStudioShellInterop10Version>10.0.30319</MicrosoftVisualStudioShellInterop10Version>
     <MicrosoftVisualStudioShellInterop11Version>11.0.61030</MicrosoftVisualStudioShellInterop11Version>
     <MicrosoftVisualStudioTextManagerInterop10Version>10.0.30319</MicrosoftVisualStudioTextManagerInterop10Version>
+    <MicrosoftVisualStudioTextManagerInterop12Version>12.0.30110</MicrosoftVisualStudioTextManagerInterop12Version>
   </PropertyGroup>
 
   <Choose>

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -17,6 +17,10 @@
     <BuildNumberBuildOfTheDayPadded Condition="('$(BuildNumber)' != '') AND ($(BuildNumber.Split('.').Length) == 2)">$(BuildNumber.Split('.')[1].PadLeft(2,'0'))</BuildNumberBuildOfTheDayPadded>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <ProjectSystemSDKVersion>15.3.5-pre-g4382fbdb8f</ProjectSystemSDKVersion>
+  </PropertyGroup>
+
   <Choose>
     <When Condition="'$(BuildVersion)' != ''">
       <!-- The user specified a build version number. In that case, we'll use their version number
@@ -62,7 +66,6 @@
   <!-- NuGet version -->
   <PropertyGroup>
     <VSSemanticVersion>15.3</VSSemanticVersion>
-
     <RoslynNuGetReleaseVersion>$(RoslynSemanticVersion.Substring(0, $(RoslynSemanticVersion.LastIndexOf('.'))))</RoslynNuGetReleaseVersion>
     <RoslynNuGetPerBuildVersion Condition="'$(BuildNumberFiveDigitDateStamp)' != '' AND '$(BuildNumberBuildOfTheDayPadded)' != ''">$(RoslynNuGetReleaseVersion).rc-$(BuildNumberFiveDigitDateStamp.Trim())$(BuildNumberBuildOfTheDayPadded.Trim())</RoslynNuGetPerBuildVersion>
     <RoslynNuGetPerBuildVersion Condition="'$(RoslynNuGetPerBuildVersion)' == ''">1.0.0-rc</RoslynNuGetPerBuildVersion>

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -21,6 +21,7 @@
     <ProjectSystemSDKVersion>15.3.5-pre-g4382fbdb8f</ProjectSystemSDKVersion>
     <SystemCollectionsImmutableVersion>1.3.1</SystemCollectionsImmutableVersion>
     <MicrosoftVisualStudioShellInterop10Version>10.0.30319</MicrosoftVisualStudioShellInterop10Version>
+    <MicrosoftVisualStudioShellInterop11Version>11.0.61030</MicrosoftVisualStudioShellInterop11Version>
   </PropertyGroup>
 
   <Choose>

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -26,6 +26,7 @@
     <MicrosoftVisualStudioTextManagerInterop12Version>12.0.30110</MicrosoftVisualStudioTextManagerInterop12Version>
     <MicrosoftVisualStudioShell15Version>15.0.26201</MicrosoftVisualStudioShell15Version>
     <MicrosoftVisualStudioShellDesign>15.0.26201</MicrosoftVisualStudioShellDesign>
+    <MicrosoftVisualStudioManagedInterfaces>8.0.50727</MicrosoftVisualStudioManagedInterfaces>
   </PropertyGroup>
 
   <Choose>

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -2,14 +2,14 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 
 <configuration>
-  
   <packageSources>
-    <clear />  
+    <clear />
     <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="myget.org roslyn-master-nightly" value="https://dotnet.myget.org/F/roslyn-master-nightly/api/v3/index.json" />
     <add key="myget.org msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
     <add key="myget.org nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
     <add key="dotnet.myget.org roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
+    <add key="myget.org vs-devcore" value="http://www.myget.org/F/vs-devcore/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 

--- a/src/NuGet/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.nuspec
@@ -15,7 +15,7 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
       <dependency id="Microsoft.VisualStudio.ManagedInterfaces" version="8.0.50727" />
-      <dependency id="Microsoft.VisualStudio.TextManager.Interop.10.0" version="10.0.30319" />
+      <dependency id="Microsoft.VisualStudio.TextManager.Interop.10.0" version="$microsoftvisualstudiotextmanagerinterop10version$" />
       <dependency id="Microsoft.VisualStudio.TextManager.Interop.12.0" version="12.0.30110" />
       <dependency id="Microsoft.VisualStudio.Shell.15.0" version="15.0.26201" />
       <dependency id="Microsoft.VisualStudio.Shell.Design" version="15.0.26201" />

--- a/src/NuGet/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.nuspec
@@ -16,7 +16,7 @@
     <dependencies>
       <dependency id="Microsoft.VisualStudio.ManagedInterfaces" version="8.0.50727" />
       <dependency id="Microsoft.VisualStudio.TextManager.Interop.10.0" version="$microsoftvisualstudiotextmanagerinterop10version$" />
-      <dependency id="Microsoft.VisualStudio.TextManager.Interop.12.0" version="12.0.30110" />
+      <dependency id="Microsoft.VisualStudio.TextManager.Interop.12.0" version="$microsoftvisualstudiotextmanagerinterop12version$" />
       <dependency id="Microsoft.VisualStudio.Shell.15.0" version="15.0.26201" />
       <dependency id="Microsoft.VisualStudio.Shell.Design" version="15.0.26201" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.10.0" version="$microsoftvisualstudioshellinterop10version$" />

--- a/src/NuGet/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.nuspec
@@ -14,7 +14,7 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
-      <dependency id="Microsoft.VisualStudio.ManagedInterfaces" version="8.0.50727" />
+      <dependency id="Microsoft.VisualStudio.ManagedInterfaces" version="$microsoftvisualstudiomanagedinterfaces$" />
       <dependency id="Microsoft.VisualStudio.TextManager.Interop.10.0" version="$microsoftvisualstudiotextmanagerinterop10version$" />
       <dependency id="Microsoft.VisualStudio.TextManager.Interop.12.0" version="$microsoftvisualstudiotextmanagerinterop12version$" />
       <dependency id="Microsoft.VisualStudio.Shell.15.0" version="$microsoftvisualstudioshell15version$" />

--- a/src/NuGet/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.nuspec
@@ -17,7 +17,7 @@
       <dependency id="Microsoft.VisualStudio.ManagedInterfaces" version="8.0.50727" />
       <dependency id="Microsoft.VisualStudio.TextManager.Interop.10.0" version="$microsoftvisualstudiotextmanagerinterop10version$" />
       <dependency id="Microsoft.VisualStudio.TextManager.Interop.12.0" version="$microsoftvisualstudiotextmanagerinterop12version$" />
-      <dependency id="Microsoft.VisualStudio.Shell.15.0" version="15.0.26201" />
+      <dependency id="Microsoft.VisualStudio.Shell.15.0" version="$microsoftvisualstudioshell15version$" />
       <dependency id="Microsoft.VisualStudio.Shell.Design" version="15.0.26201" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.10.0" version="$microsoftvisualstudioshellinterop10version$" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.11.0" version="$microsoftvisualstudioshellinterop11version$" />

--- a/src/NuGet/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.nuspec
@@ -19,7 +19,7 @@
       <dependency id="Microsoft.VisualStudio.TextManager.Interop.12.0" version="12.0.30110" />
       <dependency id="Microsoft.VisualStudio.Shell.15.0" version="15.0.26201" />
       <dependency id="Microsoft.VisualStudio.Shell.Design" version="15.0.26201" />
-      <dependency id="Microsoft.VisualStudio.Shell.Interop.10.0" version="10.0.30319" />
+      <dependency id="Microsoft.VisualStudio.Shell.Interop.10.0" version="$microsoftvisualstudioshellinterop10version$" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.11.0" version="11.0.61030" />
     </dependencies>
   </metadata>

--- a/src/NuGet/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.nuspec
@@ -18,7 +18,7 @@
       <dependency id="Microsoft.VisualStudio.TextManager.Interop.10.0" version="$microsoftvisualstudiotextmanagerinterop10version$" />
       <dependency id="Microsoft.VisualStudio.TextManager.Interop.12.0" version="$microsoftvisualstudiotextmanagerinterop12version$" />
       <dependency id="Microsoft.VisualStudio.Shell.15.0" version="$microsoftvisualstudioshell15version$" />
-      <dependency id="Microsoft.VisualStudio.Shell.Design" version="15.0.26201" />
+      <dependency id="Microsoft.VisualStudio.Shell.Design" version="$microsoftvisualstudioshelldesign$" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.10.0" version="$microsoftvisualstudioshellinterop10version$" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.11.0" version="$microsoftvisualstudioshellinterop11version$" />
     </dependencies>

--- a/src/NuGet/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.nuspec
@@ -20,7 +20,7 @@
       <dependency id="Microsoft.VisualStudio.Shell.15.0" version="15.0.26201" />
       <dependency id="Microsoft.VisualStudio.Shell.Design" version="15.0.26201" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.10.0" version="$microsoftvisualstudioshellinterop10version$" />
-      <dependency id="Microsoft.VisualStudio.Shell.Interop.11.0" version="11.0.61030" />
+      <dependency id="Microsoft.VisualStudio.Shell.Interop.11.0" version="$microsoftvisualstudioshellinterop11version$" />
     </dependencies>
   </metadata>
   <files>

--- a/src/NuGet/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.nuspec
@@ -15,7 +15,7 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
       <dependency id="Microsoft.VisualStudio.AppDesigner" version="$version$" />
-      <dependency id="Microsoft.VisualStudio.Shell.15.0" version="15.0.26201" />
+      <dependency id="Microsoft.VisualStudio.Shell.15.0" version="$microsoftvisualstudioshell15version$" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.10.0" version="$microsoftvisualstudioshellinterop10version$" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.11.0" version="$microsoftvisualstudioshellinterop11version$" />
     </dependencies>

--- a/src/NuGet/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.nuspec
@@ -17,7 +17,7 @@
       <dependency id="Microsoft.VisualStudio.AppDesigner" version="$version$" />
       <dependency id="Microsoft.VisualStudio.Shell.15.0" version="15.0.26201" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.10.0" version="$microsoftvisualstudioshellinterop10version$" />
-      <dependency id="Microsoft.VisualStudio.Shell.Interop.11.0" version="11.0.61030" />
+      <dependency id="Microsoft.VisualStudio.Shell.Interop.11.0" version="$microsoftvisualstudioshellinterop11version$" />
     </dependencies>
   </metadata>
   <files>

--- a/src/NuGet/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.nuspec
@@ -16,7 +16,7 @@
     <dependencies>
       <dependency id="Microsoft.VisualStudio.AppDesigner" version="$version$" />
       <dependency id="Microsoft.VisualStudio.Shell.15.0" version="15.0.26201" />
-      <dependency id="Microsoft.VisualStudio.Shell.Interop.10.0" version="10.0.30319" />
+      <dependency id="Microsoft.VisualStudio.Shell.Interop.10.0" version="$microsoftvisualstudioshellinterop10version$" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.11.0" version="11.0.61030" />
     </dependencies>
   </metadata>

--- a/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.nuspec
@@ -14,7 +14,7 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
-      <dependency id="System.Collections.Immutable" version="1.1.36" />
+      <dependency id="System.Collections.Immutable" version="$systemcollectionsimmutableversion$" />
       <dependency id="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" version="14.1.24720" />
       <dependency id="Microsoft.VisualStudio.ProjectSystem.Managed" version="$version$" />
       <dependency id="Microsoft.VisualStudio.ProjectSystem.SDK" version="$projectsystemsdkversion$" />

--- a/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.nuspec
@@ -20,7 +20,7 @@
       <dependency id="Microsoft.VisualStudio.ProjectSystem.SDK" version="$projectsystemsdkversion$" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.10.0" version="$microsoftvisualstudioshellinterop10version$" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.11.0" version="$microsoftvisualstudioshellinterop11version$" />
-      <dependency id="Microsoft.VisualStudio.TextManager.Interop.10.0" version="10.0.30319" />
+      <dependency id="Microsoft.VisualStudio.TextManager.Interop.10.0" version="$microsoftvisualstudiotextmanagerinterop10version$" />
       <dependency id="Microsoft.VisualStudio.TextManager.Interop.12.0" version="12.0.30110" />
     </dependencies>
   </metadata>

--- a/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.nuspec
@@ -21,7 +21,7 @@
       <dependency id="Microsoft.VisualStudio.Shell.Interop.10.0" version="$microsoftvisualstudioshellinterop10version$" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.11.0" version="$microsoftvisualstudioshellinterop11version$" />
       <dependency id="Microsoft.VisualStudio.TextManager.Interop.10.0" version="$microsoftvisualstudiotextmanagerinterop10version$" />
-      <dependency id="Microsoft.VisualStudio.TextManager.Interop.12.0" version="12.0.30110" />
+      <dependency id="Microsoft.VisualStudio.TextManager.Interop.12.0" version="$microsoftvisualstudiotextmanagerinterop12version$" />
     </dependencies>
   </metadata>
   <files>

--- a/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.nuspec
@@ -17,7 +17,7 @@
       <dependency id="System.Collections.Immutable" version="1.1.36" />
       <dependency id="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" version="14.1.24720" />
       <dependency id="Microsoft.VisualStudio.ProjectSystem.Managed" version="$version$" />
-      <dependency id="Microsoft.VisualStudio.ProjectSystem.SDK" version="15.3.5-pre-g4382fbdb8f" />
+      <dependency id="Microsoft.VisualStudio.ProjectSystem.SDK" version="$projectsystemsdkversion$" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.10.0" version="10.0.30319" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.11.0" version="11.0.61030" />
       <dependency id="Microsoft.VisualStudio.TextManager.Interop.10.0" version="10.0.30319" />

--- a/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.nuspec
@@ -7,7 +7,7 @@
       Microsoft VisualStudio ProjectSystem for Managed Languages Project hosts that interact with VisualStudio interfaces.
     </description>
     <language>en-US</language>
-    <version>2.0.0</version> <!-- This value will be overriden by the Nuget pack call. Having this value to satisfy the schema. -->
+    <version>2.3.0-alpha</version> <!-- This value will be overriden by the Nuget pack call. Having this value to satisfy the schema. -->
     <authors>dotnet</authors>
     <projectUrl>https://github.com/dotnet/roslyn-project-system/</projectUrl>
     <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=529445</licenseUrl>
@@ -17,7 +17,7 @@
       <dependency id="System.Collections.Immutable" version="1.1.36" />
       <dependency id="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" version="14.1.24720" />
       <dependency id="Microsoft.VisualStudio.ProjectSystem.Managed" version="$version$" />
-      <dependency id="Microsoft.VisualStudio.ProjectSystem.SDK" version="15.0.737" />
+      <dependency id="Microsoft.VisualStudio.ProjectSystem.SDK" version="15.0.5-pre-g4382fbdb8f" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.10.0" version="10.0.30319" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.11.0" version="11.0.61030" />
       <dependency id="Microsoft.VisualStudio.TextManager.Interop.10.0" version="10.0.30319" />

--- a/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.nuspec
@@ -17,7 +17,7 @@
       <dependency id="System.Collections.Immutable" version="1.1.36" />
       <dependency id="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" version="14.1.24720" />
       <dependency id="Microsoft.VisualStudio.ProjectSystem.Managed" version="$version$" />
-      <dependency id="Microsoft.VisualStudio.ProjectSystem.SDK" version="15.0.5-pre-g4382fbdb8f" />
+      <dependency id="Microsoft.VisualStudio.ProjectSystem.SDK" version="15.3.5-pre-g4382fbdb8f" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.10.0" version="10.0.30319" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.11.0" version="11.0.61030" />
       <dependency id="Microsoft.VisualStudio.TextManager.Interop.10.0" version="10.0.30319" />

--- a/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.nuspec
@@ -19,7 +19,7 @@
       <dependency id="Microsoft.VisualStudio.ProjectSystem.Managed" version="$version$" />
       <dependency id="Microsoft.VisualStudio.ProjectSystem.SDK" version="$projectsystemsdkversion$" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.10.0" version="$microsoftvisualstudioshellinterop10version$" />
-      <dependency id="Microsoft.VisualStudio.Shell.Interop.11.0" version="11.0.61030" />
+      <dependency id="Microsoft.VisualStudio.Shell.Interop.11.0" version="$microsoftvisualstudioshellinterop11version$" />
       <dependency id="Microsoft.VisualStudio.TextManager.Interop.10.0" version="10.0.30319" />
       <dependency id="Microsoft.VisualStudio.TextManager.Interop.12.0" version="12.0.30110" />
     </dependencies>

--- a/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.nuspec
@@ -18,7 +18,7 @@
       <dependency id="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" version="14.1.24720" />
       <dependency id="Microsoft.VisualStudio.ProjectSystem.Managed" version="$version$" />
       <dependency id="Microsoft.VisualStudio.ProjectSystem.SDK" version="$projectsystemsdkversion$" />
-      <dependency id="Microsoft.VisualStudio.Shell.Interop.10.0" version="10.0.30319" />
+      <dependency id="Microsoft.VisualStudio.Shell.Interop.10.0" version="$microsoftvisualstudioshellinterop10version$" />
       <dependency id="Microsoft.VisualStudio.Shell.Interop.11.0" version="11.0.61030" />
       <dependency id="Microsoft.VisualStudio.TextManager.Interop.10.0" version="10.0.30319" />
       <dependency id="Microsoft.VisualStudio.TextManager.Interop.12.0" version="12.0.30110" />

--- a/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.nuspec
@@ -7,7 +7,7 @@
       Microsoft VisualStudio ProjectSystem for Managed languages Projects
     </description>
     <language>en-US</language>
-    <version>2.0.0</version> <!-- This value will be overriden by the Nuget pack call. Having this value to satisfy the schema. -->
+    <version>2.3.0-alpha</version> <!-- This value will be overriden by the Nuget pack call. Having this value to satisfy the schema. -->
     <authors>dotnet</authors>
     <projectUrl>https://github.com/dotnet/roslyn-project-system/</projectUrl>
     <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=529445</licenseUrl>
@@ -15,7 +15,7 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
       <dependency id="System.Collections.Immutable" version="1.1.36" />
-      <dependency id="Microsoft.VisualStudio.ProjectSystem.SDK" version="15.0.737" />
+      <dependency id="Microsoft.VisualStudio.ProjectSystem.SDK" version="15.0.5-pre-g4382fbdb8f" />
     </dependencies>
   </metadata>
   <files>

--- a/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.nuspec
@@ -14,7 +14,7 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
-      <dependency id="System.Collections.Immutable" version="1.1.36" />
+      <dependency id="System.Collections.Immutable" version="$systemcollectionsimmutableversion$" />
       <dependency id="Microsoft.VisualStudio.ProjectSystem.SDK" version="$projectsystemsdkversion$" />
     </dependencies>
   </metadata>

--- a/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.nuspec
@@ -15,7 +15,7 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
       <dependency id="System.Collections.Immutable" version="1.1.36" />
-      <dependency id="Microsoft.VisualStudio.ProjectSystem.SDK" version="15.3.5-pre-g4382fbdb8f" />
+      <dependency id="Microsoft.VisualStudio.ProjectSystem.SDK" version="$projectsystemsdkversion$" />
     </dependencies>
   </metadata>
   <files>

--- a/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.nuspec
@@ -15,7 +15,7 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
       <dependency id="System.Collections.Immutable" version="1.1.36" />
-      <dependency id="Microsoft.VisualStudio.ProjectSystem.SDK" version="15.0.5-pre-g4382fbdb8f" />
+      <dependency id="Microsoft.VisualStudio.ProjectSystem.SDK" version="15.3.5-pre-g4382fbdb8f" />
     </dependencies>
   </metadata>
   <files>

--- a/src/NuGet/NuGet.proj
+++ b/src/NuGet/NuGet.proj
@@ -48,6 +48,7 @@
                    -prop microsoftvisualstudioshellinterop11version=$(MicrosoftVisualStudioShellInterop11Version) ^
                    -prop microsoftvisualstudiotextmanagerinterop10version=$(MicrosoftVisualStudioTextManagerInterop10Version) ^
                    -prop microsoftvisualstudiotextmanagerinterop12version=$(MicrosoftVisualStudioTextManagerInterop12Version) ^
+                   -prop microsoftvisualstudioshell15version=$(MicrosoftVisualStudioShell15Version) ^
                    %(NuSpec.NuGetArguments)" />
 
    </Target>

--- a/src/NuGet/NuGet.proj
+++ b/src/NuGet/NuGet.proj
@@ -38,8 +38,8 @@
    <Target Name="Build" Inputs="@(NuSpec);@(PackageAssets)" Outputs="@(NuSpec->'%(NuPkgOutput)')" DependsOnTargets="LogOutput">
 
      <MakeDir Directories="$(NuGetOutDir)" />
+     <Exec Command="$(NuGetToolPath) Pack &quot;$(MSBuildProjectDirectory)\%(NuSpec.Identity)&quot; -verbosity quiet -BasePath &quot;$(OutDir.TrimEnd('\'))&quot; -OutputDirectory &quot;$(NuGetOutDir.TrimEnd('\'))&quot; -prop projectsystemsdkversion=$(ProjectSystemSDKVersion) %(NuSpec.NuGetArguments)" />
 
-     <Exec Command="$(NuGetToolPath) Pack &quot;$(MSBuildProjectDirectory)\%(NuSpec.Identity)&quot; -verbosity quiet -BasePath &quot;$(OutDir.TrimEnd('\'))&quot; -OutputDirectory &quot;$(NuGetOutDir.TrimEnd('\'))&quot; %(NuSpec.NuGetArguments)" />
    </Target>
 
    <Target Name="Clean">

--- a/src/NuGet/NuGet.proj
+++ b/src/NuGet/NuGet.proj
@@ -11,20 +11,20 @@
 
    <ItemGroup>
      <NuSpec Include="Microsoft.VisualStudio.Editors\Microsoft.VisualStudio.Editors.nuspec">
-       <NuPkgOutput>$(NuGetOutDir)%(FileName).$(VSNuGetPerBuildReleaseVersion).nupkg</NuPkgOutput>
-       <NuGetArguments>-Version "$(VSNuGetPerBuildReleaseVersion)"</NuGetArguments>
+       <NuPkgOutput>$(NuGetOutDir)%(FileName).$(VSNuGetPerBuildVersion).nupkg</NuPkgOutput>
+       <NuGetArguments>-Version "$(VSNuGetPerBuildVersion)"</NuGetArguments>
      </NuSpec>
      <NuSpec Include="Microsoft.VisualStudio.AppDesigner\Microsoft.VisualStudio.AppDesigner.nuspec">
-       <NuPkgOutput>$(NuGetOutDir)%(FileName).$(VSNuGetPerBuildReleaseVersion).nupkg</NuPkgOutput>
-       <NuGetArguments>-Version "$(VSNuGetPerBuildReleaseVersion)"</NuGetArguments>
+       <NuPkgOutput>$(NuGetOutDir)%(FileName).$(VSNuGetPerBuildVersion).nupkg</NuPkgOutput>
+       <NuGetArguments>-Version "$(VSNuGetPerBuildVersion)"</NuGetArguments>
      </NuSpec>
      <NuSpec Include="Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.nuspec">
-       <NuPkgOutput>$(NuGetOutDir)%(FileName).$(RoslynNuGetPerBuildReleaseVersion).nupkg</NuPkgOutput>
-       <NuGetArguments>-Version "$(RoslynNuGetPerBuildReleaseVersion)"</NuGetArguments>
+       <NuPkgOutput>$(NuGetOutDir)%(FileName).$(RoslynNuGetPerBuildVersion).nupkg</NuPkgOutput>
+       <NuGetArguments>-Version "$(RoslynNuGetPerBuildVersion)"</NuGetArguments>
      </NuSpec>
       <NuSpec Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS\Microsoft.VisualStudio.ProjectSystem.Managed.VS.nuspec">
-       <NuPkgOutput>$(NuGetOutDir)%(FileName).$(RoslynNuGetPerBuildReleaseVersion).nupkg</NuPkgOutput>
-       <NuGetArguments>-Version "$(RoslynNuGetPerBuildReleaseVersion)"</NuGetArguments>
+       <NuPkgOutput>$(NuGetOutDir)%(FileName).$(RoslynNuGetPerBuildVersion).nupkg</NuPkgOutput>
+       <NuGetArguments>-Version "$(RoslynNuGetPerBuildVersion)"</NuGetArguments>
      </NuSpec>
 
      <!-- Make note, without actually knowing what's included in the NuSpec, 

--- a/src/NuGet/NuGet.proj
+++ b/src/NuGet/NuGet.proj
@@ -45,6 +45,7 @@
                    -prop projectsystemsdkversion=$(ProjectSystemSDKVersion) ^
                    -prop systemcollectionsimmutableversion=$(SystemCollectionsImmutableVersion) ^
                    -prop microsoftvisualstudioshellinterop10version=$(MicrosoftVisualStudioShellInterop10Version) ^
+                   -prop microsoftvisualstudioshellinterop11version=$(MicrosoftVisualStudioShellInterop11Version) ^
                    %(NuSpec.NuGetArguments)" />
 
    </Target>

--- a/src/NuGet/NuGet.proj
+++ b/src/NuGet/NuGet.proj
@@ -44,6 +44,7 @@
                    -OutputDirectory &quot;$(NuGetOutDir.TrimEnd('\'))&quot; ^
                    -prop projectsystemsdkversion=$(ProjectSystemSDKVersion) ^
                    -prop systemcollectionsimmutableversion=$(SystemCollectionsImmutableVersion) ^
+                   -prop microsoftvisualstudioshellinterop10version=$(MicrosoftVisualStudioShellInterop10Version) ^
                    %(NuSpec.NuGetArguments)" />
 
    </Target>

--- a/src/NuGet/NuGet.proj
+++ b/src/NuGet/NuGet.proj
@@ -49,6 +49,7 @@
                    -prop microsoftvisualstudiotextmanagerinterop10version=$(MicrosoftVisualStudioTextManagerInterop10Version) ^
                    -prop microsoftvisualstudiotextmanagerinterop12version=$(MicrosoftVisualStudioTextManagerInterop12Version) ^
                    -prop microsoftvisualstudioshell15version=$(MicrosoftVisualStudioShell15Version) ^
+                   -prop microsoftvisualstudioshelldesign=$(MicrosoftVisualStudioShellDesign) ^
                    %(NuSpec.NuGetArguments)" />
 
    </Target>

--- a/src/NuGet/NuGet.proj
+++ b/src/NuGet/NuGet.proj
@@ -47,6 +47,7 @@
                    -prop microsoftvisualstudioshellinterop10version=$(MicrosoftVisualStudioShellInterop10Version) ^
                    -prop microsoftvisualstudioshellinterop11version=$(MicrosoftVisualStudioShellInterop11Version) ^
                    -prop microsoftvisualstudiotextmanagerinterop10version=$(MicrosoftVisualStudioTextManagerInterop10Version) ^
+                   -prop microsoftvisualstudiotextmanagerinterop12version=$(MicrosoftVisualStudioTextManagerInterop12Version) ^
                    %(NuSpec.NuGetArguments)" />
 
    </Target>

--- a/src/NuGet/NuGet.proj
+++ b/src/NuGet/NuGet.proj
@@ -50,6 +50,7 @@
                    -prop microsoftvisualstudiotextmanagerinterop12version=$(MicrosoftVisualStudioTextManagerInterop12Version) ^
                    -prop microsoftvisualstudioshell15version=$(MicrosoftVisualStudioShell15Version) ^
                    -prop microsoftvisualstudioshelldesign=$(MicrosoftVisualStudioShellDesign) ^
+                   -prop microsoftvisualstudiomanagedinterfaces=$(MicrosoftVisualStudioManagedInterfaces) ^
                    %(NuSpec.NuGetArguments)" />
 
    </Target>

--- a/src/NuGet/NuGet.proj
+++ b/src/NuGet/NuGet.proj
@@ -38,7 +38,13 @@
    <Target Name="Build" Inputs="@(NuSpec);@(PackageAssets)" Outputs="@(NuSpec->'%(NuPkgOutput)')" DependsOnTargets="LogOutput">
 
      <MakeDir Directories="$(NuGetOutDir)" />
-     <Exec Command="$(NuGetToolPath) Pack &quot;$(MSBuildProjectDirectory)\%(NuSpec.Identity)&quot; -verbosity quiet -BasePath &quot;$(OutDir.TrimEnd('\'))&quot; -OutputDirectory &quot;$(NuGetOutDir.TrimEnd('\'))&quot; -prop projectsystemsdkversion=$(ProjectSystemSDKVersion) %(NuSpec.NuGetArguments)" />
+     <Exec Command="$(NuGetToolPath) Pack &quot;$(MSBuildProjectDirectory)\%(NuSpec.Identity)&quot; ^
+                   -verbosity quiet ^
+                   -BasePath &quot;$(OutDir.TrimEnd('\'))&quot; ^
+                   -OutputDirectory &quot;$(NuGetOutDir.TrimEnd('\'))&quot; ^
+                   -prop projectsystemsdkversion=$(ProjectSystemSDKVersion) ^
+                   -prop systemcollectionsimmutableversion=$(SystemCollectionsImmutableVersion) ^
+                   %(NuSpec.NuGetArguments)" />
 
    </Target>
 

--- a/src/NuGet/NuGet.proj
+++ b/src/NuGet/NuGet.proj
@@ -46,6 +46,7 @@
                    -prop systemcollectionsimmutableversion=$(SystemCollectionsImmutableVersion) ^
                    -prop microsoftvisualstudioshellinterop10version=$(MicrosoftVisualStudioShellInterop10Version) ^
                    -prop microsoftvisualstudioshellinterop11version=$(MicrosoftVisualStudioShellInterop11Version) ^
+                   -prop microsoftvisualstudiotextmanagerinterop10version=$(MicrosoftVisualStudioTextManagerInterop10Version) ^
                    %(NuSpec.NuGetArguments)" />
 
    </Target>


### PR DESCRIPTION
With this change, the nuget version of the package that are referenced both in the project and Nuspec will moved to one single properties group rather than listed in all places(`References.targets and `*.Nuspec``). The advantage is, user edits one place, the change propagates everywhere.

Without this change, the Nuget version of the packages listed in the nuspec dependency will start deviating from the actual version that is used to build the product. This already happened for System.Collections.Immutable.

This change does move all the package reference version to the property group. It moved just the packages which are referenced in more than one place.

@dotnet/project-system @davkean for review.

@RaulPerez1, you might want to get this change before you make the changes through #1771. This PR fixes the exact problem your PR will be introducing.