### PR TITLE
Move xproj project type usage to factory

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
@@ -36,7 +36,6 @@ namespace Microsoft.VisualStudio.Packaging
     {
         public const string ProjectTypeGuid = "9A19103F-16F7-4668-BE54-9A1E7A4F7556";
         public const string LegacyProjectTypeGuid = "FAE04EC0-301F-11d3-BF4B-00C04F79EFBC";
-        public const string XprojTypeGuid = "8bb2217d-0f2d-49d1-97bc-3654ed321f3b";
         public const string PackageGuid = "860A27C0-B665-47F3-BC12-637E16A1050A";
         private const string ProjectTypeGuidFormatted = "{" + ProjectTypeGuid + "}";
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
@@ -15,7 +15,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
 {
-    [Guid(CSharpProjectSystemPackage.XprojTypeGuid)]
+    [Guid("8bb2217d-0f2d-49d1-97bc-3654ed321f3b")]
     internal sealed class MigrateXprojProjectFactory : FlavoredProjectFactoryBase, IVsProjectUpgradeViaFactory, IVsProjectUpgradeViaFactory4
     {
         private readonly ProcessRunner _runner;
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
             var backupResult = BackupAndDeleteGlobalJson(solutionDirectory, solution, backupDirectory, xprojLocation, projectName, logger);
             if (!backupResult.Succeeded)
             {
-                migratedProjectGuid = Guid.Parse(CSharpProjectSystemPackage.XprojTypeGuid);
+                migratedProjectGuid = GetType().GUID;
                 migratedProjectFileLocation = xprojLocation;
                 return backupResult;
             }
@@ -76,14 +76,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
             }
             else
             {
-                migratedProjectGuid = Guid.Parse(CSharpProjectSystemPackage.XprojTypeGuid);
+                migratedProjectGuid = GetType().GUID;
                 migratedProjectFileLocation = null;
             }
 
             if (string.IsNullOrEmpty(migratedProjectFileLocation))
             {
                 // If we weren't able to find a new csproj, something went very wrong, and dotnet migrate is doing something that we don't expect.
-                migratedProjectGuid = Guid.Parse(CSharpProjectSystemPackage.XprojTypeGuid);
+                migratedProjectGuid = GetType().GUID;
                 Assumes.NotNullOrEmpty(migratedProjectFileLocation);
                 migratedProjectFileLocation = xprojLocation;
                 success = false;
@@ -312,12 +312,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
 
             if (isXproj)
             {
-                migratedProjectFactory = new Guid($"{{{CSharpProjectSystemPackage.ProjectTypeGuid}}}");
+                migratedProjectFactory = new Guid(CSharpProjectSystemPackage.ProjectTypeGuid);
                 upgradeProjectCapabilityFlags = (uint)(__VSPPROJECTUPGRADEVIAFACTORYFLAGS.PUVFF_BACKUPSUPPORTED | __VSPPROJECTUPGRADEVIAFACTORYFLAGS.PUVFF_COPYBACKUP);
             }
             else
             {
-                migratedProjectFactory = new Guid(CSharpProjectSystemPackage.XprojTypeGuid);
+                migratedProjectFactory = GetType().GUID;
                 upgradeProjectCapabilityFlags = 0;
             }
 


### PR DESCRIPTION
The package doesn't need to know about the project type of xproj - that's the factory's job.