### PR TITLE
Fix accessibility issues with Advanced Services property page...

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/AdvancedServicesDialog.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AdvancedServicesDialog.resx
@@ -135,7 +135,7 @@
     <value>139, 21</value>
   </data>
   <data name="RoleServiceCacheTimeoutLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+    <value>2</value>
   </data>
   <data name="RoleServiceCacheTimeoutLabel.Text" xml:space="preserve">
     <value>Role service cache &amp;timeout:</value>
@@ -178,6 +178,9 @@
   </data>
   <data name="&gt;&gt;TimeQuantity.ZOrder" xml:space="preserve">
     <value>3</value>
+  </data>
+  <data name="TimeUnitComboBox.AccessibleName" xml:space="preserve">
+    <value>Role service cache timeout units</value>
   </data>
   <data name="TimeUnitComboBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>354, 49</value>
@@ -337,6 +340,9 @@
   </data>
   <data name="TableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="SavePasswordHashLocallyCheckbox" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="HonorServerCookieExpirationCheckbox" Row="1" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="RoleServiceCacheTimeoutLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="TimeQuantity" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="TimeUnitComboBox" Row="2" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="UseCustomConnectionStringCheckBox" Row="3" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="CustomConnectionString" Row="4" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Absolute,70,Absolute,150" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="CustomConnectionString.AccessibleName" xml:space="preserve">
+    <value>Custom connection string</value>
   </data>
   <data name="CustomConnectionString.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>


### PR DESCRIPTION
- Tab index order was not complete/correct
- A couple controls lacked accessible names (and appropriate names could
not be inferred)

Fixes:  https://devdiv.visualstudio.com/DevDiv/_workitems?id=386365&fullScreen=true&_a=edit