### PR TITLE
Make sure the tree is published before the project has finished loading

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
@@ -13,7 +13,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 using Task = System.Threading.Tasks.Task;
 
 // We register ourselves as a new CPS "project type"
-[assembly: ProjectTypeRegistration(projectTypeGuid: CSharpProjectSystemPackage.ProjectTypeGuid, displayName: "#1", displayProjectFileExtensions: "#2", defaultProjectExtension: "csproj", language: "CSharp", resourcePackageGuid: CSharpProjectSystemPackage.PackageGuid, Capabilities = ManagedProjectSystemPackage.DefaultCapabilities)]
+[assembly: ProjectTypeRegistration(projectTypeGuid: CSharpProjectSystemPackage.ProjectTypeGuid, displayName: "#1", displayProjectFileExtensions: "#2", defaultProjectExtension: "csproj", language: "CSharp", resourcePackageGuid: CSharpProjectSystemPackage.PackageGuid, Capabilities = ManagedProjectSystemPackage.DefaultCapabilities, DisableAsynchronousProjectTreeLoad = true)]
 
 namespace Microsoft.VisualStudio.Packaging
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Packaging/VisualBasicProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Packaging/VisualBasicProjectSystemPackage.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.Shell;
 using System.Runtime.InteropServices;
 
 // We register ourselves as a new CPS "project type", as well as setting ourselves as the prefered project type for the legacy VB project type.
-[assembly: ProjectTypeRegistration(projectTypeGuid: VisualBasicProjectSystemPackage.ProjectTypeGuid, displayName: "#1", displayProjectFileExtensions: "#2", defaultProjectExtension: "vbproj", language: "VisualBasic", resourcePackageGuid: VisualBasicProjectSystemPackage.PackageGuid, Capabilities = ManagedProjectSystemPackage.DefaultCapabilities)]
+[assembly: ProjectTypeRegistration(projectTypeGuid: VisualBasicProjectSystemPackage.ProjectTypeGuid, displayName: "#1", displayProjectFileExtensions: "#2", defaultProjectExtension: "vbproj", language: "VisualBasic", resourcePackageGuid: VisualBasicProjectSystemPackage.PackageGuid, Capabilities = ManagedProjectSystemPackage.DefaultCapabilities, DisableAsynchronousProjectTreeLoad = true)]
 
 namespace Microsoft.VisualStudio.Packaging
 {


### PR DESCRIPTION
Turn off asynchronous tree loading to bring the behavior of the project system in line with the legacy project system. This lets extensions query for project items after the project load event has fired and get correct results.

Make note, that the tree was being published anyway during load in variety of places anyway:

1) File -> New always published the tree due to wizards expecting the project to be done by the time they were called
2) The LanguageServiceHost would already publish not too much after the Project factory had "completed", so depending on the when the component looked, sometimes you'll get correct results, and sometimes you wouldn't. This is going to be removed as a part of https://github.com/dotnet/roslyn-project-system/issues/1655. This change makes it always consistent.