### PR TITLE
Stop using the Managed capability

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
     ///     An implementation of <see cref="IVsErrorListProvider"/> that delegates onto the language
     ///     service so that it de-dup warnings and errors between IntelliSense and build.
     /// </summary>
-    [AppliesTo(ProjectCapability.ManagedLanguageService)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
     [Export(typeof(IVsErrorListProvider))]
     [Order(1)] // One less than the CPS version of this class, until they've removed it
     internal partial class LanguageServiceErrorListProvider : IVsErrorListProvider

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
 
         [ProjectAutoLoad(startAfter:ProjectLoadCheckpoint.ProjectFactoryCompleted)]
-        [AppliesTo(ProjectCapability.Managed)]
+        [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
         internal Task Load()
         {
             EnsureInitialized();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Extensibility/ProjectExportProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Extensibility/ProjectExportProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Extensibility
     /// MEF component which has methods for consumers to get to project specific MEF exports
     /// </summary>
     [Export(typeof(IProjectExportProvider))]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class ProjectExportProvider : IProjectExportProvider
     {
         private IProjectServiceAccessor ProjectServiceAccesspr { get; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Generators/SingleFileGeneratorFactoryAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Generators/SingleFileGeneratorFactoryAggregator.cs
@@ -7,7 +7,7 @@ using System.ComponentModel.Composition;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Generators
 {
     [ExportProjectNodeComService(typeof(IVsSingleFileGeneratorFactory))]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class SingleFileGeneratorFactoryAggregator : IVsSingleFileGeneratorFactory
     {
         // Constants for the generator information registry keys

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ProjectContextCodeModelProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ProjectContextCodeModelProvider.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
     /// </summary>
     [Export(typeof(ICodeModelProvider))]
     [Export(typeof(IProjectCodeModelProvider))]
-    [AppliesTo(ProjectCapability.ManagedLanguageService)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
     internal class ProjectContextCodeModelProvider : ICodeModelProvider, IProjectCodeModelProvider
     {
         private readonly IProjectThreadingService _threadingService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
@@ -14,7 +14,7 @@ using SVsServiceProvider = Microsoft.VisualStudio.Shell.SVsServiceProvider;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 {
     [Export(typeof(IVsContainedLanguageComponentsFactory))]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class VsContainedLanguageComponentsFactory : OnceInitializedOnceDisposedAsync, IVsContainedLanguageComponentsFactory
     {
         private readonly SVsServiceProvider _serviceProvider;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         }
 
         [ProjectAutoLoad(startAfter: ProjectLoadCheckpoint.ProjectFactoryCompleted)]
-        [AppliesTo(ProjectCapability.Managed)]
+        [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
         internal Task OnProjectFactoryCompletedAsync()
         {
             // set up a subscription to listen for target framework changes

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         /// Called on project load.
         /// </summary>
         [ConfiguredProjectAutoLoad(RequiresUIThread = true)]
-        [AppliesTo(ProjectCapability.Managed)]
+        [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
         internal void Load()
         {
             EnsureInitialized();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/ProjectFileOrAssemblyInfoPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/ProjectFileOrAssemblyInfoPropertiesProvider.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
     [Export("ProjectFileOrAssemblyInfo", typeof(IProjectPropertiesProvider))]
     [Export(typeof(IProjectPropertiesProvider))]
     [ExportMetadata("Name", "ProjectFileOrAssemblyInfo")]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class ProjectFileOrAssemblyInfoPropertiesProvider : AbstractProjectFileOrAssemblyInfoPropertiesProvider
     {
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/BuildMacroInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/BuildMacroInfo.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
     /// Implements the <see cref="IVsBuildMacroInfo"/> interface to be consumed by project properties.
     /// </summary>
     [ExportProjectNodeComService((typeof(IVsBuildMacroInfo)))]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class BuildMacroInfo : IVsBuildMacroInfo
     {
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/AddFileContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/AddFileContextProvider.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.Composition;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.References
 {
     [ExportIVsReferenceManagerUserAsync(VSConstants.FileReferenceProvider_string, ReferencePriority.File)]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     [Order(OverrideCPSProvider)]
     internal class AddFileContextProvider : BaseReferenceContextProvider
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/AssemblyReferenceContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/AssemblyReferenceContextProvider.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.Composition;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.References
 {
     [ExportIVsReferenceManagerUserAsync(VSConstants.AssemblyReferenceProvider_string, ReferencePriority.Assembly)]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     [Order(OverrideCPSProvider)]
     internal class AssemblyReferencesProviderContext : BaseReferenceContextProvider
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ComReferencesProviderContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ComReferencesProviderContext.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.Composition;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.References
 {
     [ExportIVsReferenceManagerUserAsync(VSConstants.ComReferenceProvider_string, ReferencePriority.Com)]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     [Order(OverrideCPSProvider)]
     internal class ComReferencesProviderContext : BaseReferenceContextProvider
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
     /// </summary>
     [Export]
     [ExportVsProfferedProjectService(typeof(SVsDesignTimeAssemblyResolution))]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     [Order(1)] // Before CPS's version
     internal partial class DesignTimeAssemblyResolution : IVsDesignTimeAssemblyResolution
     {
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         // BUG (https://devdiv.visualstudio.com/DevDiv/_workitems?id=367916): VS MEF rejects a part marked 
         // with two Export/Metadata attributes where one is AllowMultiple=false
         [ExportProjectNodeComService(typeof(IVsDesignTimeAssemblyResolution))]  // Need to override CPS's version, which it implements on the project node as IVsDesignTimeAssemblyResolution
-        [AppliesTo(ProjectCapability.Managed)]
+        [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
         [Order(1)] // Before CPS's version
         public IVsDesignTimeAssemblyResolution ComService
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ProjectReferencesProviderContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ProjectReferencesProviderContext.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.Composition;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.References
 {
     [ExportIVsReferenceManagerUserAsync(VSConstants.ProjectReferenceProvider_string, ReferencePriority.Project)]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     [Order(OverrideCPSProvider)]
     internal class ProjectReferencesProviderContext : BaseReferenceContextProvider
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/SharedProjectReferencesProviderContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/SharedProjectReferencesProviderContext.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.Composition;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.References
 {
     [ExportIVsReferenceManagerUserAsync(VSConstants.SharedProjectReferenceProvider_string, ReferencePriority.SharedProject)]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     [Order(OverrideCPSProvider)]
     internal class SharedProjectReferencesProviderContext : BaseReferenceContextProvider
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/WinRTReferencesProviderContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/WinRTReferencesProviderContext.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.Composition;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.References
 {
     [ExportIVsReferenceManagerUserAsync(VSConstants.PlatformReferenceProvider_string, ReferencePriority.Platform)]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     [Order(OverrideCPSProvider)]
     internal class WinRTReferencesProviderContext : BaseReferenceContextProvider
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/DialogServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/DialogServices.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UI
     /// can be retrieved from this servcie. 
     /// </summary>
     [Export(typeof(IDialogServices))]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class DialogServices : IDialogServices
     {
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     ///<see cref="IActiveConfiguredProjectsProvider"/>
     /// </summary>
     [Export(typeof(IActiveConfiguredProjectsProvider))]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class ActiveConfiguredProjectsProvider : IActiveConfiguredProjectsProvider
     {
         private readonly IUnconfiguredProjectServices _services;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/CommandLineDesignTimeBuildPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/CommandLineDesignTimeBuildPropertiesProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
     ///     arguments that it would have passed to the compiler, instead of calling it.
     /// </summary>
     [ExportBuildGlobalPropertiesProvider(designTimeBuildProperties: true)]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class CommandLineDesignTimeBuildPropertiesProvider : StaticGlobalPropertiesProviderBase
     {
         private static readonly Task<IImmutableDictionary<string, string>> BuildProperties = Task.FromResult<IImmutableDictionary<string, string>>(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/PublishableProjectConfigProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/PublishableProjectConfigProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
     ///     Provides publishable project config for projects that support click once publishing.
     /// </summary>
     [Export(typeof(IPublishProvider))]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class PublishableProjectConfigProvider : IPublishProvider
     {
         public Task<bool> IsPublishSupportedAsync()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/TargetFrameworkGlobalBuildPropertyProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/TargetFrameworkGlobalBuildPropertyProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
     /// </summary>
     /// <remarks>We specify attribute 'Order(Int32.MaxValue)` to ensure that this is the most preferred build properties provider, so it overrides target framework setting from prior providers.</remarks>
     [ExportBuildGlobalPropertiesProvider(designTimeBuildProperties: false)]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     [Order(int.MaxValue)]
     internal class TargetFrameworkGlobalBuildPropertyProvider : StaticGlobalPropertiesProviderBase
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/TurnOffUseHostCompilerIfAvailableBuildPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/TurnOffUseHostCompilerIfAvailableBuildPropertiesProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
     ///     Turns off UseHostCompilerIfAvailable to prevent CoreCompile from always being called during builds, see: https://github.com/dotnet/sdk/issues/708.
     /// </summary>
     [ExportBuildGlobalPropertiesProvider]
-    [AppliesTo(ProjectCapability.ManagedLanguageService)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
     internal class TurnOffUseHostCompilerIfAvailableBuildPropertiesProvider : StaticGlobalPropertiesProviderBase
     {
         private static readonly Task<IImmutableDictionary<string, string>> BuildProperties = Task.FromResult<IImmutableDictionary<string, string>>(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     /// Providers a wrapper around the what is considered the active debugging framework.
     /// </summary>
     [Export(typeof(IActiveDebugFrameworkServices))]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class ActiveDebugFrameworkServices : IActiveDebugFrameworkServices
     {
         const int MaxFrameworks = 20;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/ProjectImageProviderAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/ProjectImageProviderAggregator.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Imaging
     ///     <see cref="IProjectImageProvider"/>.
     /// </summary>
     [Export]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class ProjectImageProviderAggregator : IProjectImageProvider
     {
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ConfiguredProjectReadyToBuild.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ConfiguredProjectReadyToBuild.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
     [Export(typeof(IConfiguredProjectReadyToBuild))]
-    [AppliesTo(ProjectCapability.ManagedLanguageService)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
     [Order(int.MaxValue)]
     internal sealed class ConfiguredProjectReadyToBuild : IConfiguredProjectReadyToBuild, IDisposable
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     ///     Handles changes to the  &lt;AdditionalFiles/&gt; item during design-time builds.
     /// </summary>
     [Export(typeof(ILanguageServiceCommandLineHandler))]
-    [AppliesTo(ProjectCapability.ManagedLanguageService)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
     internal class AdditionalFilesItemHandler : ILanguageServiceCommandLineHandler
     {
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     ///     Handles changes to the  &lt;Analyzer/&gt; item during design-time builds.
     /// </summary>
     [Export(typeof(ILanguageServiceCommandLineHandler))]
-    [AppliesTo(ProjectCapability.ManagedLanguageService)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
     internal class AnalyzerItemHandler : ILanguageServiceCommandLineHandler
     {
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     ///     Handles changes to the command-line arguments that are passed to the compiler during design-time builds.
     /// </summary>
     [Export(typeof(ILanguageServiceRuleHandler))]
-    [AppliesTo(ProjectCapability.ManagedLanguageService)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
     internal class CommandLineItemHandler : AbstractLanguageServiceRuleHandler
     {
         private readonly ICommandLineParserService _commandLineParser;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     ///     Handles changes to references that are passed to the compiler during design-time builds.
     /// </summary>
     [Export(typeof(ILanguageServiceCommandLineHandler))]
-    [AppliesTo(ProjectCapability.ManagedLanguageService)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
     internal class MetadataReferenceItemHandler : ILanguageServiceCommandLineHandler
     {
         private readonly UnconfiguredProject _unconfiguredProject;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     ///     Handles changes to the project and makes sure the language service is aware of them.
     /// </summary>
     [Export(typeof(ILanguageServiceRuleHandler))]
-    [AppliesTo(ProjectCapability.ManagedLanguageService)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
     internal class ProjectPropertiesItemHandler : AbstractLanguageServiceRuleHandler
     {
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     /// </summary>
     [Export(typeof(ILanguageServiceCommandLineHandler))]
     [Export(typeof(ILanguageServiceRuleHandler))]
-    [AppliesTo(ProjectCapability.ManagedLanguageService)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
     internal class SourceItemHandler : AbstractLanguageServiceRuleHandler, ILanguageServiceCommandLineHandler
     {
         // When a source file has been added/removed from a project, we'll receive notifications for it twice; once

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
 
         [ProjectAutoLoad(ProjectLoadCheckpoint.ProjectFactoryCompleted)]
-        [AppliesTo(ProjectCapability.ManagedLanguageService)]
+        [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
         private Task OnProjectFactoryCompletedAsync()
         {
             return InitializeAsync();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
@@ -11,12 +11,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public const string CSharp = ProjectCapabilities.CSharp;
         public const string VisualBasic = ProjectCapabilities.VB;
         public const string FSharp = nameof(FSharp);
-        public const string Managed = ProjectCapabilities.Managed;
+        public const string CSharpOrVisualBasicOrFSharp = "(" + ProjectCapabilities.CSharp + " | " + ProjectCapabilities.VB + " | " + FSharp + ")";
         public const string VisualBasicAppDesigner = ProjectCapabilities.VB + " & " + AppDesigner;
         public const string CSharpAppDesigner = ProjectCapabilities.CSharp + " & " + AppDesigner;
         public const string FSharpAppDesigner = FSharp + " & " + AppDesigner;
         public const string CSharpOrVisualBasic = "(" + ProjectCapabilities.CSharp + " | " + ProjectCapabilities.VB + ")";
-        public const string ManagedLanguageService = ProjectCapabilities.Managed +" & " + ProjectCapabilities.LanguageService;
+        public const string CSharpOrVisualBasicOrFSharpLanguageService = CSharpOrVisualBasicOrFSharp + " & " + ProjectCapabilities.LanguageService;
         public const string AppDesigner = nameof(AppDesigner);
         public const string AppSettings = nameof(AppSettings);
         public const string DependenciesTree = nameof(DependenciesTree);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectRootImageProjectTreePropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectRootImageProjectTreePropertiesProvider.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     ///     Modifies the Solution Explorer tree image for the project root.
     /// </summary>
     [Export(typeof(IProjectTreePropertiesProvider))]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class ProjectRootImageProjectTreePropertiesProvider : IProjectTreePropertiesProvider
     {
         private readonly IProjectCapabilitiesService _capabilities;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ImplicitProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ImplicitProjectPropertiesProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     [Export("ImplicitProjectFile", typeof(IProjectInstancePropertiesProvider))]
     [Export(typeof(IProjectInstancePropertiesProvider))]
     [ExportMetadata("Name", "ImplicitProjectFile")]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class ImplicitProjectPropertiesProvider : DelegatedProjectPropertiesProviderBase
     {
         private readonly ImplicitProjectPropertiesStore<string, string> _propertyStore;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ImplicitProjectPropertiesStore.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ImplicitProjectPropertiesStore.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     /// be shared by all configured projects, each of which will get its own <see cref="ImplicitProjectPropertiesProvider"/>.
     /// </summary>
     [Export(typeof(ImplicitProjectPropertiesStore<,>))]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class ImplicitProjectPropertiesStore<T1, T2> : ConcurrentDictionary<T1, T2>
     {
         // We import UnconfiguredProject here to ensure that we're loaded into the UnconfiguredProject scope.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ProjectFileInterceptedProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ProjectFileInterceptedProjectPropertiesProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     [Export("ProjectFileWithInterception", typeof(IProjectInstancePropertiesProvider))]
     [Export(typeof(IProjectInstancePropertiesProvider))]
     [ExportMetadata("Name", "ProjectFileWithInterception")]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal sealed class ProjectFileInterceptedProjectPropertiesProvider : InterceptedProjectPropertiesProviderBase
     {
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/OutputTypeEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/OutputTypeEnumProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     /// Winmdobj and appcontainerexe need to be mapped to dll and exe respectively for the OutputTypeproperty.
     /// </summary>
     [ExportDynamicEnumValuesProvider("OutputTypeEnumProvider")]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class OutputTypeEnumProvider : IDynamicEnumValuesProvider
     {
         public Task<IDynamicEnumValuesGenerator> GetProviderAsync(IList<NameValuePair> options)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/References/AlwaysAllowValidProjectReferenceChecker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/References/AlwaysAllowValidProjectReferenceChecker.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.References
     ///     same behavior, inside and outside of Visual Studio.
     /// </remarks>
     [Export(typeof(IValidProjectReferenceChecker))]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     [Order(1)] // Before the default checker, which delegates onto normal P-2-P rules
     internal class AlwaysAllowValidProjectReferenceChecker : IValidProjectReferenceChecker
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Reload/ProjectReloadInterceptor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Reload/ProjectReloadInterceptor.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     /// C#/VB specific project reload interceptor.
     /// </summary>
     [Export(typeof(IProjectReloadInterceptor))]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal sealed class ProjectReloadInterceptor : IProjectReloadInterceptor
     {
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppConfigFileSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppConfigFileSpecialFileProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.IO;
 namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
 {
     [ExportSpecialFileProvider(SpecialFiles.AppConfig)]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class AppConfigFileSpecialFileProvider : AbstractSpecialFileProvider
     {
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/ResourcesFileSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/ResourcesFileSpecialFileProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.IO;
 namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
 {
     [ExportSpecialFileProvider(SpecialFiles.AssemblyResource)]
-    [AppliesTo(ProjectCapability.Managed)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class ResourcesFileSpecialFileProvider : AbstractSpecialFileProvider
     {
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/SettingsFileSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/SettingsFileSpecialFileProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.IO;
 namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
 {
     [ExportSpecialFileProvider(SpecialFiles.AppSettings)]
-    [AppliesTo(ProjectCapability.Managed + " & " + ProjectCapability.AppSettings)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp + " & " + ProjectCapability.AppSettings)]
     internal class SettingsFileSpecialFileProvider : AbstractSpecialFileProvider
     {
         [ImportingConstructor]


### PR DESCRIPTION
The Managed capability is already used by Managed C++ and the components in this repo don't apply there. So create a CSharpOrVBOrFSharp capability instead.

@dotnet/project-system 