### PR TITLE
Project.EditProjectFile should be always available

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/EditProjectFileCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/EditProjectFileCommandTests.cs
@@ -15,7 +15,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
     {
         private const long CommandId = VisualStudioStandard2kCommandId.EditProjectFile;
         private const string Extension = "proj";
-        private static readonly Guid XmlEditorFactoryGuid = new Guid("{fa3cd31e-987b-443a-9b81-186104e8dac1}");
 
         [Fact]
         public void EditProjectFileCommand_NullProject_Throws()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/EditProjectFileCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/EditProjectFileCommandTests.cs
@@ -18,13 +18,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         [Fact]
         public void EditProjectFileCommand_NullAsUnconfiguredProject_Throws()
         {
-            Assert.Throws<ArgumentNullException>("unconfiguredProject", () => new EditProjectFileCommand(null, IProjectFileEditorPresenterFactory.CreateLazy()));
+            var editorPresenter = IProjectFileEditorPresenterFactory.CreateLazy();
+
+            Assert.Throws<ArgumentNullException>("unconfiguredProject", () => new EditProjectFileCommand(null, editorPresenter));
         }
 
         [Fact]
         public void EditProjectFileCommand_NullAsPresenter_Throws()
         {
-            Assert.Throws<ArgumentNullException>("editorPresenter", () => new EditProjectFileCommand(UnconfiguredProjectFactory.Create(), null));
+            var unconfiguredProject = UnconfiguredProjectFactory.Create();
+
+            Assert.Throws<ArgumentNullException>("editorPresenter", () => new EditProjectFileCommand(unconfiguredProject, null));
         }
 
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/EditProjectFileCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/EditProjectFileCommandTests.cs
@@ -14,7 +14,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
     public class EditProjectFileCommandTests
     {
         private const long CommandId = VisualStudioStandard2kCommandId.EditProjectFile;
-        private const string Extension = "proj";
 
         [Fact]
         public void EditProjectFileCommand_NullAsUnconfiguredProject_Throws()
@@ -44,7 +43,7 @@ Root (flags: {ProjectRoot})
             var result = await command.GetCommandStatusAsync(nodes, CommandId, true, "", 0);
             Assert.True(result.Handled);
             Assert.Equal(CommandStatus.Enabled | CommandStatus.Supported, result.Status);
-            Assert.Equal(string.Format(VSResources.EditProjectFileCommand, $"Root.{Extension}"), result.CommandText);
+            Assert.Equal(string.Format(VSResources.EditProjectFileCommand, $"Root.proj"), result.CommandText);
         }
 
         [Fact]
@@ -64,7 +63,7 @@ Root (flags: {ProjectRoot})
             var result = await command.GetCommandStatusAsync(nodes, CommandId, true, "", 0);
             Assert.True(result.Handled);
             Assert.Equal(CommandStatus.Enabled | CommandStatus.Supported, result.Status);
-            Assert.Equal(string.Format(VSResources.EditProjectFileCommand, $"Root.{Extension}"), result.CommandText);
+            Assert.Equal(string.Format(VSResources.EditProjectFileCommand, $"Root.proj"), result.CommandText);
         }
 
         [Fact]
@@ -84,7 +83,7 @@ Root (flags: {ProjectRoot})
             var result = await command.GetCommandStatusAsync(nodes, CommandId, true, "", 0);
             Assert.True(result.Handled);
             Assert.Equal(CommandStatus.Enabled | CommandStatus.Supported, result.Status);
-            Assert.Equal(string.Format(VSResources.EditProjectFileCommand, $"Root.{Extension}"), result.CommandText);
+            Assert.Equal(string.Format(VSResources.EditProjectFileCommand, $"Root.proj"), result.CommandText);
         }
 
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/EditProjectFileCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/EditProjectFileCommandTests.cs
@@ -17,15 +17,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         private const string Extension = "proj";
 
         [Fact]
-        public void EditProjectFileCommand_NullProject_Throws()
+        public void EditProjectFileCommand_NullAsUnconfiguredProject_Throws()
         {
             Assert.Throws<ArgumentNullException>("unconfiguredProject", () => new EditProjectFileCommand(null, IProjectFileEditorPresenterFactory.CreateLazy()));
         }
 
         [Fact]
-        public void EditProjectFileCommand_NullModel_Throws()
+        public void EditProjectFileCommand_NullAsPresenter_Throws()
         {
-            Assert.Throws<ArgumentNullException>("editorState", () => new EditProjectFileCommand(UnconfiguredProjectFactory.Create(), null));
+            Assert.Throws<ArgumentNullException>("editorPresenter", () => new EditProjectFileCommand(UnconfiguredProjectFactory.Create(), null));
         }
 
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/EditProjectFileCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/EditProjectFileCommand.cs
@@ -16,16 +16,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
     internal class EditProjectFileCommand : AbstractProjectCommand
     {
         private readonly UnconfiguredProject _unconfiguredProject;
-        private readonly Lazy<IProjectFileEditorPresenter> _editorState;
+        private readonly Lazy<IProjectFileEditorPresenter> _editorPresenter;
 
         [ImportingConstructor]
-        public EditProjectFileCommand(UnconfiguredProject unconfiguredProject, Lazy<IProjectFileEditorPresenter> editorState)
+        public EditProjectFileCommand(UnconfiguredProject unconfiguredProject, Lazy<IProjectFileEditorPresenter> editorPresenter)
         {
             Requires.NotNull(unconfiguredProject, nameof(unconfiguredProject));
-            Requires.NotNull(editorState, nameof(editorState));
+            Requires.NotNull(editorPresenter, nameof(editorPresenter));
 
             _unconfiguredProject = unconfiguredProject;
-            _editorState = editorState;
+            _editorPresenter = editorPresenter;
         }
 
         protected override Task<CommandStatusResult> GetCommandStatusAsync(IImmutableSet<IProjectTree> nodes, bool focused, string commandText, CommandStatus progressiveStatus)
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 
         protected override async Task<bool> TryHandleCommandAsync(IImmutableSet<IProjectTree> nodes, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
         {
-            await _editorState.Value.OpenEditorAsync().ConfigureAwait(false);
+            await _editorPresenter.Value.OpenEditorAsync().ConfigureAwait(false);
             return true;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/EditProjectFileCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/EditProjectFileCommand.cs
@@ -15,7 +15,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
     [AppliesTo(ProjectCapability.OpenProjectFile)]
     internal class EditProjectFileCommand : AbstractProjectCommand
     {
-        private static readonly Guid XmlEditorFactoryGuid = new Guid("{fa3cd31e-987b-443a-9b81-186104e8dac1}");
         private readonly UnconfiguredProject _unconfiguredProject;
         private readonly Lazy<IProjectFileEditorPresenter> _editorState;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/EditProjectFileCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/EditProjectFileCommand.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.Threading.Tasks;
@@ -12,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 {
     [ProjectCommand(CommandGroup.VisualStudioStandard2k, VisualStudioStandard2kCommandId.EditProjectFile)]
     [AppliesTo(ProjectCapability.OpenProjectFile)]
-    internal class EditProjectFileCommand : AbstractSingleNodeProjectCommand
+    internal class EditProjectFileCommand : AbstractProjectCommand
     {
         private static readonly Guid XmlEditorFactoryGuid = new Guid("{fa3cd31e-987b-443a-9b81-186104e8dac1}");
         private readonly UnconfiguredProject _unconfiguredProject;
@@ -28,23 +29,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             _editorState = editorState;
         }
 
-        protected override Task<CommandStatusResult> GetCommandStatusAsync(IProjectTree node, bool focused, string commandText, CommandStatus progressiveStatus) =>
-            ShouldHandle(node) ?
-                GetCommandStatusResult.Handled(GetCommandText(node), CommandStatus.Enabled) :
-                GetCommandStatusResult.Unhandled;
-
-        protected override async Task<bool> TryHandleCommandAsync(IProjectTree node, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
+        protected override Task<CommandStatusResult> GetCommandStatusAsync(IImmutableSet<IProjectTree> nodes, bool focused, string commandText, CommandStatus progressiveStatus)
         {
-            if (!ShouldHandle(node)) return false;
+            // Similar to other commands such as Add Reference, Project.EditProjectFile command 
+            // should be available regardless of what nodes are selected.
+            return GetCommandStatusResult.Handled(GetCommandText(), CommandStatus.Enabled);
+        }
+
+        protected override async Task<bool> TryHandleCommandAsync(IImmutableSet<IProjectTree> nodes, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
+        {
             await _editorState.Value.OpenEditorAsync().ConfigureAwait(false);
             return true;
         }
 
-        protected string GetCommandText(IProjectTree node)
+        protected string GetCommandText()
         {
             return string.Format(VSResources.EditProjectFileCommand, Path.GetFileName(_unconfiguredProject.FullPath));
         }
-
-        private bool ShouldHandle(IProjectTree node) => node.IsRoot();
     }
 }


### PR DESCRIPTION
Project.EditProjectFile was only enabled when the root node was selected in Solution Explorer, and Solution Explorer had focus. Instead, it should be enabled regardless of which node is selected, this makes make it available from Project/Command window when editor has focus or when one or many project items are selected. This is how other project-level commands work such as Add Reference.

This doesn't cause it to appear on the context menu of an item - by default it doesn't show up unless the user adds it to that context menu.

Fixes: https://github.com/dotnet/roslyn-project-system/issues/1828.